### PR TITLE
[Play] - Revisions from U/X Comments (Select Avatar)

### DIFF
--- a/play/src/pages/pregame/SelectAvatar.tsx
+++ b/play/src/pages/pregame/SelectAvatar.tsx
@@ -22,7 +22,7 @@ const GridContainer = styled('div')(({ theme }) => ({
   // using CSS Grid here because mui Grid responsiveness produces changes in spacing when crossing breakpoints
   display: 'grid',
   gridTemplateColumns: 'repeat(3, 1fr)',
-  spacing: `${theme.sizing.mediumPadding}px`,
+  gridGap: `${theme.sizing. extraSmallPadding}px`,
 }));
 
 const AvatarIconContainer = styled(Box)({
@@ -35,13 +35,13 @@ const AvatarIconContainer = styled(Box)({
   borderRadius: '20px',
 });
 
-interface MonsterContainerProps {
+interface ContainerProps {
   isSmallDevice: boolean;
 }
 
 const MonsterContainer = styled(Box, {
   shouldForwardProp: (prop) => prop !== 'isSmallDevice',
-})<MonsterContainerProps>(({ isSmallDevice, theme }) => ({
+})<ContainerProps>(({ isSmallDevice, theme }) => ({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'flex-end',
@@ -70,11 +70,13 @@ const Monster = styled('img')({
   },
 });
 
-const BottomContainer = styled(Box)(({ theme }) => ({
+const BottomContainer = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isSmallDevice',
+})<ContainerProps>(({ isSmallDevice, theme }) => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  paddingBottom: `${theme.sizing.largePadding}px`,
+  paddingBottom: isSmallDevice ? `${theme.sizing.extraExtraLargePadding}px`: `${theme.sizing.largePadding}px`,
   gap: 12,
 }));
 
@@ -132,7 +134,7 @@ export default function SelectAvatar({
             alt="monster"
           />
         </MonsterContainer>
-        <BottomContainer>
+        <BottomContainer isSmallDevice={isSmallDevice}>
           <Typography variant="h2" sx={{ textAlign: 'center' }}>
             {`${firstName} ${lastName}`}
           </Typography>


### PR DESCRIPTION
**Issue:**
This PR revises comments from this [Issue](https://github.com/rightoneducation/righton-app/issues/632). U/X has the following comments: 

1. Adjust spacing between avatars (size verified to match Figma)
2. Adjust padding from bottom of screen to button.

**Resolution:**
`spacing` changed to `gridGap` on `GridContainer`. `paddingBottom` added based on `isSmallDevice`

Relevant code:
-  `gridGap: ${theme.sizing. extraSmallPadding}px` in `SlectedAvatar.tsx`
- `paddingBottom: isSmallDevice ? ${theme.sizing.extraExtraLargePadding}px: ${theme.sizing.largePadding}px,` in `SelectedAvatar.tsx` 

**Preview:**
<img width="1671" alt="Screenshot 2023-06-07 at 11 08 00 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/0ccc4c13-6aa0-449b-9c26-71b99bcd7e30">
<img width="369" alt="Screenshot 2023-06-07 at 11 07 23 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/4c0a5aa0-9d9b-404b-bd5f-763b0dae1cd4">

