### PR TITLE
[networking] Add filtering capability to subscriptions

### DIFF
--- a/debug-panel/public/index.html
+++ b/debug-panel/public/index.html
@@ -1,21 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+  <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +22,13 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+  <title>React App</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+  <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -39,5 +38,6 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-  </body>
+</body>
+
 </html>

--- a/debug-panel/src/App.tsx
+++ b/debug-panel/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '@mui/material'
 import { ApiClient, Environment, GameSessionState } from '@righton/networking'
 import { IGameSession } from '@righton/networking'
@@ -9,16 +9,12 @@ function App() {
   const [error, setError] = useState<string | null>(null)
   
   let apiClient = new ApiClient(Environment.Staging)
+  let gameSessionSubscription: any | null = null
 
-  useEffect(() => {
-    
-    const subscription = apiClient.subscribeUpdateGameSession(gameSession => {
-      console.log(gameSession.currentState)
-    })
-  
+  useEffect(() => {  
     // @ts-ignore
-    return () => subscription.unsubscribe()
-}, []);
+    return () => gameSessionSubscription?.unsubscribe()
+  }, [])
 
 
   const handleUpdateGameSessionState = (gameSessionState: GameSessionState) => {
@@ -62,6 +58,9 @@ function App() {
               setGameSession(gameSession)
               setError(null)
               setUpdatedGameSession(null)
+              gameSessionSubscription = apiClient.subscribeUpdateGameSession(gameSession.id, gameSession => {
+                  console.log(gameSession.currentState)
+              })
             }).catch(error => {
               console.error(error.message)
               setGameSession(null)

--- a/networking/src/IGameSession.ts
+++ b/networking/src/IGameSession.ts
@@ -10,7 +10,7 @@ export interface IGameSession {
     currentQuestionId?: number | null
     currentState: GameSessionState
     gameCode: number
-    currentTimer: number
+    currentTimer?: number | null
     // questions: [Question]?
     updatedAt: string
     createdAt: string


### PR DESCRIPTION
With new Amplify gql generated models, there's a new capability of filtering the data and only subscribe to the data changes you're interested in. For the start, adding the capability to only listen to a specific game session changes by using its ID. `debug-panel` is also updated to use this new capability