### PR TITLE
[Play] - Moving Eslint/Prettier configuration settings to package.json

### DIFF
--- a/play/package.json
+++ b/play/package.json
@@ -43,22 +43,6 @@
     "build-storybook": "build-storybook -s public",
     "chromatic": "chromatic --project-token 99c8d45b7b98"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ],
-    "overrides": [
-      {
-        "files": [
-          "**/*.stories.*"
-        ],
-        "rules": {
-          "import/no-anonymous-default-export": "off"
-        }
-      }
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",
@@ -108,6 +92,76 @@
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0",
     "styled-components": "^5",
     "@mui/styled-engine": "npm:@mui/styled-engine-sc@latest"
+  },
+  "prettier": {
+    "singleQuote": true
+  },
+  "eslintConfig": {
+    "root": true,
+    "env": {
+      "browser": true,
+      "es2021": true
+    },
+    "extends": [
+      "airbnb",
+      "airbnb/hooks",
+      "airbnb-typescript",
+      "prettier",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:import/typescript"
+    ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+      "ecmaVersion": "latest",
+      "sourceType": "module",
+      "project": "./tsconfig.json"
+    },
+    "plugins": [
+      "react",
+      "@typescript-eslint",
+      "prettier"
+    ],
+    "ignorePatterns": [
+      "build/*",
+      "**/coverage/**",
+      "node_modules/*"
+    ],
+    "settings": {
+      "import/core-modules": [
+        "@righton/networking"
+      ]
+    },
+    "rules": {
+      "import/no-extraneous-dependencies": [
+        "error",
+        {
+          "devDependencies": [
+            "**/*.stories.*",
+            "**/.storybook/**/*.*",
+            "@righton/networking/*"
+          ],
+          "peerDependencies": true
+        }
+      ],
+      "react/jsx-props-no-spreading": [
+        "off"
+      ],
+      "react/require-default-props": [
+        "off"
+      ],
+      "arrow-body-style": [
+        "off"
+      ],
+      "no-console": [
+        1,
+        {
+          "allow": [
+            "debug",
+            "error"
+          ]
+        }
+      ]
+    }
   },
   "readme": "readme.md",
   "_id": "play2@0.1.0"


### PR DESCRIPTION
**Issue:**

Prettier/Eslint configuration was happening in `.prettierrc` and `.eslintrc`, respectively, which is then ignored by .gitignore. To share these settings across developers, these settings have been moved to `package.json`


**Resolution:**
Settings moved to `package.json`. Please ensure that you delete any local eslint and prettier dotfiles from your `play` folders. Eslint's precedence hierarchy puts `package.json` files under local files, so those local files need to be deleted for our `package.json` settings to apply. Prettier reverses this order so it should be fine, but for cleanliness we might as well remove them. 

For example delete the `.esclintrc.json` and `.prettierrc` files struck out in the below snip:
<img width="291" alt="Screenshot 2023-06-20 at 9 45 14 AM" src="https://github.com/rightoneducation/righton-app/assets/79417944/52537353-f08d-4bfa-83ce-028c7cff8921">


Relevant code:
- `eslintConfig` in `package.json` - linting config settings
- `prettier` in `package.json` - prettier config settings
