### PR TITLE
[Play] - Revisions from U/X Comments (FinalResults)

### DIFF
--- a/play/src/pages/finalresults/Congrats.tsx
+++ b/play/src/pages/finalresults/Congrats.tsx
@@ -67,7 +67,10 @@ export default function Congrats({
     <BackgroundContainerStyled>
       <StackContainer spacing={3}>
         <Box style={{ zIndex: 1 }}>
-          <Typography variant="h1" sx={{ textAlign: 'center' }}>
+          <Typography variant="h1" sx={{ 
+            textAlign: 'center',
+            paddingTop: `${theme.sizing.largePadding}px`,
+          }}>
             {t('finalresults.congrats.title')}
           </Typography>
           <Typography


### PR DESCRIPTION
**Issue:**
This PR revises comments from this [Issue](https://github.com/rightoneducation/righton-app/issues/640). U/X has the following comments: 

1. Increase padding from top of screen to title text

**Resolution:**
Padding value added

Relevant code:
- `paddingTop: `${theme.sizing.largePadding}px`,` to `Congrats.tsx`

**Preview:**
<img width="1670" alt="Screenshot 2023-06-07 at 10 42 07 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/05158120-f236-40ca-bea6-5bd8647b459b">
<img width="367" alt="Screenshot 2023-06-07 at 10 41 54 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/16aa634e-19ea-49a8-9771-fc1b270db0da">



