### PR TITLE
[Host] - Prevent 3-2-1 timer showing on every question

### DIFF
--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -20,7 +20,7 @@ const GameSessionContainer = () => {
   const [gameSession, setGameSession] = useState<IGameSession | null>();
   const [teamsArray, setTeamsArray] = useState([{}]);
   const [isTimerActive, setIsTimerActive] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
   const apiClient = new ApiClient(Environment.Staging);
   const [headerGameCurrentTime, setHeaderGameCurrentTime] = React.useState(localStorage.getItem('currentGameTimeStore'));
   const [gameTimer, setGameTimer] = useState(false);
@@ -108,13 +108,13 @@ const GameSessionContainer = () => {
 
   // stops scrolling on the startgame modal
   useEffect(() => {
-    if (isModalOpen) {
+    if (isLoadModalOpen) {
       document.body.style.overflow = 'hidden';
     }
     else {
       document.body.style.overflow = 'unset';
     }
-  }, [isModalOpen]);
+  }, [isLoadModalOpen]);
 
 
   // headerGame timer, 1 second interval, update localstorage in case page resets
@@ -194,7 +194,7 @@ const GameSessionContainer = () => {
             .catch(reason => console.log(reason));
         });
       setIsTimerActive(true);
-      setIsModalOpen(true);
+      setIsLoadModalOpen(true);
     }
   };
 
@@ -210,7 +210,7 @@ const GameSessionContainer = () => {
     case GameSessionState.PHASE_1_DISCUSS:
     case GameSessionState.CHOOSE_TRICKIEST_ANSWER:
     case GameSessionState.PHASE_2_DISCUSS:
-      return <GameInProgress {...gameSession} teamsArray={teamsArray} handleUpdateGameSession={handleUpdateGameSession} headerGameCurrentTime={headerGameCurrentTime} gameTimer={gameTimer} gameTimerZero={gameTimerZero} isLoadModalOpen={isModalOpen} />;
+      return <GameInProgress {...gameSession} teamsArray={teamsArray} handleUpdateGameSession={handleUpdateGameSession} headerGameCurrentTime={headerGameCurrentTime} gameTimer={gameTimer} gameTimerZero={gameTimerZero} isLoadModalOpen={isLoadModalOpen} setIsLoadModalOpen={setIsLoadModalOpen}/>;
 
     case GameSessionState.PHASE_1_RESULTS:
     case GameSessionState.PHASE_2_START:

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -22,7 +22,8 @@ export default function GameInProgress({
   headerGameCurrentTime,
   gameTimer,
   gameTimerZero,
-  isLoadModalOpen
+  isLoadModalOpen,
+  setIsLoadModalOpen,
 }) {
 
   const classes = useStyles();
@@ -31,7 +32,6 @@ export default function GameInProgress({
   let answerArray;
   let totalAnswers;
   let [modalOpen, setModalOpen] = useState(false);
-  let [loadModalOpen, setLoadModalOpen] = useState(isLoadModalOpen)
   const footerButtonTextDictionary = { //dictionary used to assign button text based on the next state 
 
     //0-not started
@@ -75,7 +75,7 @@ export default function GameInProgress({
 
   // handles the countdown modal closing once the countdown is finished
   const handleStartGameModalTimerFinished = () => {
-    setLoadModalOpen(false);
+    setIsLoadModalOpen(false);
   };
 
 
@@ -159,7 +159,7 @@ export default function GameInProgress({
 
   return (
     <div className={classes.background}>
-      <GameLoadModal handleStartGameModalTimerFinished={handleStartGameModalTimerFinished} modalOpen={loadModalOpen} />
+      <GameLoadModal handleStartGameModalTimerFinished={handleStartGameModalTimerFinished} modalOpen={isLoadModalOpen} />
       <div
         style={{
           backgroundImage: `url(${CheckMark})`,


### PR DESCRIPTION
**Issue:**
3-2-1 timer is showing on the start of every question, rather than just when the player enters the game.


**Resolution:**
Hoisting `isModalOpen` to the `GameSessionContainer` allows for the resetting of the state and the passing of the updated value down to the correct switch. It needs to be at this level in the tree because this is where it is initially set by `handleStartGame`.

Relevant code:
- `isModalOpen` in `GameSessionContainer` - `state` value that controls visibility of 3-2-1 timer modal

**Preview:**

https://github.com/rightoneducation/righton-app/assets/79417944/aee477b1-a483-4df4-a804-abff6b7dac58

