### PR TITLE
[web] select game when edit action clicked

### DIFF
--- a/web/src/components/Games.jsx
+++ b/web/src/components/Games.jsx
@@ -100,7 +100,7 @@ export default function Games({ loading, games, saveGame, saveQuestion, saveNewG
                       keepMounted
                       open={activeIndex === String(index)}
                       onClose={handleClose}
-                      onClick={(event) => event.stopPropagation()}
+                      onClick={(event) => { if (!match) event.stopPropagation(); }}
                     >
                       <MenuItem onClick={(event) => { history.push(`/games/${index + 1}/edit`); event.stopPropagation(); handleClose(); }}>Edit</MenuItem>
                       <MenuItem onClick={cloneHandler(game)}>Clone</MenuItem>


### PR DESCRIPTION
Clicking the action menu on a game should trigger the game details, iff you're on the sidebar view.