### PR TITLE
[Play] - update PWA title per U/X comments

### DIFF
--- a/play/public/manifest.json
+++ b/play/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "short_name": "Right On!",
+  "short_name": "RightOn!",
   "name": "Right On! Student Play App",
   "icons": [
     {


### PR DESCRIPTION
**Issue:**
Currently, when our app is added to the home screen on iPhones, the title is displayed as Right On!:
![image](https://github.com/rightoneducation/righton-app/assets/79417944/3150a2e1-6fe4-4fe3-b20d-4a806f6b49ac)

This should be changed to RightOn!


**Resolution:**
`manifest.json` has been updated to `RightOn!`.

Relevant code:
- `play/public/manifest.json` 

**Preview:**
<img src="https://github.com/rightoneducation/righton-app/assets/79417944/5f7c2f25-5dfb-4757-8092-ef6d53cb2028" width="350" >

<img src="https://github.com/rightoneducation/righton-app/assets/79417944/fef61e0d-6bfa-433b-86d9-a6a69940f378" width="350" >

