### PR TITLE
[Mobile][Phase 2] cards working correctly based on current state

### DIFF
--- a/mobile/src/Student/components/Card/index.js
+++ b/mobile/src/Student/components/Card/index.js
@@ -28,6 +28,7 @@ const styles = StyleSheet.create({
         flexDirection: 'column',
         justifyContent: 'space-between',
         alignContent: 'center',
+        paddingVertical: verticalScale(20),
     },
     cardContent: {
         marginLeft: moderateScale(25),

--- a/mobile/src/Student/components/RoundTextIcon/index.js
+++ b/mobile/src/Student/components/RoundTextIcon/index.js
@@ -2,7 +2,6 @@ import React from "react"
 import { StyleSheet, View, TextInput, Image, Pressable } from "react-native"
 import { scale, verticalScale } from "react-native-size-matters"
 import { fontFamilies, fonts } from "../../../utils/theme"
-import { GameSessionState } from "@righton/networking"
 
 const RoundTextIcon = ({
     icon,
@@ -14,7 +13,7 @@ const RoundTextIcon = ({
     showIcon,
     readonly,
     onTextChanged,
-    style,
+    style = {},
     disabled,
 }) => {
     return (
@@ -23,7 +22,7 @@ const RoundTextIcon = ({
             onPress={() => onPress(data)}
         >
             <View
-                style={[styles.container, { height, borderColor }, ...style]}
+                style={[styles.container, { height, borderColor }, { ...style }]}
                 pointerEvents={readonly ? "none" : "auto"}
             >
                 <TextInput

--- a/mobile/src/Student/screens/Game/Components/HintsView/index.js
+++ b/mobile/src/Student/screens/Game/Components/HintsView/index.js
@@ -1,30 +1,11 @@
 import React, { useState } from "react"
-import { StyleSheet, Text, View } from "react-native"
-import { ScrollView, FlatList } from "react-native-gesture-handler"
-import { scale, verticalScale } from "react-native-size-matters"
+import { StyleSheet, View } from "react-native"
+import { FlatList } from "react-native-gesture-handler"
+import { scale } from "react-native-size-matters"
 import { fontFamilies, fonts, colors } from "../../../../../utils/theme"
 import Hint from "./Hint"
-import Button from "../../../../components/Button"
 
-const HintsView = ({ hints, onTappedShowNextHint, isMoreHintsAvailable }) => {
-    const [showNextHintEnabled, setShowNextHintEnabled] = useState(false)
-
-    const onTappedNextHint = () => {
-        setShowNextHintEnabled(false)
-        onTappedShowNextHint()
-    }
-
-    const isShowHintsDisabled = !showNextHintEnabled || !isMoreHintsAvailable
-
-    const showNextStepButton = {
-        ...styles.buttonStyle,
-        ...{
-            backgroundColor: isShowHintsDisabled
-                ? "#9BA5B4"
-                : colors.buttonSecondary,
-        },
-    }
-
+const HintsView = ({ hints }) => {
     const mappedHints = hints.map((hint, idx) => {
         return {
             hintNo: idx + 1,
@@ -32,48 +13,9 @@ const HintsView = ({ hints, onTappedShowNextHint, isMoreHintsAvailable }) => {
         }
     })
 
-    return (
-        <View>
-            <FlatList
-                data={mappedHints}
-                keyExtractor={(item) => `${item.hintNo}`}
-                renderItem={({ item }) => (
-                    <Hint hintNo={item.hintNo} hint={item.hint} />
-                )}
-            />
-            <View style={styles.showNextHintContainer}>
-                {/* <Button
-                    title="Show Next Step"
-                    buttonStyle={showNextStepButton}
-                    onPress={onTappedNextHint}
-                    titleStyle={styles.showNextStepTitle}
-                    disabled={isShowHintsDisabled}
-                /> */}
-                {!showNextHintEnabled && isMoreHintsAvailable && (
-                    <LoadingIndicator
-                        theme={[
-                            "#FF78A520",
-                            "#FF78A540",
-                            "#FF78A560",
-                            "#FF78A580",
-                            "#FF78A5A0",
-                            "#FF78A5C0",
-                            "#FF78A5E0",
-                            "#FF78A5FF",
-                        ]}
-                        radius={scale(29)}
-                        shouldShowCountdown={true}
-                        fontSize={24}
-                        textColor={"#384466"}
-                        timerStartInSecond={5}
-                        onTimerFinished={() =>
-                            setShowNextHintEnabled(!showNextHintEnabled)
-                        }
-                    />
-                )}
-            </View>
-        </View>
-    )
+    return mappedHints.map((item) => (
+        <Hint key={item.hintNo} hintNo={item.hintNo} hint={item.hint} />
+    ))
 }
 
 export default HintsView

--- a/mobile/src/Student/screens/Game/PhaseTwoBasicGamePlay/index.js
+++ b/mobile/src/Student/screens/Game/PhaseTwoBasicGamePlay/index.js
@@ -9,7 +9,7 @@ import {
 } from "react-native"
 import LinearGradient from "react-native-linear-gradient"
 import * as Progress from "react-native-progress"
-import { moderateScale, scale, verticalScale } from "react-native-size-matters"
+import { scale, verticalScale } from "react-native-size-matters"
 import uuid from "react-native-uuid"
 import { fontFamilies, fonts } from "../../../../utils/theme"
 import Card from "../../../components/Card"
@@ -27,8 +27,6 @@ const PhaseTwoBasicGamePlay = ({
     totalScore,
     smallAvatar,
 }) => {
-    console.debug("team in Phase Two:", team)
-
     smallAvatar = smallAvatar
         ? smallAvatar
         : require("../../SelectTeam/img/MonsterIcon1.png")
@@ -41,10 +39,10 @@ const PhaseTwoBasicGamePlay = ({
     const question = gameSession?.isAdvanced
         ? team.question
         : gameSession?.questions[
-              gameSession?.currentQuestionIndex == null
-                  ? 0
-                  : gameSession?.currentQuestionIndex
-          ]
+        gameSession?.currentQuestionIndex == null
+            ? 0
+            : gameSession?.currentQuestionIndex
+        ]
 
     const phaseTime = gameSession?.phaseTwoTime
 
@@ -128,9 +126,27 @@ const PhaseTwoBasicGamePlay = ({
 
     const correctAnswer = answerChoices.find((answer) => answer.isCorrectAnswer)
 
-    //wip. need to render each card to a seperate carousel page
-    const wrongAnswerCards = wrongAnswers.map((answer) => {
-        return (
+    let carouselCards = [
+        <Card headerTitle="Question">
+            <ScrollableQuestion question={question} />
+        </Card>,
+        <Card headerTitle="Answers">
+            <AnswerOptionsPhaseTwo
+                isAdvancedMode={gameSession.isAdvanced}
+                isFacilitator={teamMember?.isFacilitator}
+                onAnswered={(answer) => {
+                    handleAnswerResult(answer)
+                }}
+                answers={answerChoices}
+                isCorrectAnswer={correctAnswer.isCorrectAnswer}
+                gameSession={gameSession}
+            />
+        </Card>
+    ]
+
+    if (gameSession?.currentState ===
+        GameSessionState.PHASE_2_DISCUSS) {
+        carouselCards = wrongAnswers.map((answer) => (
             <Card
                 key={answer.id}
                 style={styles.headerText}
@@ -140,8 +156,8 @@ const PhaseTwoBasicGamePlay = ({
                     <Text>{answer.reason}</Text>
                 </Card>
             </Card>
-        )
-    })
+        ))
+    }
 
     return (
         <SafeAreaView style={styles.mainContainer}>
@@ -152,7 +168,7 @@ const PhaseTwoBasicGamePlay = ({
                 end={{ x: 1, y: 1 }}
             >
                 {gameSession?.currentState ===
-                GameSessionState.CHOOSE_TRICKIEST_ANSWER ? (
+                    GameSessionState.CHOOSE_TRICKIEST_ANSWER ? (
                     <>
                         <Text style={styles.headerText}>
                             Pick the Trickiest!
@@ -177,27 +193,7 @@ const PhaseTwoBasicGamePlay = ({
             </LinearGradient>
             <View style={styles.carouselContainer}>
                 <HorizontalPageView>
-                    <Card headerTitle="Question">
-                        <ScrollableQuestion question={question} />
-                    </Card>
-                    <Card headerTitle="Answers">
-                        <AnswerOptionsPhaseTwo
-                            isAdvancedMode={gameSession.isAdvanced}
-                            isFacilitator={teamMember?.isFacilitator}
-                            onAnswered={(answer) => {
-                                handleAnswerResult(answer)
-                            }}
-                            answers={answerChoices.map((choice) => {
-                                return choice
-                            })}
-                            isCorrectAnswer={correctAnswer.isCorrectAnswer}
-                            gameSession={gameSession}
-                        />
-                    </Card>
-                    {gameSession?.currentState ===
-                    GameSessionState.PHASE_2_DISCUSS
-                        ? wrongAnswerCards
-                        : null}
+                    {carouselCards}
                 </HorizontalPageView>
             </View>
             <View style={styles.footerView}>

--- a/mobile/src/containers/GameSessionContainer.js
+++ b/mobile/src/containers/GameSessionContainer.js
@@ -6,6 +6,8 @@ async function storeGameSessionLocal(gameSession, teamId, teamMember, gameCode) 
     try {
         const localGameSession = await EncryptedStorage.setItem(
             "localGameSession",
+            // TODO: maybe we should spread the existing value here and only add 
+            // values with updates
             JSON.stringify({
                 gameSession: gameSession,
                 teamId: teamId,
@@ -55,12 +57,12 @@ const GameSessionContainer = ({ children }) => {
     const [teamMember, setTeamMember] = useState(null)
 
     useEffect(() => {
-        loadLocalGameSession().then((localGameSession) => {
-            if (localGameSession) {
-                setGameSession(localGameSession.gameSession)
-                setTeamId(localGameSession.teamId)
-                setTeamMember(localGameSession.teamMember)
-                setGameCode(localGameSession.gameCode)
+        loadLocalGameSession().then((localStorage) => {
+            if (localStorage) {
+                setGameSession(localStorage.gameSession)
+                setTeamId(localStorage.teamId)
+                setTeamMember(localStorage.teamMember)
+                setGameCode(localStorage.gameSession.gameCode)
             }
         })
     }, [])
@@ -81,17 +83,19 @@ const GameSessionContainer = ({ children }) => {
                                     setGameSession(
                                         gameSessionSubscriptionResponse
                                     )
+                                    console.debug(gameSessionSubscriptionResponse)
                                     if (team || teamId) {
                                         const newTeamObj =
                                             gameSessionSubscriptionResponse.teams.find(
                                                 (team) => team.id === teamId
                                             )
                                         // only update the team member if the team member is found
-
-                                        const newTeamMemberObj = newTeamObj.teamMembers.find(
-                                            (item) => item.id === teamMember.id
-                                        )
-                                        if (newTeamMemberObj) setTeamMember(newTeamMemberObj)
+                                        if (newTeamObj) {
+                                            const newTeamMemberObj = newTeamObj.teamMembers.find(
+                                                (item) => item.id === teamMember.id
+                                            )
+                                            if (newTeamMemberObj) setTeamMember(newTeamMemberObj)
+                                        }
                                     }
                                 }
                             )
@@ -103,6 +107,7 @@ const GameSessionContainer = ({ children }) => {
     }, [gameCode])
 
     useEffect(() => {
+        // TODO: team id and team member should only be updated if they are non-null
         if (gameSession?.gameCode) {
             storeGameSessionLocal(gameSession, teamId, teamMember, gameCode)
         } else {


### PR DESCRIPTION
> Currently the wrong answer explanations are separated in individual cards with proper titles, but need to get them separated to be "swipable" left and right. Each one needs to fill the the screen individually
> 
> Seems like a Carousel indexing issue perhaps?
> 
> [Phase 2 Source code](https://github.com/rightoneducation/righton-app/tree/dev/mobile/src/Student/screens/Game/PhaseTwoBasicGamePlay)
> [Component rendering the carousel Component](https://github.com/rightoneducation/righton-app/tree/dev/mobile/src/Student/components/HorizontalPageView)

https://github.com/rightoneducation/righton-app/issues/383