### PR TITLE
[Play] - Revisions from U/X Comments (Splash Screen)

### DIFF
--- a/play/src/lib/Theme.tsx
+++ b/play/src/lib/Theme.tsx
@@ -41,6 +41,7 @@ const smallPadding = 16; // upper and lower margins on text, spacing of content 
 const mediumPadding = 24; // timer margin
 const largePadding = 32; // text spacing on answer selector, top margin on titles
 const extraLargePadding = 48; // spacing between card and edge of screen
+const extraExtraLargePadding = 64; // spacing between buttons and bottom of screen
 
 // adds mainGradient field to the palette theme
 declare module '@mui/material/styles' {
@@ -53,6 +54,7 @@ declare module '@mui/material/styles' {
       mediumPadding: number;
       largePadding: number;
       extraLargePadding: number;
+      extraExtraLargePadding: number;
     };
   }
 
@@ -65,6 +67,7 @@ declare module '@mui/material/styles' {
       mediumPadding?: number;
       largePadding?: number;
       extraLargePadding?: number;
+      extraExtraLargePadding?: number;
     };
   }
 
@@ -118,6 +121,7 @@ export default createTheme({
     mediumPadding,
     largePadding,
     extraLargePadding,
+    extraExtraLargePadding
   },
   palette: {
     primary: {

--- a/play/src/pages/pregame/SplashScreen.tsx
+++ b/play/src/pages/pregame/SplashScreen.tsx
@@ -29,7 +29,7 @@ const StackContainer = styled(Stack)(({ theme }) => ({
 }));
 
 const BottomBox = styled(Box)(({ theme }) => ({
-  paddingBottom: `${theme.sizing.mediumPadding}px`,
+  paddingBottom: `${theme.sizing.extraExtraLargePadding}px`,
 }));
 
 interface SplashScreenProps {


### PR DESCRIPTION
**Issue:**
This PR revises comments from this [Issue](https://github.com/rightoneducation/righton-app/issues/629). U/X has the following comments: 

1. Increase spacing between Join Game button and bottom of screen


**Resolution:**
The spacing has been increased per Figma (64 px) 

Relevant code:
- `extraExtraLargePadding` in `Theme.lib` - additional padding value added to theme with 64px value

**Preview:**
![image](https://github.com/rightoneducation/righton-app/assets/79417944/280a7455-4223-44d8-b3b5-80bae4aea0f6)
![image](https://github.com/rightoneducation/righton-app/assets/79417944/43f67b21-0db2-4475-8683-231f0d19e928)
