### PR TITLE
[Play] - Nice try/Correct Text on Discuss Answers

### DIFF
--- a/play/public/locales/en/translation.json
+++ b/play/public/locales/en/translation.json
@@ -69,9 +69,9 @@
     "discussanswer": {
       "questionanswercolumn": "Question and Correct Answer",
       "incorrectanswercolumn": "Incorrect Answers",
-      "correcttext": "Yes, ",
-      "nicetrytext": "Nice try, ",
-      "correctanswertext": "the correct answer is..."
+      "correcttext": "Correct!",
+      "nicetrytext": "Nice try",
+      "correctanswertext": "The answer is..."
     },
     "startphase2": {
       "title": "Starting Phase 2...",

--- a/play/public/locales/es/translation.json
+++ b/play/public/locales/es/translation.json
@@ -69,9 +69,9 @@
     "discussanswer": {
       "questionanswercolumn": "Pregunta y Respuesta Correcta",
       "incorrectanswercolumn": "Respuestas Incorrectas",
-      "correcttext": "Sí, ",
-      "nicetrytext": "Buen intento, ",
-      "correctanswertext": "la respuesta correcta es..."
+      "correcttext": "Correcta!",
+      "nicetrytext": "Buen intento",
+      "correctanswertext": "La respuesta es..."
     },
     "startphase2": {
       "title": "Empezando la Fase 2...",

--- a/play/src/components/DiscussAnswerCard.tsx
+++ b/play/src/components/DiscussAnswerCard.tsx
@@ -40,22 +40,14 @@ export default function DiscussAnswerCard({
     <BodyCardStyled elevation={5}>
       <BodyCardContainerStyled sx={{ alignItems: 'flex-start' }}>
         {correctCard && currentState === GameSessionState.PHASE_1_DISCUSS && (
-          <Box
-            display="inline"
-            sx={{ paddingBottom: `${theme.sizing.extraSmallPadding}px` }}
-          >
+          <Box sx={{ paddingBottom: `${theme.sizing.extraSmallPadding}px` }}>
             <Typography
-              variant="body1"
-              display="inline"
-              sx={{
-                fontWeight: 700,
-                left: 0,
-                paddingLeft: `${theme.sizing.extraSmallPadding}px`,
-              }}
+              variant="subtitle1" 
+              sx={{ paddingBottom: `${theme.sizing.extraSmallPadding}px` }}
             >
               {resultText}
-            </Typography>
-            <Typography variant="body1" display="inline">
+            </Typography >
+            <Typography variant="body1">
               {t('gameinprogress.discussanswer.correctanswertext')}
             </Typography>
           </Box>

--- a/play/src/lib/Theme.tsx
+++ b/play/src/lib/Theme.tsx
@@ -12,9 +12,9 @@ const radialGradient =
 const highlightGradient = 'linear-gradient(90deg, #159EFA 0%, #19BCFB 100%)'; // button and score indicator
 const altHighlightGradient =
   'linear-gradient(190deg, #7BDD61 0%, #22B851 100%)'; // new points score indicator
-const secondaryColor = '#8E2E9D'; // eslint-disable-line @typescript-eslint/no-unused-vars
 const primaryTextColor = '#FFFFFF'; // main text (headers, titles)
 const secondaryTextColor = '#384466'; // secondary text (question text, answer text)
+const darkestTextColor = '#000000'; // darkest color for text(ex black)
 const playerNameTextColor = '#AEAEAE'; // player name
 const darkPurpleColor = '#4700B2'; // phase results, selected answer
 const greenColor = '#22AE48'; // answer card title highlight (correct answer phase)
@@ -183,6 +183,13 @@ export default createTheme({
       fontSize: '35px',
       lineHeight: '48px',
       color: primaryTextColor,
+    },
+    subtitle1: {
+    // correct/nice try discuss answer text
+    fontWeight: '800',
+    fontSize: '24px',
+    lineHeight: '38px',
+    color: darkestTextColor,
     },
     body1: {
       // question text


### PR DESCRIPTION
**Issue:**
Per this [Issue](https://github.com/rightoneducation/righton-app/issues/620), it was decided to provide large, more prominent text for the 'Nice Try'/'Correct!' text on Discuss Answer.

**Resolution:**
The styling of the text has been adjusted.

Relevant code:
- `DiscussAnswerCard.tsx` - styling for text

**Preview:**

https://github.com/rightoneducation/righton-app/assets/79417944/83934576-19d7-4ef8-a33e-0da4accf3cf0


