### PR TITLE
[Play] - Revisions from U/X Comments (Choose Answer)

### DIFF
--- a/play/src/components/AnswerSelector.tsx
+++ b/play/src/components/AnswerSelector.tsx
@@ -69,7 +69,6 @@ export default function AnswerSelector({
     [AnswerState.PREVIOUS]: SelectedAnswer,
     [AnswerState.PLAYER_SELECTED_CORRECT]: PlayerCorrectImage,
   };
-
   const buttonContents = (
     <>
       <Typography
@@ -95,19 +94,21 @@ export default function AnswerSelector({
       >
         {answerText}
       </Typography>
-      <img
-        src={imageMap[answerStatus]}
-        style={{
-          position: 'absolute',
-          right: isSubmitted ? `17px` : `16px`,
-          width: `16px`,
-          height: `16px`,
-          paddingTop: '2px',
-          opacity:
-            isSubmitted && answerStatus === AnswerState.SELECTED ? 0.5 : 1,
-        }}
-        alt="SelectedAnswerImage"
-      />
+      {!isSubmitted || answerStatus !== AnswerState.DEFAULT &&
+        <img
+          src={imageMap[answerStatus]}
+          style={{
+            position: 'absolute',
+            right: isSubmitted ? `17px` : `16px`,
+            width: `16px`,
+            height: `16px`,
+            paddingTop: '2px',
+            opacity:
+              isSubmitted && answerStatus === AnswerState.SELECTED ? 0.5 : 1,
+          }}
+          alt="SelectedAnswerImage"
+        />
+      }
     </>
   );
 

--- a/play/src/components/ButtonSubmitAnswer.tsx
+++ b/play/src/components/ButtonSubmitAnswer.tsx
@@ -26,7 +26,7 @@ export default function ButtonSubmitAnswer({
     ? t('gameinprogress.button.submitted')
     : t('gameinprogress.button.submit');
   const buttonContents = (
-    <Typography variant="button"> {buttonText} </Typography>
+    <Typography sx={{textTransform: 'none'}} variant="button"> {buttonText} </Typography>
   );
 
   return isSelected && !isSubmitted ? (
@@ -40,8 +40,7 @@ export default function ButtonSubmitAnswer({
     </GamePlayButtonStyled>
   ) : (
     <GamePlayButtonStyledDisabled disabled>
-      {' '}
-      {buttonContents}{' '}
+      {buttonContents}
     </GamePlayButtonStyledDisabled>
   );
 }


### PR DESCRIPTION
**Issue:**
This PR revises comments from this [Issue](https://github.com/rightoneducation/righton-app/issues/634). U/X has the following comments: 

1. Fix casing on submit answer button
2. don't show empty circles on answer selector

**Resolution:**
Conditional added to img. `textTransform` set to `none` on child `Typography` element. 

Relevant code:
-  ` {!isSubmitted || answerStatus !== AnswerState.DEFAULT &&` in `AnswerSelector.tsx`
- `sx={{textTransform: 'none'}` in `ButtonSubmitAnswer.tsx` 

**Preview:**
<img width="1636" alt="Screenshot 2023-06-07 at 11 35 56 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/b4595384-7cc7-4596-8258-d4a0dbeb385b">
<img width="371" alt="Screenshot 2023-06-07 at 11 35 32 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/4065982a-e256-4267-9dbd-b1961a84235a">


