### PR TITLE
[Play] - GameInProgress and Final Results Functionality Flow

### DIFF
--- a/play/src/components/AnswerCard.tsx
+++ b/play/src/components/AnswerCard.tsx
@@ -11,7 +11,7 @@ import BodyCardContainerStyled from '../lib/styledcomponents/BodyCardContainerSt
 interface AnswerCardProps {
   answers: { text: string; isCorrectAnswer: boolean }[] | undefined;
   isSubmitted: boolean;
-  handleSubmitAnswer: () => void;
+  handleSubmitAnswer: (answerText: string) => void;
   currentState: GameSessionState;
   selectedAnswer: number | null;
   handleSelectAnswer: (index: number) => void;
@@ -82,6 +82,8 @@ export default function AnswerCard({
         </Stack>
         <ButtonSubmitAnswer
           isSubmitted={isSubmitted}
+          selectedAnswer={selectedAnswer}
+          answers={answers}
           handleSubmitAnswer={handleSubmitAnswer}
           isSelected={!isNullOrUndefined(selectedAnswer)}
         />

--- a/play/src/components/ButtonSubmitAnswer.tsx
+++ b/play/src/components/ButtonSubmitAnswer.tsx
@@ -8,12 +8,16 @@ import {
 interface ButtonSubmitAnswerProps {
   isSelected: boolean;
   isSubmitted: boolean;
-  handleSubmitAnswer: (isSubmitted: boolean) => void;
+  selectedAnswer: number | null;
+  answers: { text: string; isCorrectAnswer: boolean }[] | undefined;
+  handleSubmitAnswer: (answer: string) => void;
 }
 
 export default function ButtonSubmitAnswer({
   isSelected,
   isSubmitted,
+  selectedAnswer,
+  answers,
   handleSubmitAnswer,
 }: ButtonSubmitAnswerProps) {
   const buttonText = isSubmitted ? 'Submitted' : 'Submit Answer';
@@ -24,7 +28,8 @@ export default function ButtonSubmitAnswer({
   return isSelected && !isSubmitted ? (
     <GamePlayButtonStyled
       onClick={() => {
-        handleSubmitAnswer(true);
+        const answerText = answers?.[selectedAnswer ?? 0]?.text;
+        handleSubmitAnswer(answerText ?? '');
       }}
     >
       {buttonContents}

--- a/play/src/components/finalresults/Congrats.tsx
+++ b/play/src/components/finalresults/Congrats.tsx
@@ -3,7 +3,7 @@ import { styled, useTheme } from '@mui/material/styles';
 import { Stack, Box, Typography } from '@mui/material';
 import BackgroundContainerStyled from '../../lib/styledcomponents/layout/BackgroundContainerStyled';
 import { GamePlayButtonStyled } from '../../lib/styledcomponents/GamePlayButtonStyled';
-import { monsterMap } from '../../lib/PlayModels';
+import { monsterMap, FinalResultsState } from '../../lib/PlayModels';
 import Podium from '../../img/Podium.svg';
 
 const StackContainer = styled(Stack)(({ theme }) => ({
@@ -51,13 +51,15 @@ interface CongratsProps {
   isSmallDevice: boolean;
   selectedAvatar: number;
   leader: boolean;
+  setFinalResultsState: (newState: FinalResultsState) => void;
 }
 
 export default function Congrats({
   score,
   isSmallDevice,
   selectedAvatar,
-  leader
+  leader,
+  setFinalResultsState
 }: CongratsProps) {
   const theme = useTheme();
   const introString = `You've earned a total of`;
@@ -96,7 +98,7 @@ export default function Congrats({
           <img src={Podium} alt="podium" style={{position: 'absolute', width: '150px', zIndex: -1, top: '100%', marginTop: '-20px'}}/>
         </Stack>
         <BottomBox style={{zIndex:1}}> 
-          <GamePlayButtonStyled > View Leaderboard </GamePlayButtonStyled>
+          <GamePlayButtonStyled onClick={()=>setFinalResultsState(FinalResultsState.LEADERBOARD)}> View Leaderboard </GamePlayButtonStyled>
         </BottomBox>
       </StackContainer>
     </BackgroundContainerStyled>

--- a/play/src/components/gameinprogress/ChooseAnswer.tsx
+++ b/play/src/components/gameinprogress/ChooseAnswer.tsx
@@ -17,7 +17,7 @@ interface ChooseAnswerProps {
   questionUrl: string;
   answerChoices: { text: string; isCorrectAnswer: boolean }[] | undefined;
   isSubmitted: boolean;
-  handleSubmitAnswer: () => void;
+  handleSubmitAnswer: (answerText: string) => void;
   currentState: GameSessionState;
   selectedAnswer: number | null;
   handleSelectAnswer: (answer: number) => void;

--- a/play/src/containers/GameInProgressContainer.tsx
+++ b/play/src/containers/GameInProgressContainer.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import {
   IGameSession,
   IChoice,
+  IQuestion,
   GameSessionState,
 } from '@righton/networking';
 import { v4 as uuidv4 } from 'uuid';
@@ -14,26 +15,24 @@ import { FinalResultsState, JoinBasicGameData } from '../lib/PlayModels';
 
 interface ConnectedGameContainerProps {
   gameSession: IGameSession;
+  teamId: string;
   currentState: GameSessionState;
   setCurrentState: (state: GameSessionState) => void;
   teamAvatar: number;
+  addTeamAnswerToTeamMember: (question: IQuestion, answerText: string, gameSessionState: GameSessionState) => void;
 }
 
-export default function GameInProgressContainer({gameSession, currentState, teamAvatar} : ConnectedGameContainerProps) {
+export default function GameInProgressContainer({gameSession, teamId, currentState, teamAvatar, addTeamAnswerToTeamMember} : ConnectedGameContainerProps) {
   const [isPregameCountdown, setIsPregameCountdown] = useState<boolean>(true); 
   const currentQuestion =   gameSession?.questions[gameSession?.currentQuestionIndex ?? 0];
-  const teamId = '2d609343-de50-4830-b65e-71eb72bb9bef';
-  const [finalResultsState, setFinalResultsState] = useState( // eslint-disable-line @typescript-eslint/no-unused-vars
-  FinalResultsState.LEADERBOARD
-);
   const leader = true;
-  const [answerChoices, setAnswerChoices] = useState<{id: string, text: string, isCorrectAnswer: boolean, reason: string}[]>(currentQuestion?.choices!.map((choice: IChoice) => ({
+  const answerChoices = currentQuestion?.choices!.map((choice: IChoice) => ({
     id: uuidv4(),
     text: choice.text,
     isCorrectAnswer: choice.isAnswer,
     reason: choice.reason ?? '',
-  })));
-
+  }));
+  
   const handlePregameTimerFinished = () => {
     setIsPregameCountdown(false);
   };
@@ -49,16 +48,20 @@ export default function GameInProgressContainer({gameSession, currentState, team
         {...gameSession}
         teamAvatar={teamAvatar}
         answerChoices={answerChoices}
-        teamId="2d609343-de50-4830-b65e-71eb72bb9bef"
+        teamId={teamId}
+        addTeamAnswerToTeamMember={addTeamAnswerToTeamMember}
       />
     );
   case GameSessionState.CHOOSE_TRICKIEST_ANSWER:
+  case GameSessionState.PHASE_1_DISCUSS:
+  case GameSessionState.PHASE_2_DISCUSS:
     return (
       <GameInProgress
         {...gameSession}
         teamAvatar={teamAvatar}
         answerChoices={answerChoices}
-        teamId="2d609343-de50-4830-b65e-71eb72bb9bef"
+        teamId={teamId}
+        addTeamAnswerToTeamMember={addTeamAnswerToTeamMember}
       />
     );
   case GameSessionState.PHASE_1_RESULTS:
@@ -68,7 +71,6 @@ export default function GameInProgressContainer({gameSession, currentState, team
         {...gameSession}
         gameSession={gameSession}
         currentQuestionIndex={gameSession!.currentQuestionIndex ?? 0}
-        currentState={gameSession!.currentState}
         teamAvatar={teamAvatar}
         teamId={teamId}
         answerChoices={answerChoices}
@@ -86,7 +88,6 @@ export default function GameInProgressContainer({gameSession, currentState, team
         selectedAvatar={teamAvatar}
         teamId={teamId}
         leader={leader}
-        finalResultsState={finalResultsState}
       />
     );
   }

--- a/play/src/pages/FinalResults.tsx
+++ b/play/src/pages/FinalResults.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { ITeam, GameSessionState } from '@righton/networking';
@@ -13,7 +13,6 @@ interface FinalResultsProps {
   selectedAvatar: number;
   teamId: string;
   leader: boolean;
-  finalResultsState: FinalResultsState;
 }
 
 export default function FinalResults({
@@ -23,10 +22,12 @@ export default function FinalResults({
   selectedAvatar,
   teamId,
   leader,
-  finalResultsState,
 }: FinalResultsProps) {
   const theme = useTheme();
   const isSmallDevice = useMediaQuery(theme.breakpoints.down('sm'));
+  const [finalResultsState, setFinalResultsState] = useState( // eslint-disable-line @typescript-eslint/no-unused-vars
+  FinalResultsState.CONGRATS
+);
 
   switch (finalResultsState) {
     case FinalResultsState.LEADERBOARD:
@@ -48,6 +49,7 @@ export default function FinalResults({
           isSmallDevice={isSmallDevice}
           selectedAvatar={selectedAvatar}
           leader={leader}
+          setFinalResultsState={() => setFinalResultsState(FinalResultsState.LEADERBOARD)}
         />
       );
   }

--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -32,6 +32,7 @@ interface GameInProgressProps {
     isCorrectAnswer: boolean;
     reason: string;
   }[];
+  addTeamAnswerToTeamMember: (question: IQuestion, answerText: string, currentState: GameSessionState) => void;
 }
 
 export default function GameInProgress({
@@ -42,6 +43,7 @@ export default function GameInProgress({
   currentQuestionIndex,
   teamId,
   answerChoices,
+  addTeamAnswerToTeamMember,
 }: GameInProgressProps) {
   const theme = useTheme();
   const isSmallDevice = useMediaQuery(theme.breakpoints.down('sm'));
@@ -86,7 +88,8 @@ export default function GameInProgress({
     setTimerIsPaused(true);
   };
 
-  const handleSubmitAnswer = () => {
+  const handleSubmitAnswer = (answerText: string) => {
+    addTeamAnswerToTeamMember(currentQuestion, answerText, currentState);
     setIsSubmitted(true);
   };
 


### PR DESCRIPTION
**Update:**
There are a few PRs outstanding that are nested in the below structure (with PR608 as the base):
[[Play] - Join_Game Functionality Flow #608](https://github.com/rightoneducation/righton-app/pull/608)
-> [[Play] - GameInProgress and Final Results Functionality Flow #613](https://github.com/rightoneducation/righton-app/pull/613)
->-> [[Play] - Internationalisation via react-i18next for JoinGame Flow #610](https://github.com/rightoneducation/righton-app/pull/610)
->->-> [[Play] - Internationalisation for GameInProgress and FinalResults #611](https://github.com/rightoneducation/righton-app/pull/611)

**Description:**
This PR extends from [[Play] - Join_Game Functionality Flow #608](https://github.com/rightoneducation/righton-app/pull/608) and adds functionality for routing and team answering through to the end of `GameSessionState.FINISHED.`

Specifically it adds: 

- routing for `GameInProgress` and `FinalResults` phases
- `addTeamAnswerToTeamMember` API call to update gameSession object with players' answers.
