### PR TITLE
[Play] - Revisions from U/X Comments (Enter Game Code)

### DIFF
--- a/play/src/lib/Theme.tsx
+++ b/play/src/lib/Theme.tsx
@@ -46,6 +46,7 @@ const xl = 1536;
 // design tokens - header, footer, padding sizes (coordinate this approach with U/X team): (comments = example usage)
 const headerHeight = 68;
 const footerHeight = 60;
+const pregameMinColumnWidth = 215;
 const extraSmallPadding = 8; // small icons, text positioning
 const smallPadding = 16; // upper and lower margins on text, spacing of content in cards
 const mediumPadding = 24; // timer margin
@@ -59,6 +60,7 @@ declare module '@mui/material/styles' {
     sizing: {
       headerHeight: number;
       footerHeight: number;
+      pregameMinColumnWidth: number;
       extraSmallPadding: number;
       smallPadding: number;
       mediumPadding: number;
@@ -72,6 +74,7 @@ declare module '@mui/material/styles' {
     sizing?: {
       headerHeight?: number;
       footerHeight?: number;
+      pregameMinColumnWidth?: number;
       extraSmallPadding?: number;
       smallPadding?: number;
       mediumPadding?: number;
@@ -128,6 +131,7 @@ export default createTheme({
   sizing: {
     headerHeight,
     footerHeight,
+    pregameMinColumnWidth,
     extraSmallPadding,
     smallPadding,
     mediumPadding,

--- a/play/src/pages/pregame/EnterGameCode.tsx
+++ b/play/src/pages/pregame/EnterGameCode.tsx
@@ -49,10 +49,10 @@ export default function EnterGameCode({
 
   return (
     <BackgroundContainerStyled>
-      <StackContainer spacing={isSmallDevice ? 4 : 5}>
+      <StackContainer sx={{minWidth: `${theme.sizing.pregameMinColumnWidth}px`}} spacing={isSmallDevice ? 4 : 5}>
         <img
           style={{
-            width: '214px',
+            width: `${theme.sizing.pregameMinColumnWidth}px`,
             height: '118px',
             paddingTop: `${theme.sizing.extraLargePadding}px`,
           }}
@@ -60,7 +60,7 @@ export default function EnterGameCode({
           alt="Question"
         />
         {/* container here to trim the spacing set by parent stack between text and input, typ */}
-        <Box>
+        <Box sx={{width: '100%'}}>
           <Typography variant="h2" sx={{ weight: 700, textAlign: 'center' }}>
             {t('joingame.gamecode.title')}
           </Typography>

--- a/play/src/pages/pregame/EnterPlayerName.tsx
+++ b/play/src/pages/pregame/EnterPlayerName.tsx
@@ -56,7 +56,7 @@ export default function EnterPlayerName({
       <StackContainer spacing={isSmallDevice ? 4 : 5}>
         <img
           style={{
-            width: '214px',
+            width: `${theme.sizing.pregameMinColumnWidth}px`,
             height: '118px',
             paddingTop: `${theme.sizing.extraLargePadding}px`,
           }}

--- a/play/src/pages/pregame/SplashScreen.tsx
+++ b/play/src/pages/pregame/SplashScreen.tsx
@@ -63,7 +63,7 @@ export default function SplashScreen({
           <Stack sx={{ alignItems: 'center' }} spacing={2}>
             <img
               style={{
-                width: '214px',
+                width: `${theme.sizing.pregameMinColumnWidth}px`,
                 height: '118px',
                 paddingTop: `${theme.sizing.extraLargePadding}px`,
               }}


### PR DESCRIPTION
**Issue:**
The input text field on the Enter Game Code screen needs to be wider. 


**Resolution:**
The main stack container that hosts the entire screens width has been set with a `minWidth` property that aligns to the width per Figma:

<img width="387" alt="Screenshot 2023-06-12 at 3 25 56 PM" src="https://github.com/rightoneducation/righton-app/assets/79417944/5bcf53c3-e1c6-4b16-9e9e-b5decf2d92b2">


Relevant code:
- `Theme.tsx` - `const pregameMinColumnWidth = 215; `

**Preview:**
Original:
<img width="278" alt="Screenshot 2023-06-12 at 3 25 24 PM" src="https://github.com/rightoneducation/righton-app/assets/79417944/dc8a6b1a-7d34-47d9-8c17-c1efb62b5fbe">

Revised:
<img width="274" alt="Screenshot 2023-06-12 at 3 25 09 PM" src="https://github.com/rightoneducation/righton-app/assets/79417944/7e7db2b5-e51d-4aef-91c8-89f1fa87e874">



