### PR TITLE
Adding linebreaks to Wrong Answer Explanation on Host

### DIFF
--- a/host/src/components/GameAnswers.jsx
+++ b/host/src/components/GameAnswers.jsx
@@ -13,9 +13,8 @@ export default function GameAnswers({ questions, questionChoices, currentQuestio
         return null;
     }
     questions[currentQuestionIndex].instructions.map((step, index) => {
-    instructions += " Step " + (index+1) + ": " + step;
+    instructions += "Step " + (index+1) + ": " + step + "\n\n";
     });
-    console.log(instructions);
     return instructions;
   };
 

--- a/host/src/components/GameAnswersDropdown.jsx
+++ b/host/src/components/GameAnswersDropdown.jsx
@@ -203,7 +203,8 @@ const useStyles = makeStyles(theme => ({
     fontWeight: "400",
     fontSize: "12px",
     lineHeight: "18px",
-    color: "#FFFFFF"
+    color: "#FFFFFF",
+    whiteSpace: 'pre-line'
   },
   expandedBox: {
     display: "none"


### PR DESCRIPTION
`host` resolution to https://github.com/rightoneducation/righton-app/issues/423

Looks like:
![image](https://user-images.githubusercontent.com/79417944/203486307-7b87a767-40c9-4e85-bc4c-8c3f31f0b1ba.png)

I'll merge but let me know if you are looking for anything else here @amarax 