### PR TITLE
[StatusPage] proof of concept for GraphQL subscription

### DIFF
--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -49,12 +49,10 @@ enum GameSessionState {
 }
 
 type JoinScreen implements Screen {
-  __typename: String
   gameID: Int!
   screenID: ScreenID!
   title: String!
   text: String
-  gameCode: String!
 }
 
 type Mutation {
@@ -86,7 +84,6 @@ type Question {
 }
 
 type QuestionScreen implements Screen {
-  __typename: String
   gameID: Int!
   screenID: ScreenID!
   title: String!
@@ -105,7 +102,6 @@ input ScoreInput {
 }
 
 type ScorecardScreen implements Screen {
-  __typename: String
   gameID: Int!
   screenID: ScreenID!
   title: String!
@@ -114,7 +110,6 @@ type ScorecardScreen implements Screen {
 }
 
 interface Screen {
-  __typename: String
   gameID: Int!
   screenID: ScreenID!
   title: String!
@@ -122,19 +117,17 @@ interface Screen {
 }
 
 enum ScreenID {
-  JOIN
-  QUESTION
-  SCORECARD
+  JoinScreen
+  QuestionScreen
+  ScorecardScreen
 }
 
 input ScreenInput {
-  __typename: String
   screenID: ScreenID!
   title: String!
   text: String!
   answers: [String]
   scores: [ScoreInput]
-  gameCode: String
 }
 
 type Subscription {

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -48,6 +48,15 @@ enum GameSessionState {
   VOTING
 }
 
+type JoinScreen implements Screen {
+  __typename: String
+  gameID: Int!
+  screenID: ScreenID!
+  title: String!
+  text: String
+  gameCode: String!
+}
+
 type Mutation {
   deleteGame(id: Int!): Game
   createGame(game: CreateGameInput!): Game
@@ -55,6 +64,8 @@ type Mutation {
   deleteQuestion(id: Int!): Question
   createQuestion(question: CreateQuestionInput!): Question
   updateQuestion(question: UpdateQuestionInput!): Question
+  createGameStatus(gameID: Int!): Screen
+  updateGameStatus(gameID: Int!, screenData: ScreenInput!): Screen
 }
 
 type Query {
@@ -74,9 +85,65 @@ type Question {
   createdAt: AWSDateTime!
 }
 
+type QuestionScreen implements Screen {
+  __typename: String
+  gameID: Int!
+  screenID: ScreenID!
+  title: String!
+  text: String
+  answers: [String]!
+}
+
+type Score {
+  teamName: String!
+  teamScore: Int!
+}
+
+input ScoreInput {
+  teamName: String!
+  teamScore: Int!
+}
+
+type ScorecardScreen implements Screen {
+  __typename: String
+  gameID: Int!
+  screenID: ScreenID!
+  title: String!
+  text: String
+  scores: [Score]!
+}
+
+interface Screen {
+  __typename: String
+  gameID: Int!
+  screenID: ScreenID!
+  title: String!
+  text: String
+}
+
+enum ScreenID {
+  JOIN
+  QUESTION
+  SCORECARD
+}
+
+input ScreenInput {
+  __typename: String
+  screenID: ScreenID!
+  title: String!
+  text: String!
+  answers: [String]
+  scores: [ScoreInput]
+  gameCode: String
+}
+
 type Subscription {
-  onCreateGame: Game @aws_subscribe(mutations: ["createGame"])
-  onCreateQuestion: Question @aws_subscribe(mutations: ["createQuestion"])
+  onCreateGame: Game
+    @aws_subscribe(mutations: ["createGame"])
+  onCreateQuestion: Question
+    @aws_subscribe(mutations: ["createQuestion"])
+  subscribeToGameStatusUpdates(gameID: Int!): Screen
+    @aws_subscribe(mutations: ["updateGameStatus"])
 }
 
 input UpdateGameInput {

--- a/web/.graphqlconfig.yml
+++ b/web/.graphqlconfig.yml
@@ -13,3 +13,6 @@ projects:
         region: us-east-1
         apiId: mz6btgo62nhu5dcl67k5namuwe
         maxDepth: 2
+extensions:
+  amplify:
+    version: 3

--- a/web/src/API.ts
+++ b/web/src/API.ts
@@ -62,6 +62,68 @@ export type UpdateQuestionInput = {
   instructions?: string | null,
 };
 
+export type Screen = {
+  __typename: "Screen",
+  gameID: number,
+  screenID: ScreenID,
+  title: string,
+  text?: string | null,
+};
+
+export type QuestionScreen = {
+  __typename: "QuestionScreen",
+  gameID: number,
+  screenID: ScreenID,
+  title: string,
+  text?: string | null,
+  answers: Array< string | null >,
+};
+
+export enum ScreenID {
+  JOIN = "JOIN",
+  QUESTION = "QUESTION",
+  SCORECARD = "SCORECARD",
+}
+
+
+export type JoinScreen = {
+  __typename: "JoinScreen",
+  gameID: number,
+  screenID: ScreenID,
+  title: string,
+  text?: string | null,
+  gameCode: string,
+};
+
+export type ScorecardScreen = {
+  __typename: "ScorecardScreen",
+  gameID: number,
+  screenID: ScreenID,
+  title: string,
+  text?: string | null,
+  scores:  Array<Score | null >,
+};
+
+export type Score = {
+  __typename: "Score",
+  teamName: string,
+  teamScore: number,
+};
+
+export type ScreenInput = {
+  screenID: ScreenID,
+  title: string,
+  text: string,
+  answers?: Array< string | null > | null,
+  scores?: Array< ScoreInput | null > | null,
+  gameCode?: string | null,
+};
+
+export type ScoreInput = {
+  teamName: string,
+  teamScore: number,
+};
+
 export type DeleteGameMutationVariables = {
   id: number,
 };
@@ -200,6 +262,75 @@ export type UpdateQuestionMutation = {
   } | null,
 };
 
+export type CreateGameStatusMutationVariables = {
+  gameID: number,
+};
+
+export type CreateGameStatusMutation = {
+  createGameStatus: ( {
+      __typename: "QuestionScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      answers: Array< string | null >,
+    } | {
+      __typename: "JoinScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      gameCode: string,
+    } | {
+      __typename: "ScorecardScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      scores:  Array< {
+        __typename: string,
+        teamName: string,
+        teamScore: number,
+      } | null >,
+    }
+  ) | null,
+};
+
+export type UpdateGameStatusMutationVariables = {
+  gameID: number,
+  screenData: ScreenInput,
+};
+
+export type UpdateGameStatusMutation = {
+  updateGameStatus: ( {
+      __typename: "QuestionScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      answers: Array< string | null >,
+    } | {
+      __typename: "JoinScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      gameCode: string,
+    } | {
+      __typename: "ScorecardScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      scores:  Array< {
+        __typename: string,
+        teamName: string,
+        teamScore: number,
+      } | null >,
+    }
+  ) | null,
+};
+
 export type GetGameQueryVariables = {
   id: number,
 };
@@ -320,4 +451,38 @@ export type OnCreateQuestionSubscription = {
     updatedAt: string,
     createdAt: string,
   } | null,
+};
+
+export type SubscribeToGameStatusUpdatesSubscriptionVariables = {
+  gameID: number,
+};
+
+export type SubscribeToGameStatusUpdatesSubscription = {
+  subscribeToGameStatusUpdates: ( {
+      __typename: "QuestionScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      answers: Array< string | null >,
+    } | {
+      __typename: "JoinScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      gameCode: string,
+    } | {
+      __typename: "ScorecardScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      scores:  Array< {
+        __typename: string,
+        teamName: string,
+        teamScore: number,
+      } | null >,
+    }
+  ) | null,
 };

--- a/web/src/API.ts
+++ b/web/src/API.ts
@@ -70,31 +70,6 @@ export type Screen = {
   text?: string | null,
 };
 
-export type QuestionScreen = {
-  __typename: "QuestionScreen",
-  gameID: number,
-  screenID: ScreenID,
-  title: string,
-  text?: string | null,
-  answers: Array< string | null >,
-};
-
-export enum ScreenID {
-  JOIN = "JOIN",
-  QUESTION = "QUESTION",
-  SCORECARD = "SCORECARD",
-}
-
-
-export type JoinScreen = {
-  __typename: "JoinScreen",
-  gameID: number,
-  screenID: ScreenID,
-  title: string,
-  text?: string | null,
-  gameCode: string,
-};
-
 export type ScorecardScreen = {
   __typename: "ScorecardScreen",
   gameID: number,
@@ -104,10 +79,34 @@ export type ScorecardScreen = {
   scores:  Array<Score | null >,
 };
 
+export enum ScreenID {
+  JoinScreen = "JoinScreen",
+  QuestionScreen = "QuestionScreen",
+  ScorecardScreen = "ScorecardScreen",
+}
+
+
 export type Score = {
   __typename: "Score",
   teamName: string,
   teamScore: number,
+};
+
+export type QuestionScreen = {
+  __typename: "QuestionScreen",
+  gameID: number,
+  screenID: ScreenID,
+  title: string,
+  text?: string | null,
+  answers: Array< string | null >,
+};
+
+export type JoinScreen = {
+  __typename: "JoinScreen",
+  gameID: number,
+  screenID: ScreenID,
+  title: string,
+  text?: string | null,
 };
 
 export type ScreenInput = {
@@ -116,7 +115,6 @@ export type ScreenInput = {
   text: string,
   answers?: Array< string | null > | null,
   scores?: Array< ScoreInput | null > | null,
-  gameCode?: string | null,
 };
 
 export type ScoreInput = {
@@ -268,6 +266,17 @@ export type CreateGameStatusMutationVariables = {
 
 export type CreateGameStatusMutation = {
   createGameStatus: ( {
+      __typename: "ScorecardScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      scores:  Array< {
+        __typename: string,
+        teamName: string,
+        teamScore: number,
+      } | null >,
+    } | {
       __typename: "QuestionScreen",
       gameID: number,
       screenID: ScreenID,
@@ -280,18 +289,6 @@ export type CreateGameStatusMutation = {
       screenID: ScreenID,
       title: string,
       text?: string | null,
-      gameCode: string,
-    } | {
-      __typename: "ScorecardScreen",
-      gameID: number,
-      screenID: ScreenID,
-      title: string,
-      text?: string | null,
-      scores:  Array< {
-        __typename: string,
-        teamName: string,
-        teamScore: number,
-      } | null >,
     }
   ) | null,
 };
@@ -303,6 +300,17 @@ export type UpdateGameStatusMutationVariables = {
 
 export type UpdateGameStatusMutation = {
   updateGameStatus: ( {
+      __typename: "ScorecardScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      scores:  Array< {
+        __typename: string,
+        teamName: string,
+        teamScore: number,
+      } | null >,
+    } | {
       __typename: "QuestionScreen",
       gameID: number,
       screenID: ScreenID,
@@ -315,18 +323,6 @@ export type UpdateGameStatusMutation = {
       screenID: ScreenID,
       title: string,
       text?: string | null,
-      gameCode: string,
-    } | {
-      __typename: "ScorecardScreen",
-      gameID: number,
-      screenID: ScreenID,
-      title: string,
-      text?: string | null,
-      scores:  Array< {
-        __typename: string,
-        teamName: string,
-        teamScore: number,
-      } | null >,
     }
   ) | null,
 };
@@ -459,6 +455,17 @@ export type SubscribeToGameStatusUpdatesSubscriptionVariables = {
 
 export type SubscribeToGameStatusUpdatesSubscription = {
   subscribeToGameStatusUpdates: ( {
+      __typename: "ScorecardScreen",
+      gameID: number,
+      screenID: ScreenID,
+      title: string,
+      text?: string | null,
+      scores:  Array< {
+        __typename: string,
+        teamName: string,
+        teamScore: number,
+      } | null >,
+    } | {
       __typename: "QuestionScreen",
       gameID: number,
       screenID: ScreenID,
@@ -471,18 +478,6 @@ export type SubscribeToGameStatusUpdatesSubscription = {
       screenID: ScreenID,
       title: string,
       text?: string | null,
-      gameCode: string,
-    } | {
-      __typename: "ScorecardScreen",
-      gameID: number,
-      screenID: ScreenID,
-      title: string,
-      text?: string | null,
-      scores:  Array< {
-        __typename: string,
-        teamName: string,
-        teamScore: number,
-      } | null >,
     }
   ) | null,
 };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import {
   BrowserRouter as Router,
-  Route
+  Route,
+  Switch
 } from "react-router-dom";
 import Box from '@material-ui/core/Box';
 import {
@@ -15,6 +16,7 @@ import Games from './components/Games';
 import { fetchGames, sortGames, createGame, updateGame, cloneGame, deleteGame } from './lib/games';
 import { SORT_TYPES } from './lib/sorting';
 import { Game } from './API';
+import StatusPageContainer from './components/StatusPageContainer';
 
 const filterGame = (game: Game | null, search: string) => {
   if (game && game.title && game.title.toLowerCase().indexOf(search) > -1) return true;
@@ -118,17 +120,20 @@ function App() {
 
   return (
     <Router>
-      <ThemeProvider theme={theme}>
-        <AlertContext.Provider value={alertContext}>
-          <Box>
-            <Nav />
-            <Route path="/">
-              <Games loading={loading} games={filteredGames} saveNewGame={saveNewGame} saveGame={saveGame} saveQuestion={handleSaveQuestion} setSearchInput={setSearchInput} searchInput={searchInput} deleteGame={handleDeleteGame} cloneGame={handleCloneGame} sortType={sortType} setSortType={setSortType} />
-            </Route>
-          </Box>
-          <AlertBar />
-        </AlertContext.Provider>
-      </ThemeProvider>
+      <Switch>
+        <Route path="/status/:gameID" component={StatusPageContainer} />
+        <ThemeProvider theme={theme}>
+          <AlertContext.Provider value={alertContext}>
+            <Box>
+              <Nav />
+              <Route path="/">
+                <Games loading={loading} games={filteredGames} saveNewGame={saveNewGame} saveGame={saveGame} saveQuestion={handleSaveQuestion} setSearchInput={setSearchInput} searchInput={searchInput} deleteGame={handleDeleteGame} cloneGame={handleCloneGame} sortType={sortType} setSortType={setSortType} />
+              </Route>
+            </Box>
+            <AlertBar />
+          </AlertContext.Provider>
+        </ThemeProvider>
+      </ Switch>
     </Router>
   );
 }

--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Score, JoinScreen, QuestionScreen, ScorecardScreen } from '../API';
 
-const Join = ({ gameCode }: JoinScreen) => {
+const Join = ({ gameID }: JoinScreen) => {
   return (
     <form>
-      <p>{gameCode}</p>
+      <p>{gameID}</p>
       <input type="text" />
       <br />
       <br />

--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Score, JoinScreen, QuestionScreen, ScorecardScreen } from '../API';
+
+const Join = ({ gameCode }: JoinScreen) => {
+  return (
+    <form>
+      <p>{gameCode}</p>
+      <input type="text" />
+      <br />
+      <br />
+      <input type="submit" onClick={() => {}} />
+    </form>
+  );
+};
+
+const Question = ({ answers }: QuestionScreen) => {
+  const answersList = answers.map((answer) => (
+    <button onClick={() => {}}>{answer}</button>
+  ));
+
+  return <ul>{answersList}</ul>;
+};
+
+const Scorecard = ({ scores }: ScorecardScreen) => {
+  const scoreList = (scores as Score[]).map((score: Score) => (
+    <li>
+      {score.teamName}: {score.teamScore}
+    </li>
+  ));
+
+  return <ul>{scoreList}</ul>;
+};
+
+const PageMap = {
+  JoinScreen: Join,
+  QuestionScreen: Question,
+  ScorecardScreen: Scorecard,
+};
+
+export default function StatusPage({ screen }: any) {
+  // @ts-ignore
+  const PageComponent = PageMap[screen.screenID] as any; // TODO: fix typing
+
+  return (
+    <div>
+      <h1>{screen.title}</h1>
+      <h3>{screen.text}</h3>
+      <PageComponent {...screen} />
+    </div>
+  );
+};

--- a/web/src/components/StatusPageContainer.tsx
+++ b/web/src/components/StatusPageContainer.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from "react-router-dom";
+import { API, graphqlOperation } from 'aws-amplify';
+import Observable from 'zen-observable-ts';
+import { subscribeToGameStatusUpdates } from '../graphql/subscriptions';
+import { SubscribeToGameStatusUpdatesSubscription } from '../API';
+import StatusPage from './Status';
+
+type Result = { 
+    value: {
+        data: SubscribeToGameStatusUpdatesSubscription 
+    }
+}
+
+export default function StatusPageContainer() {
+    const { gameID } = useParams<{ gameID: string | undefined }>();
+    const [screenData, setScreenData] = useState<any>(null);
+    useEffect(() => {
+        // Subscribe to the status of this game
+        const subscription = (API.graphql(graphqlOperation(subscribeToGameStatusUpdates, { gameID })) as Observable<Result>)
+            .subscribe(
+                {
+                    next: ({ value }) => {
+                        const screen = value?.data?.subscribeToGameStatusUpdates;
+
+                        if (screen) {
+                            setScreenData(screen);
+                        }
+                    },
+                    error: error => console.warn(error)
+                }
+            );
+
+        return function cleanup() {
+            // Stop receiving data updates from the subscription
+            subscription.unsubscribe();
+        };
+    }, [gameID])
+
+    if (screenData === null) return null;
+
+    // @ts-ignore
+    return <StatusPage screen={screenData as Screen} />
+}

--- a/web/src/graphql/mutations.ts
+++ b/web/src/graphql/mutations.ts
@@ -113,3 +113,48 @@ export const updateQuestion = /* GraphQL */ `
     }
   }
 `;
+export const createGameStatus = /* GraphQL */ `
+  mutation CreateGameStatus($gameID: Int!) {
+    createGameStatus(gameID: $gameID) {
+      gameID
+      screenID
+      title
+      text
+      ... on QuestionScreen {
+        answers
+      }
+      ... on JoinScreen {
+        gameCode
+      }
+      ... on ScorecardScreen {
+        scores {
+          teamName
+          teamScore
+        }
+      }
+    }
+  }
+`;
+export const updateGameStatus = /* GraphQL */ `
+  mutation UpdateGameStatus($gameID: Int!, $screenData: ScreenInput!) {
+    updateGameStatus(gameID: $gameID, screenData: $screenData) {
+      __typename
+      gameID
+      screenID
+      title
+      text
+      ... on QuestionScreen {
+        answers
+      }
+      ... on JoinScreen {
+        gameCode
+      }
+      ... on ScorecardScreen {
+        scores {
+          teamName
+          teamScore
+        }
+      }
+    }
+  }
+`;

--- a/web/src/graphql/mutations.ts
+++ b/web/src/graphql/mutations.ts
@@ -120,17 +120,14 @@ export const createGameStatus = /* GraphQL */ `
       screenID
       title
       text
-      ... on QuestionScreen {
-        answers
-      }
-      ... on JoinScreen {
-        gameCode
-      }
       ... on ScorecardScreen {
         scores {
           teamName
           teamScore
         }
+      }
+      ... on QuestionScreen {
+        answers
       }
     }
   }
@@ -138,22 +135,18 @@ export const createGameStatus = /* GraphQL */ `
 export const updateGameStatus = /* GraphQL */ `
   mutation UpdateGameStatus($gameID: Int!, $screenData: ScreenInput!) {
     updateGameStatus(gameID: $gameID, screenData: $screenData) {
-      __typename
       gameID
       screenID
       title
       text
-      ... on QuestionScreen {
-        answers
-      }
-      ... on JoinScreen {
-        gameCode
-      }
       ... on ScorecardScreen {
         scores {
           teamName
           teamScore
         }
+      }
+      ... on QuestionScreen {
+        answers
       }
     }
   }

--- a/web/src/graphql/schema.json
+++ b/web/src/graphql/schema.json
@@ -522,6 +522,67 @@
           },
           "isDeprecated" : false,
           "deprecationReason" : null
+        }, {
+          "name" : "createGameStatus",
+          "description" : null,
+          "args" : [ {
+            "name" : "gameID",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "SCALAR",
+                "name" : "Int",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "INTERFACE",
+            "name" : "Screen",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "updateGameStatus",
+          "description" : null,
+          "args" : [ {
+            "name" : "gameID",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "SCALAR",
+                "name" : "Int",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          }, {
+            "name" : "screenData",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "INPUT_OBJECT",
+                "name" : "ScreenInput",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "INTERFACE",
+            "name" : "Screen",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
         } ],
         "inputFields" : null,
         "interfaces" : [ ],
@@ -795,6 +856,225 @@
         "enumValues" : null,
         "possibleTypes" : null
       }, {
+        "kind" : "INTERFACE",
+        "name" : "Screen",
+        "description" : null,
+        "fields" : [ {
+          "name" : "gameID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "screenID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "ScreenID",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "title",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "text",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : [ {
+          "kind" : "OBJECT",
+          "name" : "QuestionScreen",
+          "ofType" : null
+        }, {
+          "kind" : "OBJECT",
+          "name" : "JoinScreen",
+          "ofType" : null
+        }, {
+          "kind" : "OBJECT",
+          "name" : "ScorecardScreen",
+          "ofType" : null
+        } ]
+      }, {
+        "kind" : "ENUM",
+        "name" : "ScreenID",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : [ {
+          "name" : "JOIN",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "QUESTION",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "SCORECARD",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ScreenInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "screenID",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "ScreenID",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "title",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "text",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "answers",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "scores",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ScoreInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "gameCode",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ScoreInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "teamName",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "teamScore",
+          "description" : null,
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
         "kind" : "OBJECT",
         "name" : "Subscription",
         "description" : null,
@@ -820,10 +1100,161 @@
           },
           "isDeprecated" : false,
           "deprecationReason" : null
+        }, {
+          "name" : "subscribeToGameStatusUpdates",
+          "description" : null,
+          "args" : [ {
+            "name" : "gameID",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "SCALAR",
+                "name" : "Int",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "INTERFACE",
+            "name" : "Screen",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
         } ],
         "inputFields" : null,
         "interfaces" : [ ],
         "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "QuestionScreen",
+        "description" : null,
+        "fields" : [ {
+          "name" : "gameID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "screenID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "ScreenID",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "title",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "text",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "answers",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "LIST",
+              "name" : null,
+              "ofType" : {
+                "kind" : "SCALAR",
+                "name" : "String",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ {
+          "kind" : "INTERFACE",
+          "name" : "Screen",
+          "ofType" : null
+        } ],
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "ENUM",
+        "name" : "GameSessionState",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : [ {
+          "name" : "CHOOSINGTRICKANSWER",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "FINISHED",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "INITIALINTRO",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "NOTSTARTED",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "REVIEWINGRESULT",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "VOTING",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
         "possibleTypes" : null
       }, {
         "kind" : "INPUT_OBJECT",
@@ -932,43 +1363,215 @@
         "enumValues" : null,
         "possibleTypes" : null
       }, {
-        "kind" : "ENUM",
-        "name" : "GameSessionState",
+        "kind" : "OBJECT",
+        "name" : "JoinScreen",
         "description" : null,
-        "fields" : null,
-        "inputFields" : null,
-        "interfaces" : null,
-        "enumValues" : [ {
-          "name" : "CHOOSINGTRICKANSWER",
+        "fields" : [ {
+          "name" : "gameID",
           "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "FINISHED",
+          "name" : "screenID",
           "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "ScreenID",
+              "ofType" : null
+            }
+          },
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "INITIALINTRO",
+          "name" : "title",
           "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "NOTSTARTED",
+          "name" : "text",
           "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "REVIEWINGRESULT",
+          "name" : "gameCode",
           "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "VOTING",
-          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
           "isDeprecated" : false,
           "deprecationReason" : null
         } ],
+        "inputFields" : null,
+        "interfaces" : [ {
+          "kind" : "INTERFACE",
+          "name" : "Screen",
+          "ofType" : null
+        } ],
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "ScorecardScreen",
+        "description" : null,
+        "fields" : [ {
+          "name" : "gameID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "screenID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "ScreenID",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "title",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "text",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "scores",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "LIST",
+              "name" : null,
+              "ofType" : {
+                "kind" : "OBJECT",
+                "name" : "Score",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ {
+          "kind" : "INTERFACE",
+          "name" : "Screen",
+          "ofType" : null
+        } ],
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "Score",
+        "description" : null,
+        "fields" : [ {
+          "name" : "teamName",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "teamScore",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ ],
+        "enumValues" : null,
         "possibleTypes" : null
       }, {
         "kind" : "OBJECT",
@@ -1754,6 +2357,23 @@
         "onFragment" : false,
         "onField" : true
       }, {
+        "name" : "deprecated",
+        "description" : null,
+        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
+        "args" : [ {
+          "name" : "reason",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : "\"No longer supported\""
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
         "name" : "aws_auth",
         "description" : "Directs the schema to enforce authorization on a field",
         "locations" : [ "FIELD_DEFINITION" ],
@@ -1799,23 +2419,6 @@
             }
           },
           "defaultValue" : null
-        } ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "deprecated",
-        "description" : null,
-        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
-        "args" : [ {
-          "name" : "reason",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
-          },
-          "defaultValue" : "\"No longer supported\""
         } ],
         "onOperation" : false,
         "onFragment" : false,

--- a/web/src/graphql/schema.json
+++ b/web/src/graphql/schema.json
@@ -921,15 +921,15 @@
         "enumValues" : null,
         "possibleTypes" : [ {
           "kind" : "OBJECT",
+          "name" : "ScorecardScreen",
+          "ofType" : null
+        }, {
+          "kind" : "OBJECT",
           "name" : "QuestionScreen",
           "ofType" : null
         }, {
           "kind" : "OBJECT",
           "name" : "JoinScreen",
-          "ofType" : null
-        }, {
-          "kind" : "OBJECT",
-          "name" : "ScorecardScreen",
           "ofType" : null
         } ]
       }, {
@@ -940,17 +940,17 @@
         "inputFields" : null,
         "interfaces" : null,
         "enumValues" : [ {
-          "name" : "JOIN",
+          "name" : "JoinScreen",
           "description" : null,
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "QUESTION",
+          "name" : "QuestionScreen",
           "description" : null,
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "SCORECARD",
+          "name" : "ScorecardScreen",
           "description" : null,
           "isDeprecated" : false,
           "deprecationReason" : null
@@ -1024,15 +1024,6 @@
               "name" : "ScoreInput",
               "ofType" : null
             }
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "gameCode",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
           },
           "defaultValue" : null
         } ],
@@ -1131,40 +1122,10 @@
         "possibleTypes" : null
       }, {
         "kind" : "OBJECT",
-        "name" : "QuestionScreen",
+        "name" : "Score",
         "description" : null,
         "fields" : [ {
-          "name" : "gameID",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "Int",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "screenID",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "ENUM",
-              "name" : "ScreenID",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "title",
+          "name" : "teamName",
           "description" : null,
           "args" : [ ],
           "type" : {
@@ -1179,82 +1140,24 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "text",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "answers",
+          "name" : "teamScore",
           "description" : null,
           "args" : [ ],
           "type" : {
             "kind" : "NON_NULL",
             "name" : null,
             "ofType" : {
-              "kind" : "LIST",
-              "name" : null,
-              "ofType" : {
-                "kind" : "SCALAR",
-                "name" : "String",
-                "ofType" : null
-              }
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
             }
           },
           "isDeprecated" : false,
           "deprecationReason" : null
         } ],
         "inputFields" : null,
-        "interfaces" : [ {
-          "kind" : "INTERFACE",
-          "name" : "Screen",
-          "ofType" : null
-        } ],
+        "interfaces" : [ ],
         "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "ENUM",
-        "name" : "GameSessionState",
-        "description" : null,
-        "fields" : null,
-        "inputFields" : null,
-        "interfaces" : null,
-        "enumValues" : [ {
-          "name" : "CHOOSINGTRICKANSWER",
-          "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "FINISHED",
-          "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "INITIALINTRO",
-          "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "NOTSTARTED",
-          "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "REVIEWINGRESULT",
-          "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "VOTING",
-          "description" : null,
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        } ],
         "possibleTypes" : null
       }, {
         "kind" : "INPUT_OBJECT",
@@ -1364,90 +1267,6 @@
         "possibleTypes" : null
       }, {
         "kind" : "OBJECT",
-        "name" : "JoinScreen",
-        "description" : null,
-        "fields" : [ {
-          "name" : "gameID",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "Int",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "screenID",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "ENUM",
-              "name" : "ScreenID",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "title",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "text",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        }, {
-          "name" : "gameCode",
-          "description" : null,
-          "args" : [ ],
-          "type" : {
-            "kind" : "NON_NULL",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "isDeprecated" : false,
-          "deprecationReason" : null
-        } ],
-        "inputFields" : null,
-        "interfaces" : [ {
-          "kind" : "INTERFACE",
-          "name" : "Screen",
-          "ofType" : null
-        } ],
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "OBJECT",
         "name" : "ScorecardScreen",
         "description" : null,
         "fields" : [ {
@@ -1536,10 +1355,40 @@
         "possibleTypes" : null
       }, {
         "kind" : "OBJECT",
-        "name" : "Score",
+        "name" : "QuestionScreen",
         "description" : null,
         "fields" : [ {
-          "name" : "teamName",
+          "name" : "gameID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Int",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "screenID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "ScreenID",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "title",
           "description" : null,
           "args" : [ ],
           "type" : {
@@ -1554,7 +1403,50 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
-          "name" : "teamScore",
+          "name" : "text",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "answers",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "LIST",
+              "name" : null,
+              "ofType" : {
+                "kind" : "SCALAR",
+                "name" : "String",
+                "ofType" : null
+              }
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
+        "inputFields" : null,
+        "interfaces" : [ {
+          "kind" : "INTERFACE",
+          "name" : "Screen",
+          "ofType" : null
+        } ],
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "OBJECT",
+        "name" : "JoinScreen",
+        "description" : null,
+        "fields" : [ {
+          "name" : "gameID",
           "description" : null,
           "args" : [ ],
           "type" : {
@@ -1568,10 +1460,94 @@
           },
           "isDeprecated" : false,
           "deprecationReason" : null
+        }, {
+          "name" : "screenID",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "ENUM",
+              "name" : "ScreenID",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "title",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "NON_NULL",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "text",
+          "description" : null,
+          "args" : [ ],
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
         } ],
         "inputFields" : null,
-        "interfaces" : [ ],
+        "interfaces" : [ {
+          "kind" : "INTERFACE",
+          "name" : "Screen",
+          "ofType" : null
+        } ],
         "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "ENUM",
+        "name" : "GameSessionState",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : [ {
+          "name" : "CHOOSINGTRICKANSWER",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "FINISHED",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "INITIALINTRO",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "NOTSTARTED",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "REVIEWINGRESULT",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "VOTING",
+          "description" : null,
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        } ],
         "possibleTypes" : null
       }, {
         "kind" : "OBJECT",

--- a/web/src/graphql/subscriptions.ts
+++ b/web/src/graphql/subscriptions.ts
@@ -39,3 +39,25 @@ export const onCreateQuestion = /* GraphQL */ `
     }
   }
 `;
+export const subscribeToGameStatusUpdates = /* GraphQL */ `
+  subscription SubscribeToGameStatusUpdates($gameID: Int!) {
+    subscribeToGameStatusUpdates(gameID: $gameID) {
+      gameID
+      screenID
+      title
+      text
+      ... on QuestionScreen {
+        answers
+      }
+      ... on JoinScreen {
+        gameCode
+      }
+      ... on ScorecardScreen {
+        scores {
+          teamName
+          teamScore
+        }
+      }
+    }
+  }
+`;

--- a/web/src/graphql/subscriptions.ts
+++ b/web/src/graphql/subscriptions.ts
@@ -46,17 +46,14 @@ export const subscribeToGameStatusUpdates = /* GraphQL */ `
       screenID
       title
       text
-      ... on QuestionScreen {
-        answers
-      }
-      ... on JoinScreen {
-        gameCode
-      }
       ... on ScorecardScreen {
         scores {
           teamName
           teamScore
         }
+      }
+      ... on QuestionScreen {
+        answers
       }
     }
   }


### PR DESCRIPTION
Proof of concept for Teacher Projection app. Try starting the app, and going to http://localhost:3000/status/1234. Should be blank.

Then open the console and run this query:
```graphql
mutation updateExistingGameToTriggerSubscription {
  updateGameStatus(gameID: 1234, screenData: {screenID: QuestionScreen, text: "What's 2+2?", title: "Question 1", answers: ["4"]}) {
    __typename
    gameID
    screenID
    text
    title
    ... on QuestionScreen {
      answers
    }
  }
}

```
https://console.aws.amazon.com/appsync/home?region=us-east-1#/mz6btgo62nhu5dcl67k5namuwe/v1/queries

You can switch the pages by sending `screenID` JoinScreen, QuestionScreen, or ScorecardScreen.