### PR TITLE
[Mobile] - Change navigation.push to navigation.navigate on gameplay screens

### DIFF
--- a/mobile/src/screens/JoinGame/index.js
+++ b/mobile/src/screens/JoinGame/index.js
@@ -43,12 +43,12 @@ export default function JoinGame({
 
             case GameSessionState.CHOOSE_TRICKIEST_ANSWER:
             case GameSessionState.PHASE_2_DISCUSS:
-                navigation.push("PhaseTwoBasicGamePlay")
+                navigation.navigate("PhaseTwoBasicGamePlay")
                 break
 
             case GameSessionState.PHASE_1_RESULTS:
             case GameSessionState.PHASE_2_RESULTS:
-                navigation.push("PhaseResult")
+                navigation.navigate("PhaseResult")
                 break
 
             case GameSessionState.FINAL_RESULTS:


### PR DESCRIPTION
I'd like to make the included updates because @Alexandra-Kushnirsky and I have been finding that when we use navigation.push, the new instance of the screen resets `selectedAnswerIndex` via `const [selectedAnswerIndex, setSelectedAnswerIndex] = useState(null)` (ln 39 - PhaseTwoBasicGamePlay). 

We're looking to persist that value across the state change from `CHOOSE_TRICKIEST_ANSWER` to `PHASE_2_RESULTS` and the creation of a new instance of the screen seems to prevent that from happening.

I've done a test run through the app with `navigate` and the behaviour between `CHOOSE_CORRECT_ANSWER` and `PHASE_1_RESULTS` and between `CHOOSE_TRICKIEST_ANSWER` and `PHASE_2_RESULTS` seems unaffected.