### PR TITLE
[Play] - Revisions from U/X Comments (Discuss Answers)

### DIFF
--- a/play/src/components/AnswerCard.tsx
+++ b/play/src/components/AnswerCard.tsx
@@ -73,7 +73,7 @@ export default function AnswerCard({
   };
 
   return (
-    <BodyCardStyled elevation={5}>
+    <BodyCardStyled elevation={10}>
       <BodyCardContainerStyled spacing={2}>
         {currentState === GameSessionState.CHOOSE_CORRECT_ANSWER
           ? correctText

--- a/play/src/components/DiscussAnswerCard.tsx
+++ b/play/src/components/DiscussAnswerCard.tsx
@@ -37,7 +37,7 @@ export default function DiscussAnswerCard({
     answerStatus === AnswerState.CORRECT ||
     answerStatus === AnswerState.PLAYER_SELECTED_CORRECT;
   return (
-    <BodyCardStyled elevation={5}>
+    <BodyCardStyled elevation={10}>
       <BodyCardContainerStyled sx={{ alignItems: 'flex-start' }}>
         {correctCard && currentState === GameSessionState.PHASE_1_DISCUSS && (
           <Box sx={{ paddingBottom: `${theme.sizing.extraSmallPadding}px` }}>

--- a/play/src/components/QuestionCard.tsx
+++ b/play/src/components/QuestionCard.tsx
@@ -15,7 +15,7 @@ export default function QuestionCard({
 }: QuestionCardProps) {
   const theme = useTheme();
   return (
-    <BodyCardStyled elevation={5}>
+    <BodyCardStyled elevation={10}>
       <BodyCardContainerStyled>
         <img
           style={{

--- a/play/src/components/ResultsCard.tsx
+++ b/play/src/components/ResultsCard.tsx
@@ -38,7 +38,7 @@ export default function CardResults({
 
   return (
     <BodyCardStyled
-      elevation={5}
+      elevation={10}
       sx={{ boxSizing: 'border-box', width: '100%' }}
     >
       <BodyCardContainerStyled spacing={2}>

--- a/play/src/lib/styledcomponents/BodyCardStyled.tsx
+++ b/play/src/lib/styledcomponents/BodyCardStyled.tsx
@@ -9,4 +9,5 @@ export default styled(Paper)(({ theme }) => ({
   borderRadius: '24px',
   padding: `${theme.sizing.smallPadding}px`,
   backgroundColor: theme.palette.primary.main,
+  boxShadow:  '0px 8px 16px -4px rgba(92, 118, 145, 0.4)'
 }));

--- a/play/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
+++ b/play/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
@@ -7,7 +7,7 @@ import { Box } from '@mui/material';
  */
 export default styled(Box)(({ theme }) => ({
   height: `calc(100% - ${theme.sizing.footerHeight}px - ${theme.sizing.extraSmallPadding}px - 30px)`, // footer height & 8px grid spacing
-  paddingBottom: `${theme.sizing.extraSmallPadding}px`, // added so box shadow shows around edge of card
+  paddingBottom: `${theme.sizing.mediumPadding}px`, // added so box shadow shows around edge of card
   paddingLeft: `${theme.sizing.smallPadding}px`,
   paddingRight: `${theme.sizing.smallPadding}px`,
   overflow: 'auto',


### PR DESCRIPTION
**Issue:**
This PR revises comments from this [Issue](https://github.com/rightoneducation/righton-app/issues/639). U/X has the following comments: 

1. Adjust the softness of the drop shadow on the cards.

**Resolution:**
The cards box shadow have been adjusted to match the Figma. This has been done throughout the app. 

Relevant code:
- ` boxShadow:  '0px 8px 16px -4px rgba(92, 118, 145, 0.4)'` in `BodyCardStyled.tsx`

**Preview:**
![image](https://github.com/rightoneducation/righton-app/assets/79417944/44985a1c-26f0-4dfa-b018-ef364fcd21cf)
![image](https://github.com/rightoneducation/righton-app/assets/79417944/18268d30-8471-46c6-a65e-6ff125962b60)

