### PR TITLE
Fix parsing choices and instructions for question

### DIFF
--- a/debug-panel/src/App.tsx
+++ b/debug-panel/src/App.tsx
@@ -80,7 +80,7 @@ function App() {
       <Button
         variant="contained"
         onClick={() => {
-          apiClient.createGameSession(1156, false)
+          apiClient.createGameSession(1262, false)
             .then(gameSession => {
               updateGameSession(gameSession)
               setError(null)

--- a/debug-panel/src/App.tsx
+++ b/debug-panel/src/App.tsx
@@ -311,7 +311,7 @@ function App() {
           if (isNullOrUndefined(question.choices) || question.choices.length == 0) {
             return null
           }
-          const choice = question.choices[0]
+          const choice = question.choices[Math.floor(Math.random() * question.choices.length)]
           if (isNullOrUndefined(choice)) {
             return
           }

--- a/debug-panel/src/App.tsx
+++ b/debug-panel/src/App.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react'
 import { Button, TextField } from '@mui/material'
-import { ApiClient, Environment, GameSessionState, ITeamAnswer } from '@righton/networking'
-import { IApiClient } from '@righton/networking'
-import { IGameSession, ITeam, ITeamMember } from '@righton/networking'
+import { ApiClient, Environment, GameSessionState, IApiClient, IGameSession, ITeam, ITeamAnswer, ITeamMember } from '@righton/networking'
+import { useEffect, useRef, useState } from 'react'
 
 function App() {
   const [gameSession, setGameSession] = useState<IGameSession | null>()

--- a/networking/amplify/backend/api/mobile/schema.graphql
+++ b/networking/amplify/backend/api/mobile/schema.graphql
@@ -76,6 +76,10 @@ type TeamAnswer @model {
 type Subscription {
   onGameSessionUpdatedById(id: ID!): GameSession
     @aws_subscribe(mutations: ["updateGameSession"])
-  onTeamMemberUpdateByTeamId(teamId: ID!): TeamMember
+  onTeamMemberUpdateByTeamId(teamTeamMembersId: ID!): TeamMember
     @aws_subscribe(mutations: ["updateTeamMember"])
+  onTeamCreateByGameSessionId(gameSessionTeamsId: ID!): Team
+    @aws_subscribe(mutations: ["createTeam"])
+  onTeamDeleteByGameSessionId(gameSessionTeamsId: ID!): Team
+    @aws_subscribe(mutations: ["deleteTeam"])
 }

--- a/networking/amplify/team-provider-info.json
+++ b/networking/amplify/team-provider-info.json
@@ -10,6 +10,11 @@
       "StackName": "amplify-mobile-dev-124521",
       "StackId": "arn:aws:cloudformation:us-east-1:484006752749:stack/amplify-mobile-dev-124521/8882e450-faef-11ec-a2fb-12cbb9c98fc1",
       "AmplifyAppId": "d2z6928w5qibze"
+    },
+    "categories": {
+      "api": {
+        "mobile": {}
+      }
     }
   }
 }

--- a/networking/schema.graphql
+++ b/networking/schema.graphql
@@ -76,6 +76,10 @@ type TeamAnswer @model {
 type Subscription {
   onGameSessionUpdatedById(id: ID!): GameSession
     @aws_subscribe(mutations: ["updateGameSession"])
-  onTeamMemberUpdateByTeamId(teamId: ID!): TeamMember
+  onTeamMemberUpdateByTeamId(teamTeamMembersId: ID!): TeamMember
     @aws_subscribe(mutations: ["updateTeamMember"])
+  onTeamCreateByGameSessionId(gameSessionTeamsId: ID!): Team
+    @aws_subscribe(mutations: ["createTeam"])
+  onTeamDeleteByGameSessionId(gameSessionTeamsId: ID!): Team
+    @aws_subscribe(mutations: ["deleteTeam"])
 }

--- a/networking/src/AWSMobileApi.ts
+++ b/networking/src/AWSMobileApi.ts
@@ -491,6 +491,97 @@ export type ModelTeamAnswerFilterInput = {
   teamMemberAnswersId?: ModelIDInput | null,
 };
 
+export type ModelSubscriptionGameSessionFilterInput = {
+  id?: ModelSubscriptionIDInput | null,
+  gameId?: ModelSubscriptionIntInput | null,
+  startTime?: ModelSubscriptionStringInput | null,
+  phaseOneTime?: ModelSubscriptionIntInput | null,
+  phaseTwoTime?: ModelSubscriptionIntInput | null,
+  currentQuestionIndex?: ModelSubscriptionIntInput | null,
+  currentState?: ModelSubscriptionStringInput | null,
+  gameCode?: ModelSubscriptionIntInput | null,
+  isAdvancedMode?: ModelSubscriptionBooleanInput | null,
+  imageUrl?: ModelSubscriptionStringInput | null,
+  description?: ModelSubscriptionStringInput | null,
+  title?: ModelSubscriptionStringInput | null,
+  currentTimer?: ModelSubscriptionIntInput | null,
+  and?: Array< ModelSubscriptionGameSessionFilterInput | null > | null,
+  or?: Array< ModelSubscriptionGameSessionFilterInput | null > | null,
+};
+
+export type ModelSubscriptionIDInput = {
+  ne?: string | null,
+  eq?: string | null,
+  le?: string | null,
+  lt?: string | null,
+  ge?: string | null,
+  gt?: string | null,
+  contains?: string | null,
+  notContains?: string | null,
+  between?: Array< string | null > | null,
+  beginsWith?: string | null,
+  in?: Array< string | null > | null,
+  notIn?: Array< string | null > | null,
+};
+
+export type ModelSubscriptionIntInput = {
+  ne?: number | null,
+  eq?: number | null,
+  le?: number | null,
+  lt?: number | null,
+  ge?: number | null,
+  gt?: number | null,
+  between?: Array< number | null > | null,
+  in?: Array< number | null > | null,
+  notIn?: Array< number | null > | null,
+};
+
+export type ModelSubscriptionStringInput = {
+  ne?: string | null,
+  eq?: string | null,
+  le?: string | null,
+  lt?: string | null,
+  ge?: string | null,
+  gt?: string | null,
+  contains?: string | null,
+  notContains?: string | null,
+  between?: Array< string | null > | null,
+  beginsWith?: string | null,
+  in?: Array< string | null > | null,
+  notIn?: Array< string | null > | null,
+};
+
+export type ModelSubscriptionBooleanInput = {
+  ne?: boolean | null,
+  eq?: boolean | null,
+};
+
+export type ModelSubscriptionTeamFilterInput = {
+  id?: ModelSubscriptionIDInput | null,
+  name?: ModelSubscriptionStringInput | null,
+  trickiestAnswerIDs?: ModelSubscriptionIDInput | null,
+  score?: ModelSubscriptionIntInput | null,
+  and?: Array< ModelSubscriptionTeamFilterInput | null > | null,
+  or?: Array< ModelSubscriptionTeamFilterInput | null > | null,
+};
+
+export type ModelSubscriptionTeamMemberFilterInput = {
+  id?: ModelSubscriptionIDInput | null,
+  isFacilitator?: ModelSubscriptionBooleanInput | null,
+  deviceId?: ModelSubscriptionIDInput | null,
+  and?: Array< ModelSubscriptionTeamMemberFilterInput | null > | null,
+  or?: Array< ModelSubscriptionTeamMemberFilterInput | null > | null,
+};
+
+export type ModelSubscriptionTeamAnswerFilterInput = {
+  id?: ModelSubscriptionIDInput | null,
+  questionId?: ModelSubscriptionIntInput | null,
+  isChosen?: ModelSubscriptionBooleanInput | null,
+  text?: ModelSubscriptionStringInput | null,
+  and?: Array< ModelSubscriptionTeamAnswerFilterInput | null > | null,
+  or?: Array< ModelSubscriptionTeamAnswerFilterInput | null > | null,
+};
+
 export type CreateGameSessionMutationVariables = {
   input: CreateGameSessionInput,
   condition?: ModelGameSessionConditionInput | null,
@@ -2011,7 +2102,7 @@ export type OnGameSessionUpdatedByIdSubscription = {
 };
 
 export type OnTeamMemberUpdateByTeamIdSubscriptionVariables = {
-  teamId: string,
+  teamTeamMembersId: string,
 };
 
 export type OnTeamMemberUpdateByTeamIdSubscription = {
@@ -2038,6 +2129,132 @@ export type OnTeamMemberUpdateByTeamIdSubscription = {
     updatedAt: string,
     teamTeamMembersId?: string | null,
   } | null,
+};
+
+export type OnTeamCreateByGameSessionIdSubscriptionVariables = {
+  gameSessionTeamsId: string,
+};
+
+export type OnTeamCreateByGameSessionIdSubscription = {
+  onTeamCreateByGameSessionId?:  {
+    __typename: "Team",
+    id: string,
+    name: string,
+    question?:  {
+      __typename: "Question",
+      id: number,
+      text: string,
+      choices?: string | null,
+      imageUrl?: string | null,
+      instructions?: string | null,
+      standard?: string | null,
+      cluster?: string | null,
+      domain?: string | null,
+      grade?: string | null,
+      order: number,
+      gameSessionId: string,
+    } | null,
+    trickiestAnswerIDs?: Array< string | null > | null,
+    teamMembers?:  {
+      __typename: "ModelTeamMemberConnection",
+      items:  Array< {
+        __typename: "TeamMember",
+        id: string,
+        isFacilitator?: boolean | null,
+        answers?:  {
+          __typename: "ModelTeamAnswerConnection",
+          items:  Array< {
+            __typename: "TeamAnswer",
+            id: string,
+            questionId: number,
+            isChosen?: boolean | null,
+            text: string,
+            createdAt: string,
+            updatedAt: string,
+            teamMemberAnswersId?: string | null,
+          } | null >,
+          nextToken?: string | null,
+        } | null,
+        deviceId: string,
+        createdAt: string,
+        updatedAt: string,
+        teamTeamMembersId?: string | null,
+      } | null >,
+      nextToken?: string | null,
+    } | null,
+    score: number,
+    createdAt: string,
+    updatedAt: string,
+    gameSessionTeamsId?: string | null,
+    teamQuestionId?: string | null,
+    teamQuestionOrder?: number | null,
+    teamQuestionGameSessionId?: string | null,
+  } | null,
+};
+
+export type OnTeamDeleteByGameSessionIdSubscriptionVariables = {
+  gameSessionTeamsId: string,
+};
+
+export type OnTeamDeleteByGameSessionIdSubscription = {
+  onTeamDeleteByGameSessionId?:  {
+    __typename: "Team",
+    id: string,
+    name: string,
+    question?:  {
+      __typename: "Question",
+      id: number,
+      text: string,
+      choices?: string | null,
+      imageUrl?: string | null,
+      instructions?: string | null,
+      standard?: string | null,
+      cluster?: string | null,
+      domain?: string | null,
+      grade?: string | null,
+      order: number,
+      gameSessionId: string,
+    } | null,
+    trickiestAnswerIDs?: Array< string | null > | null,
+    teamMembers?:  {
+      __typename: "ModelTeamMemberConnection",
+      items:  Array< {
+        __typename: "TeamMember",
+        id: string,
+        isFacilitator?: boolean | null,
+        answers?:  {
+          __typename: "ModelTeamAnswerConnection",
+          items:  Array< {
+            __typename: "TeamAnswer",
+            id: string,
+            questionId: number,
+            isChosen?: boolean | null,
+            text: string,
+            createdAt: string,
+            updatedAt: string,
+            teamMemberAnswersId?: string | null,
+          } | null >,
+          nextToken?: string | null,
+        } | null,
+        deviceId: string,
+        createdAt: string,
+        updatedAt: string,
+        teamTeamMembersId?: string | null,
+      } | null >,
+      nextToken?: string | null,
+    } | null,
+    score: number,
+    createdAt: string,
+    updatedAt: string,
+    gameSessionTeamsId?: string | null,
+    teamQuestionId?: string | null,
+    teamQuestionOrder?: number | null,
+    teamQuestionGameSessionId?: string | null,
+  } | null,
+};
+
+export type OnCreateGameSessionSubscriptionVariables = {
+  filter?: ModelSubscriptionGameSessionFilterInput | null,
 };
 
 export type OnCreateGameSessionSubscription = {
@@ -2137,6 +2354,10 @@ export type OnCreateGameSessionSubscription = {
   } | null,
 };
 
+export type OnUpdateGameSessionSubscriptionVariables = {
+  filter?: ModelSubscriptionGameSessionFilterInput | null,
+};
+
 export type OnUpdateGameSessionSubscription = {
   onUpdateGameSession?:  {
     __typename: "GameSession",
@@ -2232,6 +2453,10 @@ export type OnUpdateGameSessionSubscription = {
     createdAt: string,
     updatedAt: string,
   } | null,
+};
+
+export type OnDeleteGameSessionSubscriptionVariables = {
+  filter?: ModelSubscriptionGameSessionFilterInput | null,
 };
 
 export type OnDeleteGameSessionSubscription = {
@@ -2331,6 +2556,10 @@ export type OnDeleteGameSessionSubscription = {
   } | null,
 };
 
+export type OnCreateTeamSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamFilterInput | null,
+};
+
 export type OnCreateTeamSubscription = {
   onCreateTeam?:  {
     __typename: "Team",
@@ -2386,6 +2615,10 @@ export type OnCreateTeamSubscription = {
     teamQuestionOrder?: number | null,
     teamQuestionGameSessionId?: string | null,
   } | null,
+};
+
+export type OnUpdateTeamSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamFilterInput | null,
 };
 
 export type OnUpdateTeamSubscription = {
@@ -2445,6 +2678,10 @@ export type OnUpdateTeamSubscription = {
   } | null,
 };
 
+export type OnDeleteTeamSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamFilterInput | null,
+};
+
 export type OnDeleteTeamSubscription = {
   onDeleteTeam?:  {
     __typename: "Team",
@@ -2502,6 +2739,10 @@ export type OnDeleteTeamSubscription = {
   } | null,
 };
 
+export type OnCreateTeamMemberSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamMemberFilterInput | null,
+};
+
 export type OnCreateTeamMemberSubscription = {
   onCreateTeamMember?:  {
     __typename: "TeamMember",
@@ -2526,6 +2767,10 @@ export type OnCreateTeamMemberSubscription = {
     updatedAt: string,
     teamTeamMembersId?: string | null,
   } | null,
+};
+
+export type OnUpdateTeamMemberSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamMemberFilterInput | null,
 };
 
 export type OnUpdateTeamMemberSubscription = {
@@ -2554,6 +2799,10 @@ export type OnUpdateTeamMemberSubscription = {
   } | null,
 };
 
+export type OnDeleteTeamMemberSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamMemberFilterInput | null,
+};
+
 export type OnDeleteTeamMemberSubscription = {
   onDeleteTeamMember?:  {
     __typename: "TeamMember",
@@ -2580,6 +2829,10 @@ export type OnDeleteTeamMemberSubscription = {
   } | null,
 };
 
+export type OnCreateTeamAnswerSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamAnswerFilterInput | null,
+};
+
 export type OnCreateTeamAnswerSubscription = {
   onCreateTeamAnswer?:  {
     __typename: "TeamAnswer",
@@ -2593,6 +2846,10 @@ export type OnCreateTeamAnswerSubscription = {
   } | null,
 };
 
+export type OnUpdateTeamAnswerSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamAnswerFilterInput | null,
+};
+
 export type OnUpdateTeamAnswerSubscription = {
   onUpdateTeamAnswer?:  {
     __typename: "TeamAnswer",
@@ -2604,6 +2861,10 @@ export type OnUpdateTeamAnswerSubscription = {
     updatedAt: string,
     teamMemberAnswersId?: string | null,
   } | null,
+};
+
+export type OnDeleteTeamAnswerSubscriptionVariables = {
+  filter?: ModelSubscriptionTeamAnswerFilterInput | null,
 };
 
 export type OnDeleteTeamAnswerSubscription = {

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -20,7 +20,7 @@ import {
 import { gameSessionByCode, getGameSession, getTeam, onCreateTeam, onCreateTeamAnswer, onDeleteTeam, onGameSessionUpdatedById, onUpdateTeamMember } from './graphql'
 import { createTeam, createTeamAnswer, createTeamMember, updateGameSession } from './graphql/mutations'
 import { IApiClient, isNullOrUndefined } from './IApiClient'
-import { IQuestion, ITeamAnswer, ITeamMember } from './Models'
+import { IChoice, IQuestion, ITeamAnswer, ITeamMember } from './Models'
 import { IGameSession } from './Models/IGameSession'
 import { ITeam } from './Models/ITeam'
 
@@ -458,6 +458,15 @@ class GameSessionParser {
         })
     }
 
+    private static parseServerArray<T>(input: any | T[]): Array<T> {
+        if (input instanceof Array) {
+            return input as T[]
+        } else if (input instanceof String) {
+            return JSON.parse(input as string)
+        }
+        return []
+    }
+
     private static mapQuestions(awsQuestions: Array<AWSQuestion | null>): Array<IQuestion> {
         return awsQuestions.map(awsQuestion => {
             if (isNullOrUndefined(awsQuestion)) {
@@ -466,9 +475,9 @@ class GameSessionParser {
             const question: IQuestion = {
                 id: awsQuestion.id,
                 text: awsQuestion.text,
-                choices: isNullOrUndefined(awsQuestion.choices) ? [] : JSON.parse(awsQuestion.choices),
+                choices: isNullOrUndefined(awsQuestion.choices) ? [] : this.parseServerArray<IChoice>(awsQuestion.choices),
                 imageUrl: awsQuestion.imageUrl,
-                instructions: isNullOrUndefined(awsQuestion.instructions) ? [] : JSON.parse(awsQuestion.instructions),
+                instructions: isNullOrUndefined(awsQuestion.instructions) ? [] : this.parseServerArray<string>(awsQuestion.instructions),
                 standard: awsQuestion.standard,
                 cluster: awsQuestion.cluster,
                 domain: awsQuestion.domain,

--- a/networking/src/ModelHelper.ts
+++ b/networking/src/ModelHelper.ts
@@ -1,6 +1,6 @@
 import { isNullOrUndefined } from "./IApiClient"
 import { IGameSession, ITeam, ITeamAnswer } from "./Models"
-import { Choice, IQuestion } from './Models/IQuestion'
+import { IChoice, IQuestion } from './Models/IQuestion'
 
 export abstract class ModelHelper {
     static getBasicTeamMemberAnswersToQuestionId(team: ITeam, questionId: number): Array<ITeamAnswer | null> | undefined {
@@ -23,10 +23,28 @@ export abstract class ModelHelper {
         })
     }
 
-    static getCorrectAnswer(question: IQuestion): Choice {
+    static getCorrectAnswer(question: IQuestion): IChoice {
         return question.choices!.filter((choice) => {
             return !isNullOrUndefined(choice.isAnswer) && choice.isAnswer
         })[0]
+    }
+
+    static getSelectedTrickAnswer(team: ITeam, questionId: number): ITeamAnswer | null {
+        if (isNullOrUndefined(team.teamMembers) ||
+            team.teamMembers.length !== 1) {
+            throw new Error("Given team has no members or more than one members")
+        }
+
+        const teamMember = team.teamMembers[0]
+        const trickAnswers = teamMember!.answers?.filter((answer) => {
+            if (isNullOrUndefined(answer)) {
+                return false
+            }
+
+            return answer.questionId === questionId && team.trickiestAnswerIDs?.includes(answer.id)
+        })
+
+        return trickAnswers?.length === 1 ? trickAnswers[0] : null
     }
 
     static calculateBasicModeWrongAnswerScore(gameSession: IGameSession, team: ITeam, questionId: number): number {

--- a/networking/src/Models/IQuestion.ts
+++ b/networking/src/Models/IQuestion.ts
@@ -1,7 +1,7 @@
 export interface IQuestion {
     id: number
     text: string
-    choices?: Array<Choice> | null
+    choices?: Array<IChoice> | null
     imageUrl?: string | null
     instructions?: Array<string> | null
     standard?: string | null
@@ -12,7 +12,7 @@ export interface IQuestion {
     order: number
 }
 
-export interface Choice {
+export interface IChoice {
     text: string
     reason?: string
     isAnswer: boolean

--- a/networking/src/graphql/schema.json
+++ b/networking/src/graphql/schema.json
@@ -5176,7 +5176,7 @@
           "name" : "onTeamMemberUpdateByTeamId",
           "description" : null,
           "args" : [ {
-            "name" : "teamId",
+            "name" : "teamTeamMembersId",
             "description" : null,
             "type" : {
               "kind" : "NON_NULL",
@@ -5197,9 +5197,66 @@
           "isDeprecated" : false,
           "deprecationReason" : null
         }, {
+          "name" : "onTeamCreateByGameSessionId",
+          "description" : null,
+          "args" : [ {
+            "name" : "gameSessionTeamsId",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "SCALAR",
+                "name" : "ID",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Team",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
+          "name" : "onTeamDeleteByGameSessionId",
+          "description" : null,
+          "args" : [ {
+            "name" : "gameSessionTeamsId",
+            "description" : null,
+            "type" : {
+              "kind" : "NON_NULL",
+              "name" : null,
+              "ofType" : {
+                "kind" : "SCALAR",
+                "name" : "ID",
+                "ofType" : null
+              }
+            },
+            "defaultValue" : null
+          } ],
+          "type" : {
+            "kind" : "OBJECT",
+            "name" : "Team",
+            "ofType" : null
+          },
+          "isDeprecated" : false,
+          "deprecationReason" : null
+        }, {
           "name" : "onCreateGameSession",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionGameSessionFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "GameSession",
@@ -5210,7 +5267,16 @@
         }, {
           "name" : "onUpdateGameSession",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionGameSessionFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "GameSession",
@@ -5221,7 +5287,16 @@
         }, {
           "name" : "onDeleteGameSession",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionGameSessionFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "GameSession",
@@ -5232,7 +5307,16 @@
         }, {
           "name" : "onCreateTeam",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "Team",
@@ -5243,7 +5327,16 @@
         }, {
           "name" : "onUpdateTeam",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "Team",
@@ -5254,7 +5347,16 @@
         }, {
           "name" : "onDeleteTeam",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "Team",
@@ -5265,7 +5367,16 @@
         }, {
           "name" : "onCreateTeamMember",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamMemberFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "TeamMember",
@@ -5276,7 +5387,16 @@
         }, {
           "name" : "onUpdateTeamMember",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamMemberFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "TeamMember",
@@ -5287,7 +5407,16 @@
         }, {
           "name" : "onDeleteTeamMember",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamMemberFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "TeamMember",
@@ -5298,7 +5427,16 @@
         }, {
           "name" : "onCreateTeamAnswer",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamAnswerFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "TeamAnswer",
@@ -5309,7 +5447,16 @@
         }, {
           "name" : "onUpdateTeamAnswer",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamAnswerFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "TeamAnswer",
@@ -5320,7 +5467,16 @@
         }, {
           "name" : "onDeleteTeamAnswer",
           "description" : null,
-          "args" : [ ],
+          "args" : [ {
+            "name" : "filter",
+            "description" : null,
+            "type" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamAnswerFilterInput",
+              "ofType" : null
+            },
+            "defaultValue" : null
+          } ],
           "type" : {
             "kind" : "OBJECT",
             "name" : "TeamAnswer",
@@ -5331,6 +5487,158 @@
         } ],
         "inputFields" : null,
         "interfaces" : [ ],
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelSubscriptionGameSessionFilterInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "id",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIDInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "gameId",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIntInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "startTime",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionStringInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "phaseOneTime",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIntInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "phaseTwoTime",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIntInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "currentQuestionIndex",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIntInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "currentState",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionStringInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "gameCode",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIntInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "isAdvancedMode",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionBooleanInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "imageUrl",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionStringInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "description",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionStringInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "title",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionStringInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "currentTimer",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIntInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "and",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionGameSessionFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "or",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionGameSessionFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
         "enumValues" : null,
         "possibleTypes" : null
       }, {
@@ -5456,238 +5764,6 @@
               "name" : "ID",
               "ofType" : null
             }
-          },
-          "defaultValue" : null
-        } ],
-        "interfaces" : null,
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "INPUT_OBJECT",
-        "name" : "ModelSubscriptionBooleanInput",
-        "description" : null,
-        "fields" : null,
-        "inputFields" : [ {
-          "name" : "ne",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "eq",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        } ],
-        "interfaces" : null,
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "INPUT_OBJECT",
-        "name" : "ModelSubscriptionFloatInput",
-        "description" : null,
-        "fields" : null,
-        "inputFields" : [ {
-          "name" : "ne",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "eq",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "le",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "lt",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "ge",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "gt",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "between",
-          "description" : null,
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "Float",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "in",
-          "description" : null,
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "Float",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "notIn",
-          "description" : null,
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "Float",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        } ],
-        "interfaces" : null,
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "SCALAR",
-        "name" : "Float",
-        "description" : "Built-in Float",
-        "fields" : null,
-        "inputFields" : null,
-        "interfaces" : null,
-        "enumValues" : null,
-        "possibleTypes" : null
-      }, {
-        "kind" : "INPUT_OBJECT",
-        "name" : "ModelFloatInput",
-        "description" : null,
-        "fields" : null,
-        "inputFields" : [ {
-          "name" : "ne",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "eq",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "le",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "lt",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "ge",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "gt",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Float",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "between",
-          "description" : null,
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "Float",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "attributeExists",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "Boolean",
-            "ofType" : null
-          },
-          "defaultValue" : null
-        }, {
-          "name" : "attributeType",
-          "description" : null,
-          "type" : {
-            "kind" : "ENUM",
-            "name" : "ModelAttributeTypes",
-            "ofType" : null
           },
           "defaultValue" : null
         } ],
@@ -5919,6 +5995,442 @@
               "name" : "String",
               "ofType" : null
             }
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelSubscriptionBooleanInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "ne",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "eq",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelSubscriptionTeamFilterInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "id",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIDInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "name",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionStringInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "trickiestAnswerIDs",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIDInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "score",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIntInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "and",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "or",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelSubscriptionTeamMemberFilterInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "id",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIDInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "isFacilitator",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionBooleanInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "deviceId",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIDInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "and",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamMemberFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "or",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamMemberFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelSubscriptionTeamAnswerFilterInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "id",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIDInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "questionId",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionIntInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "isChosen",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionBooleanInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "text",
+          "description" : null,
+          "type" : {
+            "kind" : "INPUT_OBJECT",
+            "name" : "ModelSubscriptionStringInput",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "and",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamAnswerFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "or",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "INPUT_OBJECT",
+              "name" : "ModelSubscriptionTeamAnswerFilterInput",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelSubscriptionFloatInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "ne",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "eq",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "le",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "lt",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "ge",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "gt",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "between",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Float",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "in",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Float",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "notIn",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Float",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "SCALAR",
+        "name" : "Float",
+        "description" : "Built-in Float",
+        "fields" : null,
+        "inputFields" : null,
+        "interfaces" : null,
+        "enumValues" : null,
+        "possibleTypes" : null
+      }, {
+        "kind" : "INPUT_OBJECT",
+        "name" : "ModelFloatInput",
+        "description" : null,
+        "fields" : null,
+        "inputFields" : [ {
+          "name" : "ne",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "eq",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "le",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "lt",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "ge",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "gt",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Float",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "between",
+          "description" : null,
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "Float",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "attributeExists",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "Boolean",
+            "ofType" : null
+          },
+          "defaultValue" : null
+        }, {
+          "name" : "attributeType",
+          "description" : null,
+          "type" : {
+            "kind" : "ENUM",
+            "name" : "ModelAttributeTypes",
+            "ofType" : null
           },
           "defaultValue" : null
         } ],
@@ -6709,6 +7221,22 @@
         "onFragment" : false,
         "onField" : true
       }, {
+        "name" : "aws_oidc",
+        "description" : "Tells the service this field/object has access authorized by an OIDC token.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
+        "name" : "aws_api_key",
+        "description" : "Tells the service this field/object has access authorized by an API key.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
         "name" : "aws_publish",
         "description" : "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
         "locations" : [ "FIELD_DEFINITION" ],
@@ -6751,6 +7279,27 @@
         "onFragment" : false,
         "onField" : false
       }, {
+        "name" : "aws_cognito_user_pools",
+        "description" : "Tells the service this field/object has access authorized by a Cognito User Pools token.",
+        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
+        "args" : [ {
+          "name" : "cognito_groups",
+          "description" : "List of cognito user pool groups which have access on this field",
+          "type" : {
+            "kind" : "LIST",
+            "name" : null,
+            "ofType" : {
+              "kind" : "SCALAR",
+              "name" : "String",
+              "ofType" : null
+            }
+          },
+          "defaultValue" : null
+        } ],
+        "onOperation" : false,
+        "onFragment" : false,
+        "onField" : false
+      }, {
         "name" : "aws_iam",
         "description" : "Tells the service this field/object has access authorized by sigv4 signing.",
         "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
@@ -6759,10 +7308,19 @@
         "onFragment" : false,
         "onField" : false
       }, {
-        "name" : "aws_lambda",
-        "description" : "Tells the service this field/object has access authorized by a Lambda Authorizer.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ ],
+        "name" : "deprecated",
+        "description" : null,
+        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
+        "args" : [ {
+          "name" : "reason",
+          "description" : null,
+          "type" : {
+            "kind" : "SCALAR",
+            "name" : "String",
+            "ofType" : null
+          },
+          "defaultValue" : "\"No longer supported\""
+        } ],
         "onOperation" : false,
         "onFragment" : false,
         "onField" : false
@@ -6788,56 +7346,10 @@
         "onFragment" : false,
         "onField" : false
       }, {
-        "name" : "aws_api_key",
-        "description" : "Tells the service this field/object has access authorized by an API key.",
+        "name" : "aws_lambda",
+        "description" : "Tells the service this field/object has access authorized by a Lambda Authorizer.",
         "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
         "args" : [ ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "aws_oidc",
-        "description" : "Tells the service this field/object has access authorized by an OIDC token.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "aws_cognito_user_pools",
-        "description" : "Tells the service this field/object has access authorized by a Cognito User Pools token.",
-        "locations" : [ "OBJECT", "FIELD_DEFINITION" ],
-        "args" : [ {
-          "name" : "cognito_groups",
-          "description" : "List of cognito user pool groups which have access on this field",
-          "type" : {
-            "kind" : "LIST",
-            "name" : null,
-            "ofType" : {
-              "kind" : "SCALAR",
-              "name" : "String",
-              "ofType" : null
-            }
-          },
-          "defaultValue" : null
-        } ],
-        "onOperation" : false,
-        "onFragment" : false,
-        "onField" : false
-      }, {
-        "name" : "deprecated",
-        "description" : null,
-        "locations" : [ "FIELD_DEFINITION", "ENUM_VALUE" ],
-        "args" : [ {
-          "name" : "reason",
-          "description" : null,
-          "type" : {
-            "kind" : "SCALAR",
-            "name" : "String",
-            "ofType" : null
-          },
-          "defaultValue" : "\"No longer supported\""
-        } ],
         "onOperation" : false,
         "onFragment" : false,
         "onField" : false

--- a/networking/src/graphql/subscriptions.ts
+++ b/networking/src/graphql/subscriptions.ts
@@ -91,8 +91,8 @@ export const onGameSessionUpdatedById = /* GraphQL */ `
   }
 `;
 export const onTeamMemberUpdateByTeamId = /* GraphQL */ `
-  subscription OnTeamMemberUpdateByTeamId($teamId: ID!) {
-    onTeamMemberUpdateByTeamId(teamId: $teamId) {
+  subscription OnTeamMemberUpdateByTeamId($teamTeamMembersId: ID!) {
+    onTeamMemberUpdateByTeamId(teamTeamMembersId: $teamTeamMembersId) {
       id
       isFacilitator
       answers {
@@ -114,9 +114,115 @@ export const onTeamMemberUpdateByTeamId = /* GraphQL */ `
     }
   }
 `;
+export const onTeamCreateByGameSessionId = /* GraphQL */ `
+  subscription OnTeamCreateByGameSessionId($gameSessionTeamsId: ID!) {
+    onTeamCreateByGameSessionId(gameSessionTeamsId: $gameSessionTeamsId) {
+      id
+      name
+      question {
+        id
+        text
+        choices
+        imageUrl
+        instructions
+        standard
+        cluster
+        domain
+        grade
+        order
+        gameSessionId
+      }
+      trickiestAnswerIDs
+      teamMembers {
+        items {
+          id
+          isFacilitator
+          answers {
+            items {
+              id
+              questionId
+              isChosen
+              text
+              createdAt
+              updatedAt
+              teamMemberAnswersId
+            }
+            nextToken
+          }
+          deviceId
+          createdAt
+          updatedAt
+          teamTeamMembersId
+        }
+        nextToken
+      }
+      score
+      createdAt
+      updatedAt
+      gameSessionTeamsId
+      teamQuestionId
+      teamQuestionOrder
+      teamQuestionGameSessionId
+    }
+  }
+`;
+export const onTeamDeleteByGameSessionId = /* GraphQL */ `
+  subscription OnTeamDeleteByGameSessionId($gameSessionTeamsId: ID!) {
+    onTeamDeleteByGameSessionId(gameSessionTeamsId: $gameSessionTeamsId) {
+      id
+      name
+      question {
+        id
+        text
+        choices
+        imageUrl
+        instructions
+        standard
+        cluster
+        domain
+        grade
+        order
+        gameSessionId
+      }
+      trickiestAnswerIDs
+      teamMembers {
+        items {
+          id
+          isFacilitator
+          answers {
+            items {
+              id
+              questionId
+              isChosen
+              text
+              createdAt
+              updatedAt
+              teamMemberAnswersId
+            }
+            nextToken
+          }
+          deviceId
+          createdAt
+          updatedAt
+          teamTeamMembersId
+        }
+        nextToken
+      }
+      score
+      createdAt
+      updatedAt
+      gameSessionTeamsId
+      teamQuestionId
+      teamQuestionOrder
+      teamQuestionGameSessionId
+    }
+  }
+`;
 export const onCreateGameSession = /* GraphQL */ `
-  subscription OnCreateGameSession {
-    onCreateGameSession {
+  subscription OnCreateGameSession(
+    $filter: ModelSubscriptionGameSessionFilterInput
+  ) {
+    onCreateGameSession(filter: $filter) {
       id
       gameId
       startTime
@@ -203,8 +309,10 @@ export const onCreateGameSession = /* GraphQL */ `
   }
 `;
 export const onUpdateGameSession = /* GraphQL */ `
-  subscription OnUpdateGameSession {
-    onUpdateGameSession {
+  subscription OnUpdateGameSession(
+    $filter: ModelSubscriptionGameSessionFilterInput
+  ) {
+    onUpdateGameSession(filter: $filter) {
       id
       gameId
       startTime
@@ -291,8 +399,10 @@ export const onUpdateGameSession = /* GraphQL */ `
   }
 `;
 export const onDeleteGameSession = /* GraphQL */ `
-  subscription OnDeleteGameSession {
-    onDeleteGameSession {
+  subscription OnDeleteGameSession(
+    $filter: ModelSubscriptionGameSessionFilterInput
+  ) {
+    onDeleteGameSession(filter: $filter) {
       id
       gameId
       startTime
@@ -379,8 +489,8 @@ export const onDeleteGameSession = /* GraphQL */ `
   }
 `;
 export const onCreateTeam = /* GraphQL */ `
-  subscription OnCreateTeam {
-    onCreateTeam {
+  subscription OnCreateTeam($filter: ModelSubscriptionTeamFilterInput) {
+    onCreateTeam(filter: $filter) {
       id
       name
       question {
@@ -431,8 +541,8 @@ export const onCreateTeam = /* GraphQL */ `
   }
 `;
 export const onUpdateTeam = /* GraphQL */ `
-  subscription OnUpdateTeam {
-    onUpdateTeam {
+  subscription OnUpdateTeam($filter: ModelSubscriptionTeamFilterInput) {
+    onUpdateTeam(filter: $filter) {
       id
       name
       question {
@@ -483,8 +593,8 @@ export const onUpdateTeam = /* GraphQL */ `
   }
 `;
 export const onDeleteTeam = /* GraphQL */ `
-  subscription OnDeleteTeam {
-    onDeleteTeam {
+  subscription OnDeleteTeam($filter: ModelSubscriptionTeamFilterInput) {
+    onDeleteTeam(filter: $filter) {
       id
       name
       question {
@@ -535,8 +645,10 @@ export const onDeleteTeam = /* GraphQL */ `
   }
 `;
 export const onCreateTeamMember = /* GraphQL */ `
-  subscription OnCreateTeamMember {
-    onCreateTeamMember {
+  subscription OnCreateTeamMember(
+    $filter: ModelSubscriptionTeamMemberFilterInput
+  ) {
+    onCreateTeamMember(filter: $filter) {
       id
       isFacilitator
       answers {
@@ -559,8 +671,10 @@ export const onCreateTeamMember = /* GraphQL */ `
   }
 `;
 export const onUpdateTeamMember = /* GraphQL */ `
-  subscription OnUpdateTeamMember {
-    onUpdateTeamMember {
+  subscription OnUpdateTeamMember(
+    $filter: ModelSubscriptionTeamMemberFilterInput
+  ) {
+    onUpdateTeamMember(filter: $filter) {
       id
       isFacilitator
       answers {
@@ -583,8 +697,10 @@ export const onUpdateTeamMember = /* GraphQL */ `
   }
 `;
 export const onDeleteTeamMember = /* GraphQL */ `
-  subscription OnDeleteTeamMember {
-    onDeleteTeamMember {
+  subscription OnDeleteTeamMember(
+    $filter: ModelSubscriptionTeamMemberFilterInput
+  ) {
+    onDeleteTeamMember(filter: $filter) {
       id
       isFacilitator
       answers {
@@ -607,8 +723,10 @@ export const onDeleteTeamMember = /* GraphQL */ `
   }
 `;
 export const onCreateTeamAnswer = /* GraphQL */ `
-  subscription OnCreateTeamAnswer {
-    onCreateTeamAnswer {
+  subscription OnCreateTeamAnswer(
+    $filter: ModelSubscriptionTeamAnswerFilterInput
+  ) {
+    onCreateTeamAnswer(filter: $filter) {
       id
       questionId
       isChosen
@@ -620,8 +738,10 @@ export const onCreateTeamAnswer = /* GraphQL */ `
   }
 `;
 export const onUpdateTeamAnswer = /* GraphQL */ `
-  subscription OnUpdateTeamAnswer {
-    onUpdateTeamAnswer {
+  subscription OnUpdateTeamAnswer(
+    $filter: ModelSubscriptionTeamAnswerFilterInput
+  ) {
+    onUpdateTeamAnswer(filter: $filter) {
       id
       questionId
       isChosen
@@ -633,8 +753,10 @@ export const onUpdateTeamAnswer = /* GraphQL */ `
   }
 `;
 export const onDeleteTeamAnswer = /* GraphQL */ `
-  subscription OnDeleteTeamAnswer {
-    onDeleteTeamAnswer {
+  subscription OnDeleteTeamAnswer(
+    $filter: ModelSubscriptionTeamAnswerFilterInput
+  ) {
+    onDeleteTeamAnswer(filter: $filter) {
       id
       questionId
       isChosen


### PR DESCRIPTION
- Add subscriptions to get team updates based on a game session id. This needs to be tested
- Randomize creating an answer to a question in debug panel
- Minor formatting
- Parse choices and instructions for both lambda and graphql responses as one sends down an array and the other sends down a stringified json
- Change the default game id for debug panel as the previous one has been deleted