### PR TITLE
[Play] - Revisions from U/X Comments (Phase 2 Choose Answer)

### DIFF
--- a/play/public/locales/en/translation.json
+++ b/play/public/locales/en/translation.json
@@ -53,7 +53,7 @@
       "incorrect": "Nice Try!"
     },
     "general": {
-      "swipealert": "Swipe to the left to answer the question."
+      "swipealert": "Swipe left to answer the question."
     },
     "chooseanswer": {
       "questioncolumn": "Question",

--- a/play/public/locales/en/translation.json
+++ b/play/public/locales/en/translation.json
@@ -63,7 +63,7 @@
       "correcttext1": "Choose the",
       "correcttext2": "correct answer",
       "incorrecttext1": "What do you think the most popular",
-      "incorrecttext2": "trick answer",
+      "incorrecttext2": "incorrect answer",
       "incorrecttext3": "is among your class?"
     },
     "discussanswer": {

--- a/play/public/locales/es/translation.json
+++ b/play/public/locales/es/translation.json
@@ -53,7 +53,7 @@
       "incorrect": "¡Buen Intento!"
     },
     "general": {
-      "swipealert": "Desliza hacia la izquierda para responder la pregunta."
+      "swipealert": "Desliza el dedo hacia la izquierda para responder a la pregunta."
     },
     "chooseanswer": {
       "questioncolumn": "Pregunta",

--- a/play/public/locales/es/translation.json
+++ b/play/public/locales/es/translation.json
@@ -63,7 +63,7 @@
       "correcttext1": "Elegir el",
       "correcttext2": "respuesta correcta",
       "incorrecttext1": "¿Cuál crees que es la",
-      "incorrecttext2": "respuesta engañosa",
+      "incorrecttext2": "respuesta incorrecta",
       "incorrecttext3": "más popular entre tu clase?"
     },
     "discussanswer": {


### PR DESCRIPTION
**Issue:**
This PR revises comments from this [Issue](https://github.com/rightoneducation/righton-app/issues/638). U/X has the following comments: 

1. Adjust text from "trick answer" to "incorrect answer"
2. Adjust text from "Swipe to the left to answer the question" to "Swipe left to answer the question"

**Resolution:**
Text value in translation dictionaries updated.

Relevant code:
- `incorrectText2` in `translation.json` 
- `swipealert` in `translation.json`

**Preview:**
![image](https://github.com/rightoneducation/righton-app/assets/79417944/1d978a01-60a9-4109-9786-7c3d1f744ed9)
![image](https://github.com/rightoneducation/righton-app/assets/79417944/6d3d2864-939d-4761-b0e3-09485c51c67e)

