### PR TITLE
[Play] - Random default values for Select Avatar page

### DIFF
--- a/play/src/components/joingame/SelectAvatar.tsx
+++ b/play/src/components/joingame/SelectAvatar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { styled, useTheme } from '@mui/material/styles';
 import { Stack, Box, Typography } from '@mui/material';
 import { v4 as uuidv4 } from 'uuid';
@@ -80,7 +80,7 @@ const BottomContainer = styled(Box)(({ theme }) => ({
 }));
 
 interface SelectAvatarProps {
-  selectedAvatar: number | null;
+  selectedAvatar: number;
   handleAvatarSelected: (value: number) => void;
   firstNameValue: string;
   lastNameValue: string;
@@ -126,7 +126,7 @@ export default function SelectAvatar({
         </Stack>
         <MonsterContainer isSmallDevice={isSmallDevice}>
           <Monster
-            src={monsterMap[selectedAvatar || 0].monster} // || 0 handles the case where a user has yet to select an answer so it shows the default
+            src={monsterMap[selectedAvatar].monster} // || 0 handles the case where a user has yet to select an answer so it shows the default
             alt="monster"
           />
         </MonsterContainer>

--- a/play/src/containers/GameSessionContainer.tsx
+++ b/play/src/containers/GameSessionContainer.tsx
@@ -18,7 +18,7 @@ export default function GameSessionContainer() {
   );
   const [teamAvatar, setTeamAvatar] = useState(0); // eslint-disable-line @typescript-eslint/no-unused-vars
   const [joinGameState, setjoinGameState] = useState<JoinGameState>( // eslint-disable-line @typescript-eslint/no-unused-vars
-    JoinGameState.ENTER_GAME_CODE
+    JoinGameState.SELECT_AVATAR
   ); 
 
 

--- a/play/src/pages/JoinGame.tsx
+++ b/play/src/pages/JoinGame.tsx
@@ -21,7 +21,7 @@ export default function JoinGame({ joinGameState }: JoinGameProps) {
   const [firstNameValue, setFirstNameValue] = useState('');
   const [lastNameValue, setLastNameValue] = useState('');
   const [avatar, setAvatar] = useState(0); // eslint-disable-line @typescript-eslint/no-unused-vars
-  const [selectedAvatar, setSelectedAvatar] = useState<number | null>(null);
+  const [selectedAvatar, setSelectedAvatar] = useState<number>(Math.floor(Math.random() * 6)); // default selection is random number between 0 and 5
 
   switch (joinGameState) {
     case JoinGameState.HOW_TO_PLAY:


### PR DESCRIPTION
This PR is in response to Mani's comment on PR590 [here](https://github.com/rightoneducation/righton-app/pull/590#discussion_r1178384738).

**Issue:**
On default load, the current behaviour shows a default monster selected but a null value for the white border. This means there's a splicing of the values at default with `selectedAvatar` having a default of null and the `<Monster>` tag assigning a value of `0` in this condition (all in `SelectAvatar.tsx`).

**Resolution:**
U/X has requested that the default value for the team selection be randomly generated and a white border shown around the icon by default. To achieve this, `selectedAvatar` defaults to a random number