### PR TITLE
[Play] - currentTimer null value produces error

### DIFF
--- a/play/src/containers/GameInProgressContainer.tsx
+++ b/play/src/containers/GameInProgressContainer.tsx
@@ -31,7 +31,6 @@ export function GameInProgressContainer(props: GameInProgressContainerProps) {
   // retreives game data from react-router loader
   // if no game data, redirects to splashscreen
   const localModel = useLoaderData() as LocalModel;
-  const { currentTimer } = localModel;
   // uses local game data to subscribe to gameSession
   // fetches gameSession first, then subscribes to data, finally returns object with loading, error and gamesession
   const subscription = useFetchAndSubscribeGameSession(
@@ -43,6 +42,7 @@ export function GameInProgressContainer(props: GameInProgressContainerProps) {
 
   // if there isn't data in localstorage automatically redirect to the splashscreen
   if (isNullOrUndefined(localModel)) return <Navigate replace to="/" />;
+  
   // if gamesession is loading/errored/waiting for teacher to start game
   if (
     !subscription.gameSession ||
@@ -78,7 +78,7 @@ export function GameInProgressContainer(props: GameInProgressContainerProps) {
   // if teacher has started game, pass updated gameSession object down to GameSessionSwitch
   return (
     <GameSessionSwitch
-      currentTimer={currentTimer}
+      currentTimer={localModel.currentTimer}
       hasRejoined={subscription.hasRejoined}
       localModel={localModel}
       gameSession={subscription.gameSession}


### PR DESCRIPTION
**Issue:**

In `GameInProgressContainer.tsx` ln 34 produces a null runtime error if the player navigates to play.rightoneducation.com/game, without joining a game first. The code is `const { currentTimer } = localModel;`


**Resolution:**

This is due to the fact that we're trying to destructure localModel.currentTimer when localModel is null. If we move `localModel.currentTimer` down to the render function on ln 81, this error is avoided because that function will only render when `localModel` is populated. Then, the `isNullOrUndefined` check on ln 45 won't be interrupted and the player will be routed back to `/` automatically. 

Relevant code:
- `GameInProgressContainer.tsx` - ln81 - move `localModel.currentTimer` to a location where `localModel` !== null
