### PR TITLE
[Play] - Rework of Question Text Processing

### DIFF
--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -63,23 +63,33 @@ export default function GameInProgress({
     );
   }
 
-  // this breaks down the question text from the gameSession to isolate the sentence with the question mark for formatting purposes in the component
+  // this breaks down the question text from the gameSession for bold formatting of the question text
+  // first, it looks for the last question mark and cuts the question from the proceeding period to the end of the string
+  // second, if there isn't a question mark, it looks for the last period and cuts the question from the proceeding period to the end of the string
+  // if neither of those, it just uses the default entire string as the question text
   const divideQuestionString = (inputText: string) => {
     const qmarkLocation = inputText.lastIndexOf('?');
+    const lastPeriodLocation = inputText.lastIndexOf('.');
     let introText = '';
-    let questionText = '';
-
+    let questionText = inputText;
     if (qmarkLocation !== -1) {
-      const periodLocation = inputText.lastIndexOf('.');
-      if (periodLocation !== -1 && periodLocation < qmarkLocation) {
+      const splicedString = inputText.substring(0, qmarkLocation + 1);
+      const periodLocation = splicedString.lastIndexOf('.');
+      questionText = splicedString;
+      if (periodLocation !== -1) {
         introText = inputText.substring(0, periodLocation + 1);
-        questionText = inputText.substring(
-          periodLocation + 1,
-          qmarkLocation + 1
-        );
+        questionText = inputText.substring(periodLocation + 1, inputText.length);
       }
     } else {
-      questionText = inputText;
+      const splicedString = inputText.substring(0, lastPeriodLocation);
+      const secondLastPeriodLocation = splicedString.lastIndexOf('.');
+      if (secondLastPeriodLocation !== -1) {
+        introText = inputText.substring(0, secondLastPeriodLocation + 1);
+        questionText = inputText.substring(
+          secondLastPeriodLocation + 1,
+          inputText.length
+        );
+      }
     }
     return [introText, questionText];
   };


### PR DESCRIPTION
**Issue:**

Per [Issue 625](https://github.com/rightoneducation/righton-app/issues/625), some questions aren't displaying on the `play` app. This is due to the way that we're breaking down the inputted question text (that comes into the backend as a single string) to provide the bold text face on `play` that is specified in the Figma. For example:

![image](https://github.com/rightoneducation/righton-app/assets/79417944/38ec55d0-a943-4350-a475-b54812cc8a2b)

Inputted text would be all in one block so we are breaking this string down to be able to bold just the question.


**Resolution:**
The question text breakdown as been resolved to handle the following types of input: 

1. Single line with/without question marks:
> Examples:
> Simplify the expression y=(2x+3) ^2 + (4x+3)^2
> The tallest skyscraper in the world is located in which country?
>
> Result: entire line bolded

2. Multiline question with question mark:
> Example:
> A pair of jeans were 20% off last week. This week, there’s an additional sale, and you can get an extra 50% off the already discounted price from last week. What is the total percentage discount that you’d get if you buy the jeans this week?
>
> Result: Only "What is the total percentage discount that you’d get if you buy the jeans this week?" is bolded.

3. Multiline question with question mark and trailing text: 
> Example:
> A pizza’s size is determined by its diameter. For example, a 16-inch pizza has a 16-inch diameter and a 8-inch pizza has a 8-inch diameter. Jeremiah and Rohit go to a pizza place together. Jeremiah orders two 8-inch pizzas and Rohit orders a 16-inch pizza. What is the difference, in square inches, between the area of Rohit’s pizza and the combined area of Jeremiah’s pizzas? Round your answer to the nearest whole number.
>
> Result: "What is the difference, in square inches, between the area of Rohit’s pizza and the combined area of Jeremiah’s pizzas? Round your answer to the nearest whole number." is bolded

4. All other cases will bold the entire inputted string (as it becomes too difficult to try and guess what the question becomes). 

**Relevant code:**
- `divideQuestionString` in `GameInProgress.tsx` - function that breaks up the string per above and returns the regular and bolded strings in an array.

**Preview:**
<img width="398" alt="Screenshot 2023-06-06 at 11 51 21 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/2d39e3c3-4883-4144-81f5-6376d92cc631">
<img width="401" alt="Screenshot 2023-06-06 at 11 50 36 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/72611ca3-5527-47e3-bbbf-66c8759517dc">
<img width="399" alt="Screenshot 2023-06-06 at 11 49 32 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/8c133a91-7720-446d-83a7-1a49d15c1344">

