### PR TITLE
[Play] - Prevent rejoin functionality from triggering after a set time period

### DIFF
--- a/play/src/App.tsx
+++ b/play/src/App.tsx
@@ -7,7 +7,10 @@ import {
 } from 'react-router-dom';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles'; // change to mui v5 see CSS Injection Order section of https://mui.com/material-ui/guides/interoperability/
 import { ApiClient, Environment } from '@righton/networking';
-import PregameContainer from './containers/PregameContainer';
+import {
+  PregameContainer,
+  PregameLocalModelLoader
+} from './containers/PregameContainer';
 import {
   GameInProgressContainer,
   LocalModelLoader,
@@ -23,7 +26,11 @@ const apiClient = new ApiClient(Environment.Staging);
 const router = createBrowserRouter(
   createRoutesFromElements(
     <>
-      <Route path="/" element={<PregameContainer apiClient={apiClient} />} />
+      <Route 
+        path="/" 
+        element={<PregameContainer apiClient={apiClient}/>}
+        loader={PregameLocalModelLoader} 
+      />
       <Route
         path="/game"
         element={<GameInProgressContainer apiClient={apiClient} />}

--- a/play/src/components/RejoinModal.tsx
+++ b/play/src/components/RejoinModal.tsx
@@ -5,16 +5,17 @@ import { Typography } from '@mui/material';
 import Modal from 'react-modal';
 import BodyCardContainerStyled from '../lib/styledcomponents/BodyCardContainerStyled';
 import IntroButtonStyled from '../lib/styledcomponents/IntroButtonStyled';
-import { StorageKey } from '../lib/PlayModels';
 
 interface RejoinModalProps {
   handleRejoinSession: () => void;
+  handleDontRejoinSession: () => void;
   isModalVisible: boolean;
   setIsModalVisible: (isModalVisible: boolean) => void;
 }
 
 export default function RejoinModal({
   handleRejoinSession,
+  handleDontRejoinSession,
   isModalVisible,
   setIsModalVisible,
 }: RejoinModalProps) {
@@ -69,7 +70,7 @@ export default function RejoinModal({
         </IntroButtonStyled>
         <IntroButtonStyled
           onClick={() => {
-            window.localStorage.removeItem(StorageKey);
+            handleDontRejoinSession();
             setIsModalVisible(false);
           }}
         >

--- a/play/src/containers/GameInProgressContainer.tsx
+++ b/play/src/containers/GameInProgressContainer.tsx
@@ -79,15 +79,15 @@ export function GameInProgressContainer(props: GameInProgressContainerProps) {
 }
 
 export function LocalModelLoader() {
-  let localModel = fetchLocalData();
+  const localModel = fetchLocalData();
   if (localModel) {
     if (!localModel.hasRejoined) {
-      localModel = { ...localModel, hasRejoined: true };
+      const updatedModelForNextRound = { ...localModel, hasRejoined: true };
+      window.localStorage.setItem(
+        StorageKey,
+        JSON.stringify(updatedModelForNextRound)
+      );
     }
-    window.localStorage.setItem(
-      StorageKey,
-      JSON.stringify(localModel)
-    );
     return localModel;
   }
   return redirect(`/`);

--- a/play/src/containers/GameInProgressContainer.tsx
+++ b/play/src/containers/GameInProgressContainer.tsx
@@ -4,7 +4,7 @@ import {
   isNullOrUndefined,
   GameSessionState,
 } from '@righton/networking';
-import { Navigate, useLoaderData } from 'react-router-dom';
+import { Navigate, useLoaderData, redirect } from 'react-router-dom';
 import { fetchLocalData } from '../lib/HelperFunctions';
 import useFetchAndSubscribeGameSession from '../hooks/useFetchAndSubscribeGameSession';
 import GameSessionSwitch from '../components/GameSessionSwitch';
@@ -78,14 +78,17 @@ export function GameInProgressContainer(props: GameInProgressContainerProps) {
   );
 }
 
-export function LocalModelLoader(): LocalModel {
-  const localModel = fetchLocalData();
-  if (localModel && !localModel.hasRejoined) {
-    const updatedModelForNextReload = { ...localModel, hasRejoined: true };
+export function LocalModelLoader() {
+  let localModel = fetchLocalData();
+  if (localModel) {
+    if (!localModel.hasRejoined) {
+      localModel = { ...localModel, hasRejoined: true };
+    }
     window.localStorage.setItem(
       StorageKey,
-      JSON.stringify(updatedModelForNextReload)
+      JSON.stringify(localModel)
     );
+    return localModel;
   }
-  return localModel;
+  return redirect(`/`);
 }

--- a/play/src/containers/PregameContainer.stories.tsx
+++ b/play/src/containers/PregameContainer.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { ThemeProvider } from '@mui/material/styles';
-import PregameContainer from './PregameContainer';
+import { PregameContainer } from './PregameContainer';
 import Theme from '../lib/Theme';
 
 export default {

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLoaderData } from 'react-router-dom';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { v4 as uuidv4 } from 'uuid';
@@ -20,7 +20,7 @@ interface PregameFinished {
   apiClient: ApiClient;
 }
 
-export default function Pregame({ apiClient }: PregameFinished) {
+export function PregameContainer({ apiClient }: PregameFinished) {
   const theme = useTheme();
   const navigate = useNavigate();
   const isSmallDevice = useMediaQuery(theme.breakpoints.down('sm'));
@@ -28,8 +28,8 @@ export default function Pregame({ apiClient }: PregameFinished) {
   const [pregameState, setPregameState] = useState<PregameState>(
     PregameState.SPLASH_SCREEN
   );
-  // retreive local storage data so that player can choose to rejoin game
-  const rejoinGameObject = fetchLocalData();
+  // retreive local storage data so that player can choose to rejoin game 
+  const rejoinGameObject = useLoaderData() as LocalModel;
   // state variables used to collect player information in pregame phase
   // information is loaded into local storage on select avatar screen and passed to /game
   const [gameSession, setGameSession] = useState<IGameSession | null>(null);
@@ -45,7 +45,7 @@ export default function Pregame({ apiClient }: PregameFinished) {
   // if player has opted to rejoin old game session through modal on SplashScreen, set local storage data and navigate to game
   const handleRejoinSession = () => {
     const storageObject: LocalModel = {
-      ...rejoinGameObject,
+      ...rejoinGameObject!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
       hasRejoined: true,
     };
     window.localStorage.setItem(StorageKey, JSON.stringify(storageObject));
@@ -123,6 +123,7 @@ export default function Pregame({ apiClient }: PregameFinished) {
           return;
         }
         const storageObject: LocalModel = {
+          currentTime: new Date().getTime() / 60000,
           gameSessionId: gameSession.id,
           teamId: teamInfo.teamId,
           teamMemberId: teamInfo.teamMemberId,
@@ -177,4 +178,8 @@ export default function Pregame({ apiClient }: PregameFinished) {
         />
       );
   }
+}
+
+export function PregameLocalModelLoader(): LocalModel | null {
+  return fetchLocalData();
 }

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -29,7 +29,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
     PregameState.SPLASH_SCREEN
   );
   // retreive local storage data so that player can choose to rejoin game 
-  const rejoinGameObject = useLoaderData() as LocalModel;
+  const [rejoinGameObject, setRejoinGameObject] = useState<LocalModel | null>(useLoaderData() as LocalModel);
   // state variables used to collect player information in pregame phase
   // information is loaded into local storage on select avatar screen and passed to /game
   const [gameSession, setGameSession] = useState<IGameSession | null>(null);
@@ -51,7 +51,11 @@ export function PregameContainer({ apiClient }: PregameFinished) {
     window.localStorage.setItem(StorageKey, JSON.stringify(storageObject));
     navigate(`/game`);
   };
-
+  // if player doesn't want to rejoin, remove the localStorage and set rejoinGameObject to null
+  const handleDontRejoinSession = () => {
+    window.localStorage.removeItem(StorageKey);
+    setRejoinGameObject(null);
+  }
   // on click of game code button, check if game code is valid
   // if game code is invalid, return false to display error
   // if game code is valid, store gameSessionId for future subscription and advance to ENTER_NAME state
@@ -175,6 +179,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
           rejoinGameObject={rejoinGameObject}
           setPregameState={setPregameState}
           handleRejoinSession={handleRejoinSession}
+          handleDontRejoinSession={handleDontRejoinSession}
         />
       );
   }

--- a/play/src/lib/HelperFunctions.tsx
+++ b/play/src/lib/HelperFunctions.tsx
@@ -90,9 +90,18 @@ export const checkForSubmittedAnswerOnRejoin = (
  */
 export const fetchLocalData = () => {
   const localModel = window.localStorage.getItem(StorageKey);
+  const currentTime = new Date().getTime() / 60000;
+ 
   if (isNullOrUndefined(localModel)) return null;
-
   const parsedLocalModel = JSON.parse(localModel);
+  const elapsedTime = currentTime - parsedLocalModel.currentTime;
+
+  // if the time between last accessing localModel and now is greater than 2 hours, remove localModel
+  if (elapsedTime > 120) {
+   window.localStorage.removeItem(StorageKey);
+   return null;
+  }
+
   // checks for invalid data in localModel, returns null if found
   if (
     [
@@ -102,8 +111,10 @@ export const fetchLocalData = () => {
       parsedLocalModel.selectedAvatar,
       parsedLocalModel.hasRejoined,
     ].some((value) => isNullOrUndefined(value))
-  )
+  ) {
+    window.localStorage.removeItem(StorageKey);
     return null;
+  }
   // passes validated localModel to GameInProgressContainer
   return parsedLocalModel;
 };

--- a/play/src/lib/PlayModels.tsx
+++ b/play/src/lib/PlayModels.tsx
@@ -95,12 +95,14 @@ export enum TimerMode {
 
 /**
  * Type interface that holds required info to join a 'basic' game and add team to game sesssion object at start of game
+ * @param {number} currentTime: - current time (used to ignore saved local storage after a certain interval)
  * @param {string} gameSessionId - id of game session
  * @param {string} firstName - first name of player
  * @param {string} lastName - last name of player
  * @param {number} selectedAvatar - avatar selected by player
  */
 export interface LocalModel {
+  currentTime: number;
   gameSessionId: string;
   teamId: string;
   teamMemberId: string;

--- a/play/src/pages/pregame/SplashScreen.tsx
+++ b/play/src/pages/pregame/SplashScreen.tsx
@@ -38,12 +38,14 @@ interface SplashScreenProps {
   rejoinGameObject: LocalModel | null;
   setPregameState: (gameState: PregameState) => void;
   handleRejoinSession: () => void;
+  handleDontRejoinSession: () => void;
 }
 
 export default function SplashScreen({
   rejoinGameObject,
   setPregameState,
   handleRejoinSession,
+  handleDontRejoinSession,
 }: SplashScreenProps) {
   const theme = useTheme();
   const { t } = useTranslation();
@@ -56,6 +58,7 @@ export default function SplashScreen({
       <HeroContainer>
         <RejoinModal
           handleRejoinSession={handleRejoinSession}
+          handleDontRejoinSession={handleDontRejoinSession}
           isModalVisible={isModalVisible}
           setIsModalVisible={setIsModalVisible}
         />


### PR DESCRIPTION
**Issue:**
The Design team noted that we should prevent the rejoin behaviour if a certain time period has elapsed. This is so we can avoid a situation such as a student crashing out of a game and then, on the next day, using the `play` app again and being asked if they want to join the day old game. 

@amarax, I've set the 'expiration' time to 2 hrs, pretty arbitrarily. Let me know if you think there's a better interval for this. 

**Resolution:**
While there isn't an explict means of expiring `localStorage` data, the conventional way to do this is to store the time at which the localStorage data is stored and then compare that to the expiry interval when loading. We are doing that on both the `PregameContainer` and `GameInProgressContainer`, specifically within the `fetchLocalData` function in `HelperFunctions.tsx` 

Additionally, in `PregameContainer` I've moved the `fetchLocalData` call into a `loader`, similarly to what's happening in `GameInProgressContainer.` This is to prevent the `fetchLocalData` call from happening on every render and avoids using a `useEffect`.

Relevant code:
- `fetchLocalData` in `HelperFunctions.tsx`
- `PregameLocalModelLoader` in `PregameContainer.tsx`
- `LocalModelLoader` in `GameInProgressContainer.tsx` - the logic here differs from the above loader, so two are necessary.

**Preview:**
Here's a preview. For demonstration, the interval has been set to 10 seconds. Note that rejoin functionality is enabled up until that point. 

https://github.com/rightoneducation/righton-app/assets/79417944/51612ce4-f69f-4924-999c-52c4fc129a45

