### PR TITLE
[Play] - Timer value is hardcoded on GameInProgress

### DIFF
--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -23,6 +23,8 @@ interface GameInProgressProps {
   teams?: ITeam[];
   currentState: GameSessionState;
   teamAvatar: number;
+  phaseOneTime: number;
+  phaseTwoTime: number;
   questions: IQuestion[];
   currentQuestionIndex?: number | null;
   teamId: string;
@@ -40,11 +42,14 @@ interface GameInProgressProps {
   ) => void;
 }
 
+
 export default function GameInProgress({
   teams,
   currentState,
   teamAvatar,
   questions,
+  phaseOneTime,
+  phaseTwoTime,
   currentQuestionIndex,
   teamId,
   score,
@@ -126,7 +131,7 @@ export default function GameInProgress({
           currentState={currentState}
           isCorrect={false}
           isIncorrect={false}
-          totalTime={15}
+          totalTime={currentState === GameSessionState.CHOOSE_CORRECT_ANSWER ? phaseOneTime : phaseTwoTime}
           isPaused={false}
           isFinished={false}
           handleTimerIsFinished={handleTimerIsFinished}
@@ -136,7 +141,7 @@ export default function GameInProgress({
         <BodyBoxUpperStyled />
         <BodyBoxLowerStyled />
         {currentState === GameSessionState.CHOOSE_CORRECT_ANSWER ||
-        currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER ? (
+          currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER ? (
           <ChooseAnswer
             isSmallDevice={isSmallDevice}
             questionText={questionText}


### PR DESCRIPTION
**Issue:**
This PR addresses git issue [#651](https://github.com/rightoneducation/righton-app/issues/651). 
In short: timer on play is hardcoded 

**Resolution:**
Now, timer data is being passed in from the backend

Relevant code:
In the file `GameInProgress.tsx`:
- `phaseOneTime` and `phaseTwoTime` are being passed into `interface GameInProgressProps` on `lines 26-27`
- `phaseOneTime` and `phaseTwoTime` are being passed into `function GameInProgress` as arguments on `lines 51-52` and again in the component `HeaderContent` accordingly: `totalTime={currentState === GameSessionState.CHOOSE_CORRECT_ANSWER ? phaseOneTime : phaseTwoTime}` on `line 134`, depending on the current phase of gameplay 


**Preview:**
Here is an image capturing the now dynamic timer of play which matches that of host:
<img width="1680" alt="Screenshot 2023-06-08 at 2 34 27 PM" src="https://github.com/rightoneducation/righton-app/assets/106450593/83872979-5136-4215-8266-e64fa755bc3e">

Here is a video of multiple phases of gameplay with the updated timer:

https://github.com/rightoneducation/righton-app/assets/106450593/289d7a13-36ca-4f23-90d4-e83ab0c29356




@drewjhart , @maniramezan 
