### PR TITLE
[Play] - i18next error, 404 translation.json not found before hitting fallback

### DIFF
--- a/play/src/i18n.tsx
+++ b/play/src/i18n.tsx
@@ -12,13 +12,14 @@ i18n
   .use(LanguageDetector)
   .init({
     fallbackLng: 'en',
+    supportedLngs: ['en', 'es'],
     keySeparator: '.', // to support nested translations
     debug: false,
     detection: {
       // move browser detection up in the priority line for autodetecting language
       order: [
-        'querystring',
         'navigator',
+        'querystring',
         'cookie',
         'localStorage',
         'sessionStorage',


### PR DESCRIPTION
**Issue:**
The design team noticed that a 404 error was thrown when a user's browser settings didn't contain one of the languages `play` supports. 

**Resolution:**
`i18next` provides a `SupportedLngs` configuration option (https://www.i18next.com/overview/configuration-options). If a user's language is detected outside of this range, it will automatically fallback to the default without throwing the 404. 

Relevant code:
- `i18n.tsx` - `.init({
    fallbackLng: 'en',
    supportedLngs: ['en', 'es']`...

