### PR TITLE
[Mobile] Scores not updating backend

### DIFF
--- a/mobile/src/Student/screens/PhaseResult/index.js
+++ b/mobile/src/Student/screens/PhaseResult/index.js
@@ -121,6 +121,12 @@ const PhaseResult = ({ gameSession, team, teamAvatar, fetchGameSessionByCode, se
         return `% ${calculatePercentage(answer)}`
     }
 
+    const calculateTotalScore =(gameSession, currentquestion, curTeam) => {
+      const newScore = ModelHelper.calculateBasicModeTotalScoreForQuestion(gameSession, currentQuestion, curTeam)
+      global.apiClient.updateTeam({id: curTeam.id, score: newScore})
+      return newScore
+    }
+
     return (
         <SafeAreaView style={styles.container}>
             {loadedData && <>
@@ -159,8 +165,7 @@ const PhaseResult = ({ gameSession, team, teamAvatar, fetchGameSessionByCode, se
                         icon={teamAvatar.smallSrc}
                         name={curTeam.name ? curTeam.name : "N/A"}
                         score={phase2Score}
-                        totalScore={
-                            ModelHelper.calculateBasicModeTotalScoreForQuestion(gameSession, currentQuestion, curTeam)
+                        totalScore={calculateTotalScore(gameSession,currentQuestion,curTeam)
                         }
                     />
                 </View>

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -18,7 +18,7 @@ import {
     OnUpdateTeamMemberSubscription,
     UpdateGameSessionInput,
     UpdateGameSessionMutation,
-    UpdateGameSessionMutationVariables, UpdateTeamAnswerInput, UpdateTeamAnswerMutation, UpdateTeamAnswerMutationVariables
+    UpdateGameSessionMutationVariables, UpdateTeamAnswerInput, UpdateTeamInput, UpdateTeamAnswerMutation, UpdateTeamAnswerMutationVariables, UpdateTeamMutation, UpdateTeamMutationVariables
 } from "./AWSMobileApi"
 import {
     gameSessionByCode,
@@ -35,7 +35,8 @@ import {
     createTeamAnswer,
     createTeamMember,
     updateGameSession,
-    updateTeamAnswer
+    updateTeamAnswer,
+    updateTeam
 } from "./graphql/mutations"
 import { IApiClient, isNullOrUndefined } from "./IApiClient"
 import { IChoice, IQuestion, ITeamAnswer, ITeamMember } from "./Models"
@@ -341,6 +342,27 @@ export class ApiClient implements IApiClient {
         }
         return answer.data.updateTeamAnswer as ITeamAnswer
     }
+
+    async updateTeam(
+      teamInput: UpdateTeamInput
+    ): Promise<ITeam> {
+        const input: UpdateTeamInput = teamInput
+        console.log("hi")
+        console.log(input)
+        const variables: UpdateTeamMutationVariables = { input }
+        const team = await this.callGraphQL<UpdateTeamMutation>(
+            updateTeam,
+            variables
+        )
+        if (
+            isNullOrUndefined(team.data) ||
+            isNullOrUndefined(team.data.updateTeam)
+        ) {
+            throw new Error(`Failed to update team`)
+        }
+        return team.data.updateTeam as ITeam
+    }
+
 
     // Private methods
     private subscribeGraphQL<T>(


### PR DESCRIPTION
This is in response to: https://github.com/rightoneducation/righton-app/issues/434

Issue: scores not currently showing on leaderboard on `host`
Cause: `mobile` doesn't update backend with scores
Resolution: `apiClient.updateTeam` added to `PhaseResults` so that backend is updated between rounds with correct scores.