### PR TITLE
create Further Details Page teacher side

### DIFF
--- a/mobile/src/Teacher/index.js
+++ b/mobile/src/Teacher/index.js
@@ -7,6 +7,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
 import ExploreStackScreen from './screens/Explore'
 import { colors } from '../utils/theme'
 import { HeaderTitle } from '@react-navigation/stack'
+import DetailScreen from './screens/Explore/DetailScreen'
 
 
 const Tab = createBottomTabNavigator()
@@ -34,10 +35,12 @@ const TeacherApp = ({ props, navigation }) => {
       tabBarOptions={{
         activeTintColor: 'white',
         inactiveTintColor: '#85C6FF',
-        style: { backgroundColor: '#043272' }
+        style: { backgroundColor: '#043272' },
+        tabBarVisible: false
+        
       }}
     >
-      <Tab.Screen name="Explore" component={ExploreStackScreen} navigation={navigation} />
+      <Tab.Screen name="Explore" component={ExploreStackScreen}/>
       <Tab.Screen name="My Games" component={ExploreStackScreen} />
       <Tab.Screen name="Quiz Maker" component={ExploreStackScreen} />
       <Tab.Screen name="Reports" component={ExploreStackScreen} />

--- a/mobile/src/Teacher/screens/Explore/DetailScreen.js
+++ b/mobile/src/Teacher/screens/Explore/DetailScreen.js
@@ -1,0 +1,118 @@
+import React, { Fragment, useState } from 'react';
+import NavBarView from './NavBarView'
+import { fontFamilies, fonts } from '../../../utils/theme'
+import { FlatList } from 'react-native-gesture-handler'
+import {
+    StyleSheet,
+    Text,
+    SafeAreaView,
+    View,
+    Button,
+    TouchableOpacity,
+    Pressable
+} from 'react-native';
+import { inOut } from 'react-native/Libraries/Animated/src/Easing';
+import Card from './QuestionCard';
+import { createStackNavigator } from '@react-navigation/stack';
+import ButtonBack from '../../../components/ButtonBack/index';
+import Aicon from 'react-native-vector-icons/FontAwesome';
+import LinearGradient from 'react-native-linear-gradient'
+
+// import GameDetailsScreen from './GameDetails';
+// import Games from '../Games';
+
+const detailList = ({route, navigation}) => {
+
+    const { game } = route.params;
+
+    const questions = [game.q1,game.q2,game.q3,game.q4,game.q5].filter( (question) => !!question ) 
+    
+    const parsedQuestions =  questions.map( (question) => JSON.parse(question)  )
+
+    return(
+            <SafeAreaView style={{ flex: 1, width: '100%'}}>
+                    <NavBarView title={false} avatar={false} onBack={() => navigation.goBack()} />
+                        <Text style={styles.gameTitle}>{game.title}</Text>
+                        <Text style={styles.description}>{game.description}</Text>
+                        <Text style={styles.gameStandard}>Common Core Standard: {`${game.grade}.${game.domain}.${game.cluster}.${game.standard}`}</Text>
+                        <Text style={styles.grade}>Grade {game.grade}</Text>
+
+                        <FlatList
+                            style={styles.questionContainer}
+                            data={parsedQuestions}
+                            keyExtractor={(item) => item.question}
+                            renderItem={({ item }) => (
+                                <Card
+                                    image={item.image}
+                                    question={item.question || "Question"}
+                                    instructions={item.instructions || []}
+                                />
+                            )}
+                        />
+            </SafeAreaView>
+    );
+};
+
+const styles = StyleSheet.create({
+    mainContainer: {
+        backgroundColor: '#F9F9F9',
+        flex: 1,
+    },
+    headerContainer: {
+        backgroundColor: 'red',
+        width: '100%'
+    },
+    questionContainer: {
+        paddingLeft: 40,
+    },
+    gameTitle: {
+        height: 36,
+        width: 310,
+        fontSize: 24,
+        color: '#384466',
+        fontWeight: '700',
+        fontFamily: fontFamilies.poppinsBold,
+        textAlign: 'left',
+        marginTop: 15,
+        marginBottom: 10,
+        marginLeft: 40,
+        fontStyle: 'normal'
+    },
+    description: {
+        fontSize: 14,
+        color: '#717D8F',
+        fontWeight: '500',
+        fontStyle: 'normal',
+        textAlign: 'left',
+        marginLeft: 40,
+        marginRight: 20,
+        marginBottom: 10
+    },
+    gameStandard: {
+        fontSize: 14,
+        color: '#9BA9D0',
+        fontWeight: 'bold',
+        fontStyle: 'normal',
+        textAlign: 'left',
+        marginLeft: 40,
+        marginRight: 20,
+        marginBottom: 5
+    },
+    grade: {
+        fontSize: 14,
+        color: '#717D8F',
+        fontWeight: '500',
+        fontStyle: 'normal',
+        textAlign: 'left',
+        marginLeft: 40,
+        marginRight: 20,
+        marginBottom: 15
+    },
+    item: {
+        marginTop: 24,
+        padding: 30,
+        backgroundColor: 'white',
+        fontSize: 24,
+    },
+})
+export default detailList;

--- a/mobile/src/Teacher/screens/Explore/DetailScreen.js
+++ b/mobile/src/Teacher/screens/Explore/DetailScreen.js
@@ -1,25 +1,13 @@
-import React, { Fragment, useState } from 'react';
+import React, { useState } from 'react';
 import NavBarView from './NavBarView'
-import { fontFamilies, fonts } from '../../../utils/theme'
+import { fontFamilies } from '../../../utils/theme'
 import { FlatList } from 'react-native-gesture-handler'
 import {
     StyleSheet,
     Text,
     SafeAreaView,
-    View,
-    Button,
-    TouchableOpacity,
-    Pressable
 } from 'react-native';
-import { inOut } from 'react-native/Libraries/Animated/src/Easing';
 import Card from './QuestionCard';
-import { createStackNavigator } from '@react-navigation/stack';
-import ButtonBack from '../../../components/ButtonBack/index';
-import Aicon from 'react-native-vector-icons/FontAwesome';
-import LinearGradient from 'react-native-linear-gradient'
-
-// import GameDetailsScreen from './GameDetails';
-// import Games from '../Games';
 
 const detailList = ({route, navigation}) => {
 
@@ -30,7 +18,7 @@ const detailList = ({route, navigation}) => {
     const parsedQuestions =  questions.map( (question) => JSON.parse(question)  )
 
     return(
-            <SafeAreaView style={{ flex: 1, width: '100%'}}>
+            <SafeAreaView style={styles.mainContainer}>
                     <NavBarView title={false} avatar={false} onBack={() => navigation.goBack()} />
                         <Text style={styles.gameTitle}>{game.title}</Text>
                         <Text style={styles.description}>{game.description}</Text>
@@ -55,8 +43,8 @@ const detailList = ({route, navigation}) => {
 
 const styles = StyleSheet.create({
     mainContainer: {
-        backgroundColor: '#F9F9F9',
         flex: 1,
+        width: '100%'
     },
     headerContainer: {
         backgroundColor: 'red',

--- a/mobile/src/Teacher/screens/Explore/NavBarView/index.js
+++ b/mobile/src/Teacher/screens/Explore/NavBarView/index.js
@@ -1,12 +1,12 @@
 import React from 'react'
-import { StyleSheet, Text, View, Image, Dimensions, Platform, StatusBar } from 'react-native'
+import { StyleSheet, Text, View, Image, Dimensions, Platform, StatusBar, Button, Pressable} from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import { colors, fonts, fontFamilies } from '../../../../utils/theme'
 import PropTypes from 'prop-types'
 import LinearGradient from 'react-native-linear-gradient'
 
 const NavBarView = (props, navigation) => {
-    const { title, avatar } = props
+    const { title, avatar, showHamburgerMenu = false } = props
 
     return (
         <View>
@@ -15,15 +15,20 @@ const NavBarView = (props, navigation) => {
                 style={styles.container}
             >
                 <View style={styles.navBarContainer}>
-                    <TouchableOpacity onPress={() => console.log('tapped avatar')}>
+                    {avatar ? <TouchableOpacity onPress={() => console.log('tapped avatar')}>
                         <View style={styles.avatar}>
                             <Image source={avatar} resizeMode='contain' />
                         </View>
-                    </TouchableOpacity>
+                    </TouchableOpacity> : (
+                       <Pressable style={{flexDirection: 'row'}} onPress={props.onBack}>
+                           <Text style={{color: 'white', fontSize: 35, marginRight: 5, marginTop: 5,}}>{'<'}</Text>
+                           <Text style={{color: 'white', fontSize: 17, marginTop: 18}}>Explore</Text>
+                       </Pressable>
+                    )}
                     <Text style={styles.title}>{title}</Text>
-                    <TouchableOpacity style={styles.drawer} onPress={() => console.log('tapped drawer')}>
+                    {showHamburgerMenu && <TouchableOpacity style={styles.drawer} onPress={() => console.log('tapped drawer')}>
                         <Image source={require('../../../../assets/images/menu.png')} style={styles.drawer} resizeMode='contain' />
-                    </TouchableOpacity>
+                    </TouchableOpacity>}
                 </View>
             </LinearGradient>
         </View>

--- a/mobile/src/Teacher/screens/Explore/NavBarView/index.js
+++ b/mobile/src/Teacher/screens/Explore/NavBarView/index.js
@@ -15,20 +15,24 @@ const NavBarView = (props, navigation) => {
                 style={styles.container}
             >
                 <View style={styles.navBarContainer}>
-                    {avatar ? <TouchableOpacity onPress={() => console.log('tapped avatar')}>
-                        <View style={styles.avatar}>
-                            <Image source={avatar} resizeMode='contain' />
-                        </View>
-                    </TouchableOpacity> : (
-                       <Pressable style={{flexDirection: 'row'}} onPress={props.onBack}>
-                           <Text style={{color: 'white', fontSize: 35, marginRight: 5, marginTop: 5,}}>{'<'}</Text>
-                           <Text style={{color: 'white', fontSize: 17, marginTop: 18}}>Explore</Text>
-                       </Pressable>
-                    )}
+                    {
+                        avatar ? <TouchableOpacity onPress={() => console.log('tapped avatar')}>
+                            <View style={styles.avatar}>
+                                <Image source={avatar} resizeMode='contain' />
+                            </View>
+                        </TouchableOpacity> : (
+                        <Pressable style={{flexDirection: 'row'}} onPress={props.onBack}>
+                            <Text style={{color: 'white', fontSize: 35, marginRight: 5, marginTop: 5,}}>{'<'}</Text>
+                            <Text style={{color: 'white', fontSize: 17, marginTop: 18}}>Explore</Text>
+                        </Pressable>
+                        )
+                    }
                     <Text style={styles.title}>{title}</Text>
-                    {showHamburgerMenu && <TouchableOpacity style={styles.drawer} onPress={() => console.log('tapped drawer')}>
-                        <Image source={require('../../../../assets/images/menu.png')} style={styles.drawer} resizeMode='contain' />
-                    </TouchableOpacity>}
+                    {
+                        showHamburgerMenu && <TouchableOpacity style={styles.drawer} onPress={() => console.log('tapped drawer')}>
+                            <Image source={require('../../../../assets/images/menu.png')} style={styles.drawer} resizeMode='contain' />
+                        </TouchableOpacity>
+                    }
                 </View>
             </LinearGradient>
         </View>

--- a/mobile/src/Teacher/screens/Explore/QuestionCard.js
+++ b/mobile/src/Teacher/screens/Explore/QuestionCard.js
@@ -1,0 +1,132 @@
+import React, {useState} from 'react';
+import { scale, moderateScale, verticalScale } from 'react-native-size-matters'
+import { StyleSheet, Text, View, Platform, Image, Button, Pressable } from 'react-native'
+import { fontFamilies, fonts } from '../../../utils/theme'
+import { KeyboardAwareScrollView } from '@codler/react-native-keyboard-aware-scroll-view'
+import { TouchableOpacity } from 'react-native-gesture-handler';
+
+const Card = (props) => {
+    const [hintsShown, setHintsShown] = useState(false);
+
+    const showHints = () => {
+        setHintsShown(true)
+    }
+
+    const hideHints = () => {
+        setHintsShown(false)
+    }
+
+    return(
+            <View style={styles.cardContainer}>   
+                    <Image
+                        style={styles.questionImage}
+                        source={{uri: props.image}}
+                    />
+                    <Text style={styles.headerText}>{props.question}</Text>
+                    <View style={styles.breakLine}></View>
+
+                    {hintsShown && props.instructions.map( (hint, index) => (
+                            <View style={styles.hintDirection}>
+                                <Text style={styles.hintNumber}>{index + 1}</Text>
+                                <Text style={styles.questionHint}>{hint}</Text>
+                            </View>
+                    ))}
+
+                    <View style={styles.hintButtonBackground}>
+                    {hintsShown ? 
+                            <Pressable onPress={hideHints}>
+                                    <Text style={styles.hintButton}>HIDE HINTS</Text>
+                            </Pressable>
+                        : 
+                        <Pressable onPress={showHints}>
+                            <View style={styles.hintButtonDirection}>
+                                <Text style={styles.hintButton}>SHOW HINTS</Text>
+                            </View>
+                        </Pressable>
+                    }
+                    </View>
+                    
+            </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    questionImage: {
+        width: 200,
+        height: 200,
+        paddingTop: 20,
+    },
+    breakLine: {
+        backgroundColor: '#B1BACB',
+        width: 270,
+        height: 2,
+        marginBottom: 5,
+    },
+    cardContainer: {
+        backgroundColor: 'white',
+        flex: 1,
+        alignItems: 'center',
+        borderRadius: 24,
+        paddingTop: 20,
+        width: 330,
+        shadowColor: 'black',
+        shadowOpacity: 5,
+        elevation: 10,
+        marginBottom: 20,
+    },
+    headerText: {
+        fontFamily: fontFamilies.montserratBold,
+        fontWeight: 'bold',
+        fontSize: 16,
+        color: '#384466',
+        textAlign: 'center',
+        marginTop: 20,
+        marginLeft: 10,
+        marginRight: 10,
+        paddingBottom: 20,
+    },
+    questionHint: {
+        fontWeight:'normal',
+        fontSize: 16,
+        color: '#384466',
+        marginRight: 70
+    },
+    hintNumber: {
+        fontFamily: fontFamilies.montserratBold,
+        fontWeight: 'bold',
+        fontSize: 23,
+        color: '#4700B2',
+        marginLeft: 25,
+        marginRight: 10
+    },
+    hintDirection: {
+        flexDirection: 'row',
+        flex:1,
+        marginTop: 20,
+        width: '100%',
+        padding: 10,
+        justifyContent: 'flex-start'
+    },
+    hintButtonBackground: {
+        backgroundColor: '#F4F4F4',
+        flex:1,
+        marginTop: 10,
+        width: 330,
+        height: 50,
+        borderBottomRightRadius: 24,
+        borderBottomLeftRadius: 24,
+        alignItems: 'center',
+    },
+    hintButton : {
+        marginTop: 15,
+        color: '#1C55FD',
+        fontWeight: 'bold',
+        backgroundColor: '#F4F4F4'
+    },
+    hintButtonDirection: {
+        flexDirection: 'row',
+        justifyContent: 'flex-start'
+    }
+})
+
+export default Card;

--- a/mobile/src/Teacher/screens/Explore/QuestionCard.js
+++ b/mobile/src/Teacher/screens/Explore/QuestionCard.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import { scale, moderateScale, verticalScale } from 'react-native-size-matters'
 import { StyleSheet, Text, View, Platform, Image, Button, Pressable } from 'react-native'
 import { fontFamilies, fonts } from '../../../utils/theme'
@@ -18,33 +18,36 @@ const Card = (props) => {
 
     return(
             <View style={styles.cardContainer}>   
-                    <Image
-                        style={styles.questionImage}
-                        source={{uri: props.image}}
-                    />
-                    <Text style={styles.headerText}>{props.question}</Text>
-                    <View style={styles.breakLine}></View>
+                <Image
+                    style={styles.questionImage}
+                    source={{uri: props.image}}
+                />
+                <Text style={styles.headerText}>{props.question}</Text>
+                <View style={styles.breakLine}></View>
 
-                    {hintsShown && props.instructions.map( (hint, index) => (
-                            <View style={styles.hintDirection}>
-                                <Text style={styles.hintNumber}>{index + 1}</Text>
-                                <Text style={styles.questionHint}>{hint}</Text>
-                            </View>
-                    ))}
+                {
+                    hintsShown && props.instructions.map( (hint, index) => (
+                        <View style={styles.hintDirection}>
+                            <Text style={styles.hintNumber}>{index + 1}</Text>
+                            <Text style={styles.questionHint}>{hint}</Text>
+                        </View>
+                    ))
+                }
 
-                    <View style={styles.hintButtonBackground}>
-                    {hintsShown ? 
+                <View style={styles.hintButtonBackground}>
+                    {
+                        hintsShown ? 
                             <Pressable onPress={hideHints}>
-                                    <Text style={styles.hintButton}>HIDE HINTS</Text>
+                                <Text style={styles.hintButton}>HIDE HINTS</Text>
                             </Pressable>
-                        : 
-                        <Pressable onPress={showHints}>
-                            <View style={styles.hintButtonDirection}>
-                                <Text style={styles.hintButton}>SHOW HINTS</Text>
-                            </View>
-                        </Pressable>
+                            : 
+                            <Pressable onPress={showHints}>
+                                <View style={styles.hintButtonDirection}>
+                                    <Text style={styles.hintButton}>SHOW HINTS</Text>
+                                </View>
+                            </Pressable>
                     }
-                    </View>
+                </View>
                     
             </View>
     );
@@ -109,7 +112,7 @@ const styles = StyleSheet.create({
     },
     hintButtonBackground: {
         backgroundColor: '#F4F4F4',
-        flex:1,
+        flex: 1,
         marginTop: 10,
         width: 330,
         height: 50,

--- a/mobile/src/Teacher/screens/Explore/index.js
+++ b/mobile/src/Teacher/screens/Explore/index.js
@@ -64,12 +64,12 @@ const ExploreScreen = ({ props, navigation }) => {
             keyExtractor={({ GameID }) => GameID}
             renderItem={({ item }) => (
               <ContentItem
-               category={item.grade || "General"} 
-               title={item.title || "No Title"} 
-               body={item.description || "No Description"} 
-               style={styles.contentItem} 
-               onPress={() => {
-                  navigation.navigate("GameDetails", {game:item})
+                category={item.grade || "General"} 
+                title={item.title || "No Title"} 
+                body={item.description || "No Description"} 
+                style={styles.contentItem} 
+                onPress={() => {
+                    navigation.navigate("GameDetails", {game: item})
                }} 
               />
             )}

--- a/mobile/src/Teacher/screens/Explore/index.js
+++ b/mobile/src/Teacher/screens/Explore/index.js
@@ -18,6 +18,7 @@ import { API, graphqlOperation } from 'aws-amplify'
 import { FlatList } from 'react-native-gesture-handler'
 // import API from '../../../backend'
 import gamesList from './data.json'
+import DetailScreen from './DetailScreen'
 
 const ExploreStack = createStackNavigator()
 
@@ -27,6 +28,7 @@ const ExploreStackScreen = () => {
       headerShown: false
     }}>
       <ExploreStack.Screen name="ExploreScreen" component={ExploreScreen} />
+      <ExploreStack.Screen name="GameDetails" component={DetailScreen} />
     </ExploreStack.Navigator>
   )
 }
@@ -37,9 +39,6 @@ const ExploreScreen = ({ props, navigation }) => {
     loading: 'loading',
     succeeded: 'succeeded',
     failed: 'failed',
-  }
-  const onGameSelected = () => {
-    navigation.navigate("GameDetails")
   }
 
   const [mode, setMode] = useState(Mode.loading)
@@ -57,14 +56,22 @@ const ExploreScreen = ({ props, navigation }) => {
     <Fragment>
       <SafeAreaView style={{ flex: 0, backgroundColor: '#003668' }} />
       <SafeAreaView style={styles.mainContainer}>
-        <NavBarView title="Explore" avatar={require("../../../assets/images/profile.png")} />
+        <NavBarView title="Explore" avatar={require("../../../assets/images/profile.png")} showHamBurgerMenu={true} />
         {mode == Mode.loading ? <ActivityIndicator /> : (
           <FlatList
             style={styles.content}
             data={games}
-            keyExtractor={({ GameID }, index) => GameID}
+            keyExtractor={({ GameID }) => GameID}
             renderItem={({ item }) => (
-              <ContentItem category={item.grade || "General"} title={item.title || "No Title"} body={item.description || "No Description"} style={styles.contentItem} onPress={onGameSelected} />
+              <ContentItem
+               category={item.grade || "General"} 
+               title={item.title || "No Title"} 
+               body={item.description || "No Description"} 
+               style={styles.contentItem} 
+               onPress={() => {
+                  navigation.navigate("GameDetails", {game:item})
+               }} 
+              />
             )}
           />
         )}


### PR DESCRIPTION
This PR consists of implementing the further details page (DetailScreen) for the teacher side of the mobile app. Currently, you can navigate to the details of each game on a separate screen and show/hide hints of each question and navigate back to the ExploreScreen. There are still a few tasks I would need to finish to complete the further details Page. 

1) The hints for each question are mostly centered but could be done better with the hint number better aligned
2) The show/hide button needs a design square next to them.
3) The "<" on the DetailScreen Header to navigate back was implemented through Text. I plan to import a vector icon instead.
4) The DetailScreen has the existing bottom tab navigator from the ExploreScreen. I plan to remove that by nesting the needed tab navigators inside the stack navigators.
5) The ExploreScreen is missing the burger menu on the header, resulting in the Explore Test being slightly miscentered. This has to do with the ternary operators I implemented in our NavBarView component. I'm not sure how to fix this.  