### PR TITLE
Lucah endicott  host question index

### DIFF
--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -73,6 +73,7 @@ export class ApiClient implements IApiClient {
 
     async getGameSession(id: string): Promise<IGameSession> {
         let result = await API.graphql(graphqlOperation(getGameSession, { id })) as { data: any }
+        console.log(result)
         return GameSessionParser.gameSessionFromAWSGameSession(result.data.getGameSession)
     }
 
@@ -250,7 +251,9 @@ class GameSessionParser {
             questions,
             currentTimer,
             updatedAt,
-            createdAt
+            createdAt,
+            title
+            
         } = awsGameSession || {}
 
         if (
@@ -281,7 +284,8 @@ class GameSessionParser {
             currentTimer,
             questions: GameSessionParser.mapQuestions(questions.items),
             updatedAt,
-            createdAt
+            createdAt,
+            title
         }
         return gameSession
     }

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -73,7 +73,6 @@ export class ApiClient implements IApiClient {
 
     async getGameSession(id: string): Promise<IGameSession> {
         let result = await API.graphql(graphqlOperation(getGameSession, { id })) as { data: any }
-        console.log(result)
         return GameSessionParser.gameSessionFromAWSGameSession(result.data.getGameSession)
     }
 

--- a/networking/src/Models/IGameSession.ts
+++ b/networking/src/Models/IGameSession.ts
@@ -14,6 +14,7 @@ export interface IGameSession {
     gameCode: number
     currentTimer?: number | null
     questions: Array<IQuestion>
+    title?: string | null
     updatedAt: string
     createdAt: string
 }

--- a/web/src/host/components/CurrentStudents.jsx
+++ b/web/src/host/components/CurrentStudents.jsx
@@ -6,13 +6,13 @@ const CurrentStudents = ({ teams }) => {
   const classes = useStyles();
   return (
     <div>
-      <Grid className={classes.studentCount}>{teams ? teams.items.length : 0}</Grid>
+      <Grid className={classes.studentCount}>{teams ? teams.length : 0}</Grid>
       <div className={classes.inSessionDiv}>
         <p className={classes.inSession}>Students in Session</p>
       </div>
       <hr className={classes.hr} />
       {teams &&
-        teams.items.map((team, id) => (
+        teams.map((team, id) => (
           <MenuItem container className={classes.studentCards} key={id}>
             <Grid className={classes.name}>{team.name}</Grid>
           </MenuItem>

--- a/web/src/host/components/FooterGameInProgress.jsx
+++ b/web/src/host/components/FooterGameInProgress.jsx
@@ -6,7 +6,7 @@ import { GameSessionState } from "@righton/networking";
 
 
 
-export default function FooterGameInProgress({ currentState, nextState, nextQuestion, numPlayers, numAnswers, phaseOneTime, phaseTwoTime,  handleUpdateGameSessionStateFooter }) {
+export default function FooterGameInProgress({nextState, nextQuestion, numPlayers, numAnswers, phaseOneTime, phaseTwoTime,  handleUpdateGameSessionStateFooter }) {
   const classes = useStyles();
 
   const currentStateToButtonText = { //dictionary used to assign button text based on the next state 
@@ -21,7 +21,6 @@ export default function FooterGameInProgress({ currentState, nextState, nextQues
     <BottomNavigation className={classes.footer}>
       <div className={classes.footerContainer}>
         <div className={classes.playerNum}>Players who have answered</div>
-        {console.log("currentState: " + currentState + " phaseOneTimer: " + phaseOneTime + " phaseTwoTimer: " + phaseTwoTime)}
         <PlayersAnsweredBar numPlayers={numPlayers} numAnswers={numAnswers} />
         <Button
           disabled = {phaseOneTime < 0 ? true : false || phaseTwoTime < 0 ? true : false}

--- a/web/src/host/components/FooterStartGame.jsx
+++ b/web/src/host/components/FooterStartGame.jsx
@@ -5,7 +5,6 @@ import { GameSessionState } from "@righton/networking";
 
 const FooterStartGame = ({ handleUpdateGameSessionState }) => {
   const classes = useStyles();
-
   return (
     <BottomNavigation className={classes.footer}>
       <button className={classes.startGameButton} onClick={() => 

--- a/web/src/host/components/QuestionCard.jsx
+++ b/web/src/host/components/QuestionCard.jsx
@@ -90,7 +90,6 @@ export default function QuestionCard({
     setExpanded(!expanded);
   };
 
-  console.log({ image });
   return (
     <Grid container className={classes.centerContent}>
       <Card className={classes.QuestionCard} style={{ borderRadius: "18px" }}>

--- a/web/src/host/components/QuestionCardDetails.jsx
+++ b/web/src/host/components/QuestionCardDetails.jsx
@@ -5,13 +5,16 @@ import QuestionCard from "./QuestionCard";
 
 export default function QuestionDetails({questions}) {
   const classes = useStyles();
+  //pass current question in based off current index
+
+  const currentQuestion = questions[0];
 
   return (
     <Grid>
       <QuestionCard
-        question={questions[0].text}
-        hint={questions[0].instructions}
-        image={questions[0].imageUrl}
+        question={currentQuestion.text}
+        hint={currentQuestion.instructions}
+        image={currentQuestion.imageUrl}
       ></QuestionCard>
     </Grid>
   );

--- a/web/src/host/components/QuestionCardDetails.jsx
+++ b/web/src/host/components/QuestionCardDetails.jsx
@@ -5,9 +5,6 @@ import QuestionCard from "./QuestionCard";
 
 export default function QuestionDetails({questions}) {
   const classes = useStyles();
-  //const questionsDetails = questions.questions
-  //console.log(questionsDetails);
-  console.log(questions);
 
   return (
     <Grid>

--- a/web/src/host/components/QuestionCardDetails.jsx
+++ b/web/src/host/components/QuestionCardDetails.jsx
@@ -3,17 +3,18 @@ import { makeStyles } from "@material-ui/core/styles";
 import { Grid } from "@material-ui/core";
 import QuestionCard from "./QuestionCard";
 
-export default function QuestionDetails(questions) {
+export default function QuestionDetails({questions}) {
   const classes = useStyles();
-  const questionsDetails = questions.questions
-  console.log(questionsDetails);
+  //const questionsDetails = questions.questions
+  //console.log(questionsDetails);
+  console.log(questions);
 
   return (
     <Grid>
       <QuestionCard
-        question={questionsDetails[0].text}
-        hint={questionsDetails[0].instructions}
-        image={questionsDetails[0].imageUrl}
+        question={questions[0].text}
+        hint={questions[0].instructions}
+        image={questions[0].imageUrl}
       ></QuestionCard>
     </Grid>
   );

--- a/web/src/host/containers/GameSessionContainer.tsx
+++ b/web/src/host/containers/GameSessionContainer.tsx
@@ -5,7 +5,7 @@ import {
   ApiClient,
   Environment,
   GameSessionState,
-  IGameSession
+  IGameSession,
 } from "@righton/networking";
 import GameInProgress from "../pages/GameInProgress";
 import Ranking from "../pages/Ranking";
@@ -20,7 +20,6 @@ const GameSessionContainer = () => {
 
   useEffect(() => {
     apiClient.getGameSession(gameSessionId).then(response => {
-      console.log(response);
       setGameSession(response);
     });
 
@@ -33,8 +32,8 @@ const GameSessionContainer = () => {
   }, []);
 
   const handleUpdateGameSessionState = (gameSessionState: GameSessionState) => {
-    apiClient.updateGameSession(gameSessionId, gameSessionState)
-      .then(response => {
+    apiClient.updateGameSession({id: gameSessionId, currentState: gameSessionState})
+    .then(response => {
         setGameSession(response);
       })
   }

--- a/web/src/host/containers/GameSessionContainer.tsx
+++ b/web/src/host/containers/GameSessionContainer.tsx
@@ -20,6 +20,7 @@ const GameSessionContainer = () => {
 
   useEffect(() => {
     apiClient.getGameSession(gameSessionId).then(response => {
+      console.log(response);
       setGameSession(response);
     });
 

--- a/web/src/host/containers/GameSessionContainer.tsx
+++ b/web/src/host/containers/GameSessionContainer.tsx
@@ -23,12 +23,12 @@ const GameSessionContainer = () => {
       setGameSession(response);
     });
 
-    // apiClient.subscribeUpdateGameSession(gameSessionId, response => {
-    //   setGameSession({ ...gameSession, ...response });
-    // });
+    gameSessionSubscription = apiClient.subscribeUpdateGameSession(gameSessionId, response => {
+      setGameSession({ ...gameSession, ...response });
+    });
 
     //@ts-ignore
-    //return () => gameSessionSubscription?.unsubscribe()
+    return () => gameSessionSubscription?.unsubscribe()
   }, []);
 
   const handleUpdateGameSessionState = (gameSessionState: GameSessionState) => {

--- a/web/src/host/containers/GameSessionContainer.tsx
+++ b/web/src/host/containers/GameSessionContainer.tsx
@@ -20,6 +20,7 @@ const GameSessionContainer = () => {
 
   useEffect(() => {
     apiClient.getGameSession(gameSessionId).then(response => {
+      console.log(response);
       setGameSession(response);
     });
 
@@ -28,7 +29,7 @@ const GameSessionContainer = () => {
     // });
 
     //@ts-ignore
-    return () => gameSessionSubscription?.unsubscribe()
+    //return () => gameSessionSubscription?.unsubscribe()
   }, []);
 
   const handleUpdateGameSessionState = (gameSessionState: GameSessionState) => {
@@ -51,7 +52,7 @@ const GameSessionContainer = () => {
   switch (gameSession.currentState) {
     case GameSessionState.NOT_STARTED:
     case GameSessionState.TEAMS_JOINING:
-      return <StartGame {...gameSession} handleUpdateGameSessionState={handleUpdateGameSessionState} />;
+      return <StartGame {...gameSession} gameSessionId={gameSessionId} handleUpdateGameSessionState={handleUpdateGameSessionState} />;
 
     case GameSessionState.CHOOSE_CORRECT_ANSWER:
     case GameSessionState.CHOOSE_TRICKIEST_ANSWER:

--- a/web/src/host/pages/GameInProgress.jsx
+++ b/web/src/host/pages/GameInProgress.jsx
@@ -19,15 +19,13 @@ export default function GameInProgress({
   handleUpdateGameSessionStateFooter
 }) {
 const classes = useStyles();
-const questionDetails = questions.items
- console.log(questionDetails);
 
   const stateArray = Object.values(GameSessionState); //adds all states from enum into array 
   let nextState;
  
   const numAnswersFunc = teams => { //finds all answers using isChosen, for use in footer progress bar
     let count = 0;
-    teams && teams.items.map(team => 
+    teams && teams.map(team => 
        team.teamMembers && team.teamMembers.items.map(teamMember => 
         teamMember.answers && teamMember.answers.items.map(answer => answer.isChosen && count++
     )))
@@ -36,9 +34,9 @@ const questionDetails = questions.items
   };
 
   const nextStateFunc = currentState => { //determines next state for use by footer
-    if (currentState === "PHASE_2_RESULTS" && currentQuestionId === (questions ? questions.items.length : 0)){
+    if (currentState === "PHASE_2_RESULTS" && currentQuestionId === (questions ? questions.length : 0)){
       return "FINAL_RESULTS";
-    } else if (currentState === "PHASE_2_RESULTS" && currentQuestionId !== (questions ? questions.items.length : 0)) {
+    } else if (currentState === "PHASE_2_RESULTS" && currentQuestionId !== (questions ? questions.length : 0)) {
       return "CHOOSE_CORRECT_ANSWER";
     } else {
     return stateArray[stateArray.indexOf(currentState) + 1]; 
@@ -56,21 +54,21 @@ const questionDetails = questions.items
         }}
       >
         <HeaderGameInProgress
-          totalQuestions={questions ? questions.items.length : 0}
+          totalQuestions={questions ? questions.length : 0}
           currentState={currentState}
           currentQuestion={currentQuestionId}
           phaseOneTime={phaseOneTime}
           phaseTwoTime={phaseTwoTime}
         />
-        <QuestionCardDetails questions={questions.items} />
-        <AnswersInProgressDetails questions={questions.items} />
+        <QuestionCardDetails questions={questions} />
+        <AnswersInProgressDetails questions={questions} />
       </div>
     
       <FooterGameInProgress
         currentState={currentState}
         nextState = {nextState= nextStateFunc(currentState)} 
         nextQuestion = {(nextState === 'CHOOSE_CORRECT_ANSWER') ? currentQuestionId+1 : currentQuestionId} 
-        numPlayers={teams ? teams.items.length : 0}
+        numPlayers={teams ? teams.length : 0}
         numAnswers={numAnswersFunc(teams)}
         phaseOneTime={phaseOneTime}
         phaseTwoTime={phaseTwoTime}

--- a/web/src/host/pages/GameInProgress.jsx
+++ b/web/src/host/pages/GameInProgress.jsx
@@ -32,6 +32,10 @@ const classes = useStyles();
     return count;
   };
 
+  if(currentQuestionId == null) {
+    currentQuestionId = 1;
+  }
+
   const nextStateFunc = currentState => { //determines next state for use by footer
     if (currentState === "PHASE_2_RESULTS" && currentQuestionId === (questions ? questions.length : 0)){
       return "FINAL_RESULTS";

--- a/web/src/host/pages/GameInProgress.jsx
+++ b/web/src/host/pages/GameInProgress.jsx
@@ -13,7 +13,6 @@ export default function GameInProgress({
   questions,
   currentState,
   currentQuestionId,
-  handleChangeGameStatus,
   phaseOneTime,
   phaseTwoTime,
   handleUpdateGameSessionStateFooter

--- a/web/src/host/pages/Ranking.jsx
+++ b/web/src/host/pages/Ranking.jsx
@@ -12,7 +12,7 @@ export default function Ranking({
   handleUpdateGameSessionState
 }) {
   const classes = useStyles();
-  const players = { teams }.teams.items;
+  const players = { teams }.teams;
 
   return (
     <div className={classes.background}>


### PR DESCRIPTION
Had issues with the current question index displaying properly in the header of the `GameInProgress` page. The length of how many questions in the questions array was also being miscalculated - by reading a length of 1 extra question object. 

Add an `if` statement in the `GameInProgress` page to set the `currentQuestionId` to `1` if it is `null`

This does seem to fix the issue of `.length` properly calculating the amount of question objects that are in the array, and also seems to fix the index marker and header in the UI.