### PR TITLE
[Play] - Error handling on SelectAvatar click of Pregame Flow

### DIFF
--- a/play/public/locales/en/translation.json
+++ b/play/public/locales/en/translation.json
@@ -108,7 +108,8 @@
       "gamesessionerror": "Game session not found",
       "subscriptionerror": "Subscription could not be established",
       "button1": "Try Again",
-      "button2": "Return to Main Menu"
+      "button2": "Return to Main Menu",
+      "join": "Unable to join game. Please try again"
     },
     "game": {
       "answer": "There was an error in submitting your answer. Please try again.",

--- a/play/public/locales/es/translation.json
+++ b/play/public/locales/es/translation.json
@@ -108,7 +108,8 @@
       "gamesessionerror": "Sesión de juego no encontrada",
       "subscriptionerror": "Subscription could not be established",
       "button1": "No se pudo establecer la suscripción",
-      "button2": "Volver al menú principal"
+      "button2": "Volver al menú principal",
+      "join": "Incapaz de unirse al juego. Inténtalo de nuevo"
     },
     "game": {
       "answer": "Hubo un error al enviar su respuesta. Inténtalo de nuevo.",

--- a/play/src/components/ErrorModal.tsx
+++ b/play/src/components/ErrorModal.tsx
@@ -32,6 +32,7 @@ export default function ErrorModal({
     [ErrorType.CONNECT]: t('error.connect.title1'),
     [ErrorType.ANSWER]: t('error.game.answer'),
     [ErrorType.SCORE]: t('error.game.score'),
+    [ErrorType.JOIN]: t('error.connect.join')
   };
 
   const lowerText = [
@@ -91,11 +92,11 @@ export default function ErrorModal({
       shouldCloseOnOverlayClick={false}
       appElement={document.getElementById('root') || undefined}
     >
-      <Stack spacing={2} sx={{paddingBottom: `${theme.sizing.mediumPadding}px`}}>
+      <Stack spacing={2} sx={{ paddingBottom: `${theme.sizing.mediumPadding}px` }}>
         <Typography variant="h4" sx={{ textAlign: 'center' }}>
-          {upperTextMap[errorType]} 
+          {upperTextMap[errorType]}
         </Typography>
-        { errorType === ErrorType.CONNECT && 
+        {errorType === ErrorType.CONNECT &&
           lowerText
         }
       </Stack>
@@ -109,12 +110,12 @@ export default function ErrorModal({
             boxShadow: '0px 5px 22px rgba(71, 217, 255, 0.3)',
           }}
         >
-        { errorType === ErrorType.CONNECT ?
-          `${t('error.connect.button1')} ${(retry && retry > 0) ? `(${retry})` : ''}` 
-          : t('error.connect.button1')
-        }
+          {errorType === ErrorType.CONNECT ?
+            `${t('error.connect.button1')} ${(retry && retry > 0) ? `(${retry})` : ''}`
+            : t('error.connect.button1')
+          }
         </IntroButtonStyled>
-        { errorType === ErrorType.CONNECT && 
+        {errorType === ErrorType.CONNECT &&
           lowerButton
         }
       </Stack>

--- a/play/src/components/ErrorModal.tsx
+++ b/play/src/components/ErrorModal.tsx
@@ -32,16 +32,13 @@ export default function ErrorModal({
     [ErrorType.CONNECT]: t('error.connect.title1'),
     [ErrorType.ANSWER]: t('error.game.answer'),
     [ErrorType.SCORE]: t('error.game.score'),
-    [ErrorType.JOIN]: t('error.connect.join')
+    [ErrorType.JOIN]: t('error.connect.join'),
   };
 
   const lowerText = [
-    <Typography
-      variant="h4"
-      sx={{ textAlign: 'center', fontStyle: 'italic' }}
-    >
+    <Typography variant="h4" sx={{ textAlign: 'center', fontStyle: 'italic' }}>
       {errorText}
-    </Typography>
+    </Typography>,
   ];
   const lowerButton = [
     <IntroButtonStyled
@@ -54,7 +51,7 @@ export default function ErrorModal({
       }}
     >
       {t('error.connect.button2')}
-    </IntroButtonStyled>
+    </IntroButtonStyled>,
   ];
 
   return (
@@ -92,13 +89,14 @@ export default function ErrorModal({
       shouldCloseOnOverlayClick={false}
       appElement={document.getElementById('root') || undefined}
     >
-      <Stack spacing={2} sx={{ paddingBottom: `${theme.sizing.mediumPadding}px` }}>
+      <Stack
+        spacing={2}
+        sx={{ paddingBottom: `${theme.sizing.mediumPadding}px` }}
+      >
         <Typography variant="h4" sx={{ textAlign: 'center' }}>
           {upperTextMap[errorType]}
         </Typography>
-        {errorType === ErrorType.CONNECT &&
-          lowerText
-        }
+        {errorType === ErrorType.CONNECT && lowerText}
       </Stack>
       <Stack spacing={2} style={{ alignItems: 'center' }}>
         <IntroButtonStyled
@@ -110,14 +108,13 @@ export default function ErrorModal({
             boxShadow: '0px 5px 22px rgba(71, 217, 255, 0.3)',
           }}
         >
-          {errorType === ErrorType.CONNECT ?
-            `${t('error.connect.button1')} ${(retry && retry > 0) ? `(${retry})` : ''}`
-            : t('error.connect.button1')
-          }
+          {errorType === ErrorType.CONNECT
+            ? `${t('error.connect.button1')} ${
+                retry && retry > 0 ? `(${retry})` : ''
+              }`
+            : t('error.connect.button1')}
         </IntroButtonStyled>
-        {errorType === ErrorType.CONNECT &&
-          lowerButton
-        }
+        {errorType === ErrorType.CONNECT && lowerButton}
       </Stack>
     </Modal>
   );

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -28,8 +28,10 @@ export function PregameContainer({ apiClient }: PregameFinished) {
   const [pregameState, setPregameState] = useState<PregameState>(
     PregameState.SPLASH_SCREEN
   );
-  // retreive local storage data so that player can choose to rejoin game 
-  const [rejoinGameObject, setRejoinGameObject] = useState<LocalModel | null>(useLoaderData() as LocalModel);
+  // retreive local storage data so that player can choose to rejoin game
+  const [rejoinGameObject, setRejoinGameObject] = useState<LocalModel | null>(
+    useLoaderData() as LocalModel
+  );
   // state variables used to collect player information in pregame phase
   // information is loaded into local storage on select avatar screen and passed to /game
   const [gameSession, setGameSession] = useState<IGameSession | null>(null);
@@ -41,8 +43,6 @@ export function PregameContainer({ apiClient }: PregameFinished) {
 
   // TODO: coord with u/x for modal to pop up this error message
   const [isAPIerror, setIsAPIError] = useState<boolean>(false); // eslint-disable-line @typescript-eslint/no-unused-vars
-  const [reenableChooseButton, setReenableChooseButton] =
-    useState<boolean>(false);
 
   // if player has opted to rejoin old game session through modal on SplashScreen, set local storage data and navigate to game
   const handleRejoinSession = () => {
@@ -54,16 +54,11 @@ export function PregameContainer({ apiClient }: PregameFinished) {
     navigate(`/game`);
   };
 
-  const handleRetryJoin = () => {
-    setIsAPIError(false);
-    setReenableChooseButton(true);
-  };
-
   // if player doesn't want to rejoin, remove the localStorage and set rejoinGameObject to null
   const handleDontRejoinSession = () => {
     window.localStorage.removeItem(StorageKey);
     setRejoinGameObject(null);
-  }
+  };
   // on click of game code button, check if game code is valid
   // if game code is invalid, return false to display error
   // if game code is valid, store gameSessionId for future subscription and advance to ENTER_NAME state
@@ -161,9 +156,8 @@ export function PregameContainer({ apiClient }: PregameFinished) {
           setSelectedAvatar={setSelectedAvatar}
           isSmallDevice={isSmallDevice}
           handleAvatarSelectClick={handleAvatarSelectClick}
-          displayErrorModal={isAPIerror}
-          handleRetry={handleRetryJoin}
-          reenableButton={reenableChooseButton}
+          isAPIError={isAPIerror}
+          setIsAPIError={setIsAPIError}
         />
       );
     case PregameState.ENTER_NAME:

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -41,6 +41,7 @@ export default function Pregame({ apiClient }: PregameFinished) {
 
   // TODO: coord with u/x for modal to pop up this error message
   const [APIerror, setAPIError] = useState<boolean>(false); // eslint-disable-line @typescript-eslint/no-unused-vars
+  const [reenableChooseButton, setReenableChooseButton] = useState<boolean>(false);
 
   // if player has opted to rejoin old game session through modal on SplashScreen, set local storage data and navigate to game
   const handleRejoinSession = () => {
@@ -50,6 +51,11 @@ export default function Pregame({ apiClient }: PregameFinished) {
     };
     window.localStorage.setItem(StorageKey, JSON.stringify(storageObject));
     navigate(`/game`);
+  };
+
+  const handleRetryJoin = () => {
+    setAPIError(false);
+    setReenableChooseButton(true);
   };
 
   // on click of game code button, check if game code is valid
@@ -148,6 +154,9 @@ export default function Pregame({ apiClient }: PregameFinished) {
           setSelectedAvatar={setSelectedAvatar}
           isSmallDevice={isSmallDevice}
           handleAvatarSelectClick={handleAvatarSelectClick}
+          displayErrorModal={APIerror}
+          handleRetry={handleRetryJoin}
+          reenableButton={reenableChooseButton}
         />
       );
     case PregameState.ENTER_NAME:

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -40,7 +40,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
   );
 
   // TODO: coord with u/x for modal to pop up this error message
-  const [APIerror, setAPIError] = useState<boolean>(false); // eslint-disable-line @typescript-eslint/no-unused-vars
+  const [isAPIerror, setIsAPIError] = useState<boolean>(false); // eslint-disable-line @typescript-eslint/no-unused-vars
   const [reenableChooseButton, setReenableChooseButton] =
     useState<boolean>(false);
 
@@ -55,7 +55,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
   };
 
   const handleRetryJoin = () => {
-    setAPIError(false);
+    setIsAPIError(false);
     setReenableChooseButton(true);
   };
 
@@ -104,7 +104,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
         null
       );
       if (!team) {
-        setAPIError(true);
+        setIsAPIError(true);
       } else {
         try {
           const teamMember = await apiClient.addTeamMemberToTeam(
@@ -113,15 +113,15 @@ export function PregameContainer({ apiClient }: PregameFinished) {
             uuidv4()
           );
           if (!teamMember) {
-            setAPIError(true);
+            setIsAPIError(true);
           }
           return { teamId: team.id, teamMemberId: teamMember.id };
         } catch (error) {
-          setAPIError(true);
+          setIsAPIError(true);
         }
       }
     } catch (error) {
-      setAPIError(true);
+      setIsAPIError(true);
     }
     return undefined;
   };
@@ -131,7 +131,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
       if (gameSession) {
         const teamInfo = await addTeamToGame();
         if (!teamInfo) {
-          setAPIError(true);
+          setIsAPIError(true);
           return;
         }
         const storageObject: LocalModel = {
@@ -147,7 +147,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
         navigate(`/game`);
       }
     } catch (error) {
-      setAPIError(true);
+      setIsAPIError(true);
     }
   };
 
@@ -161,7 +161,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
           setSelectedAvatar={setSelectedAvatar}
           isSmallDevice={isSmallDevice}
           handleAvatarSelectClick={handleAvatarSelectClick}
-          displayErrorModal={APIerror}
+          displayErrorModal={isAPIerror}
           handleRetry={handleRetryJoin}
           reenableButton={reenableChooseButton}
         />

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -41,7 +41,8 @@ export default function Pregame({ apiClient }: PregameFinished) {
 
   // TODO: coord with u/x for modal to pop up this error message
   const [APIerror, setAPIError] = useState<boolean>(false); // eslint-disable-line @typescript-eslint/no-unused-vars
-  const [reenableChooseButton, setReenableChooseButton] = useState<boolean>(false);
+  const [reenableChooseButton, setReenableChooseButton] =
+    useState<boolean>(false);
 
   // if player has opted to rejoin old game session through modal on SplashScreen, set local storage data and navigate to game
   const handleRejoinSession = () => {

--- a/play/src/lib/PlayModels.tsx
+++ b/play/src/lib/PlayModels.tsx
@@ -105,7 +105,7 @@ export enum ErrorType {
   CONNECT,
   ANSWER,
   SCORE,
-  JOIN
+  JOIN,
 }
 
 /**

--- a/play/src/lib/PlayModels.tsx
+++ b/play/src/lib/PlayModels.tsx
@@ -99,11 +99,13 @@ export enum TimerMode {
  * @param {string} CONNECT - error connecting to game session
  * @param {string} ANSWER - error submitting answer
  * @param {string} SCORE - error submitting score
+ * @param {string} JOIN - error joining game
  */
 export enum ErrorType {
   CONNECT,
   ANSWER,
   SCORE,
+  JOIN
 }
 
 /**

--- a/play/src/pages/pregame/SelectAvatar.tsx
+++ b/play/src/pages/pregame/SelectAvatar.tsx
@@ -89,9 +89,8 @@ interface SelectAvatarProps {
   firstName: string;
   lastName: string;
   isSmallDevice: boolean;
-  displayErrorModal: boolean;
-  handleRetry: () => void;
-  reenableButton: boolean;
+  isAPIError: boolean;
+  setIsAPIError: (value: boolean) => void;
   handleAvatarSelectClick: () => void;
 }
 
@@ -102,22 +101,26 @@ export default function SelectAvatar({
   lastName,
   isSmallDevice,
   handleAvatarSelectClick,
-  displayErrorModal,
-  handleRetry,
-  reenableButton,
+  isAPIError,
+  setIsAPIError,
 }: SelectAvatarProps) {
   const theme = useTheme();
   const { t } = useTranslation();
   const [isButtonPressed, setIsButtonPressed] = React.useState(false);
 
+  const handleRetryClick = () => {
+    setIsAPIError(false);
+    setIsButtonPressed(false);
+  };
+
   return (
     <BackgroundContainerStyled>
       <StackContainer>
         <ErrorModal
-          isModalOpen={displayErrorModal}
+          isModalOpen={isAPIError}
           errorType={ErrorType.JOIN}
           errorText=""
-          handleRetry={handleRetry}
+          handleRetry={handleRetryClick}
         />
         <Stack spacing={2}>
           <Typography
@@ -159,7 +162,7 @@ export default function SelectAvatar({
               handleAvatarSelectClick();
               setIsButtonPressed(true);
             }}
-            disabled={isButtonPressed && !reenableButton}
+            disabled={isButtonPressed}
           >
             {t('joingame.selectavatar.button')}
           </GamePlayButtonStyled>

--- a/play/src/pages/pregame/SelectAvatar.tsx
+++ b/play/src/pages/pregame/SelectAvatar.tsx
@@ -77,7 +77,9 @@ const BottomContainer = styled(Box, {
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  paddingBottom: isSmallDevice ? `${theme.sizing.extraExtraLargePadding}px` : `${theme.sizing.largePadding}px`,
+  paddingBottom: isSmallDevice
+    ? `${theme.sizing.extraExtraLargePadding}px`
+    : `${theme.sizing.largePadding}px`,
   gap: 12,
 }));
 
@@ -102,7 +104,7 @@ export default function SelectAvatar({
   handleAvatarSelectClick,
   displayErrorModal,
   handleRetry,
-  reenableButton
+  reenableButton,
 }: SelectAvatarProps) {
   const theme = useTheme();
   const { t } = useTranslation();

--- a/play/src/pages/pregame/SelectAvatar.tsx
+++ b/play/src/pages/pregame/SelectAvatar.tsx
@@ -6,7 +6,8 @@ import { useTranslation } from 'react-i18next';
 import { GamePlayButtonStyled } from '../../lib/styledcomponents/GamePlayButtonStyled';
 import BackgroundContainerStyled from '../../lib/styledcomponents/layout/BackgroundContainerStyled';
 import AvatarIconStyled from '../../lib/styledcomponents/AvatarIconStyled';
-import { monsterMap } from '../../lib/PlayModels';
+import { monsterMap, ErrorType } from '../../lib/PlayModels';
+import ErrorModal from '../../components/ErrorModal';
 
 // stack container for select avatar screen
 
@@ -22,7 +23,7 @@ const GridContainer = styled('div')(({ theme }) => ({
   // using CSS Grid here because mui Grid responsiveness produces changes in spacing when crossing breakpoints
   display: 'grid',
   gridTemplateColumns: 'repeat(3, 1fr)',
-  gridGap: `${theme.sizing. extraSmallPadding}px`,
+  gridGap: `${theme.sizing.extraSmallPadding}px`,
 }));
 
 const AvatarIconContainer = styled(Box)({
@@ -76,7 +77,7 @@ const BottomContainer = styled(Box, {
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  paddingBottom: isSmallDevice ? `${theme.sizing.extraExtraLargePadding}px`: `${theme.sizing.largePadding}px`,
+  paddingBottom: isSmallDevice ? `${theme.sizing.extraExtraLargePadding}px` : `${theme.sizing.largePadding}px`,
   gap: 12,
 }));
 
@@ -86,6 +87,9 @@ interface SelectAvatarProps {
   firstName: string;
   lastName: string;
   isSmallDevice: boolean;
+  displayErrorModal: boolean;
+  handleRetry: () => void;
+  reenableButton: boolean;
   handleAvatarSelectClick: () => void;
 }
 
@@ -96,6 +100,9 @@ export default function SelectAvatar({
   lastName,
   isSmallDevice,
   handleAvatarSelectClick,
+  displayErrorModal,
+  handleRetry,
+  reenableButton
 }: SelectAvatarProps) {
   const theme = useTheme();
   const { t } = useTranslation();
@@ -104,6 +111,12 @@ export default function SelectAvatar({
   return (
     <BackgroundContainerStyled>
       <StackContainer>
+        <ErrorModal
+          isModalOpen={displayErrorModal}
+          errorType={ErrorType.JOIN}
+          errorText=""
+          handleRetry={handleRetry}
+        />
         <Stack spacing={2}>
           <Typography
             variant="h2"
@@ -144,7 +157,7 @@ export default function SelectAvatar({
               handleAvatarSelectClick();
               setIsButtonPressed(true);
             }}
-            disabled={isButtonPressed}
+            disabled={isButtonPressed && !reenableButton}
           >
             {t('joingame.selectavatar.button')}
           </GamePlayButtonStyled>


### PR DESCRIPTION
**Issue:**
This PR addresses git issue #671: 
No UI error handling for API errors on choose avatar screen

**Resolution:**
As was suggested, the solution was to incorporate the ErrorModal component into the SelectAvatar component by passing in relevant information from PregameContainer to SelectAvatar and expand ErrorModal's functionality to respond to errors when players fail to join the game.

Relevant code:
_Adding ErrorModal for Pregame_:
In `PregameContainer.tsx`:
-Pass `APIError` into `<SelectAvatar>` on `line 164` to determine if error modal should be displayed
In `SelectAvatar.tsx`:
-`<ErrorModal>` component added on `lines 116-121`, taking in `displayErrorModal` (passed in from parent as `APIError`) as an argument for `isModalOpen` on `line 117`
In `PlayModels.tsx`:
-Added element to `ErrorType` enum called `JOIN` on `line 108` to enable unique error message for that case
In `ErrorModal.tsx`:
-Use the above enum element `JOIN` in `const upperTextMap` on `line 35`: `[ErrorType.JOIN]: t('error.connect.join')`
In `translation.json` (both en and es):
-Add `"join": "Unable to join game. Please try again"`(and (google) translated Spanish version to es file) to `error.connect` item in json on `line 112` 

_Button handling:_
In `PregameContainer.tsx`:
-Added boolean `const [reenableChooseButton, setReenableChooseButton]` on `line 44` to be updated in `handleRetryJoin` on `line 59` and eventually passed down to `<SelectAvatar>` on `line 166`
In `SelectAvatar.tsx`:
-This value is passed into `reenableButton` and is used to check if the button should be disabled: 
`disabled={isButtonPressed && !reenableButton}` (`line 162`) since we want the player to be able to press the button again after closing the errorModal (if it appears)

_Handling 'try again' press event on modal_:
In `PregameContainer.tsx`:
-Added function `handleRetryJoin()` on `lines 57-60` which sets `APIError` to false and re-enables the button described above. This function then gets passed down to `<SelectAvatar>` on `line 165`
In `SelectAvatar.tsx`:
-`handleRetry` function is passed into `<ErrorModal>` component on `line 120`

**Preview:**
I simulated APIError with some dummy code for testing purposes below:
Screenshot of error modal on select avatar screen:
<img width="365" alt="Screenshot 2023-06-20 at 8 18 31 PM" src="https://github.com/rightoneducation/righton-app/assets/106450593/c25dacef-23aa-4de7-ae88-a23f5bf59f04">

Screen recording of player attempting to join game when APIError has occurred:

https://github.com/rightoneducation/righton-app/assets/106450593/cb7220aa-e301-46ab-9013-ab265cd4be8b

@drewjhart , @maniramezan  
