### PR TITLE
Footer API Calls - Number of Answers in Progress Bar

### DIFF
--- a/web/src/host/pages/GameInProgress.jsx
+++ b/web/src/host/pages/GameInProgress.jsx
@@ -8,7 +8,13 @@ import AnswersInProgressDetails from '../components/AnswersInProgressDetails';
 export default function GameInProgress({ teams: { items: teams }, questions: { items: questions }, currentState, currentQuestionId, handleChangeGameStatus }) {
     const classes = useStyles();
     const currentQuestion = questions[currentQuestionId - 1];
-    const numAnswers = 9; //this is a temporary value until we can figure out how to discern team answers from the mock
+    const numAnswers = (teams) =>
+    {
+      let count = 0;
+      teams.map(team => (team.teamMembers.items.map(teamMember => (teamMember.answers.items.map(answer => (answer.isChosen && count++))))));//.map(teamMember => (teamMember.answers.map((answer) => answer.isAnswered && count++)))))
+      console.log("numAnswers" + count);
+      return count;
+    }
 
     return (
       <div className={classes.background}>
@@ -17,7 +23,7 @@ export default function GameInProgress({ teams: { items: teams }, questions: { i
            <QuestionCardDetails title={currentQuestion} />
            <AnswersInProgressDetails/>
         </div>
-        <FooterGameInProgress currentState={currentState} numPlayers={teams.length} numAnswers={numAnswers} handleChangeGameStatus={handleChangeGameStatus}/>
+        <FooterGameInProgress currentState={currentState} numPlayers={teams.length} numAnswers={numAnswers(teams)} handleChangeGameStatus={handleChangeGameStatus}/>
       </div>
     );
 }

--- a/web/src/mocks/gamesession.json
+++ b/web/src/mocks/gamesession.json
@@ -43,17 +43,69 @@
   },
   "teams": {
     "items": [
-    {
-      "id": 1,
-      "name": "Drew"
-    },
-    {
-      "id": 2,
-      "name": "Eric"
-    },
-    {
-      "id": 3,
-      "name": "Zach"
-    }]
+      {
+        "name": "Eric",
+        "id": "teamEric",
+        "teamMembers": {
+          "items": [
+            {
+              "id": "teamMemberEric",
+              "deviceId": "223344",
+              "answers": {
+                "items": [
+                  {
+                    "id": "990088",
+                    "teamMemberAnswersId": "teamMemberEric",
+                    "isChosen": false
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "Lucah",
+        "id": "teamLucah",
+        "teamMembers": {
+          "items": [
+            {
+              "id": "teamMemberLucah",
+              "deviceId": "4321",
+              "answers": {
+                "items": [
+                  {
+                    "id": "009988",
+                    "teamMemberAnswersId": "teamMemberLucah",
+                    "isChosen": false
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "Zach",
+        "id": "teamZach",
+        "teamMembers": {
+          "items": [
+            {
+              "id": "teamMemberZach",
+              "deviceId": "1234",
+              "answers": {
+                "items": [
+                  {
+                    "id": "889900",
+                    "teamMemberAnswersId": "teamMemberZach",
+                    "isChosen": true
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
I used AWS Amplify to generate teams, teammembers and team answers and then queried the gamesession. I updated our mock data with the result of that query (just copy and pasted the teams data I received). I've then done a series of nested .maps to scan through all the isChosen variables and count them, before passing that onto the footer component. I did the counting in the Game In Progress page but let me know if that isn't accurate. 