### PR TITLE
[Play] - Localstorage Timer fix

### DIFF
--- a/play/src/components/GameSessionSwitch.tsx
+++ b/play/src/components/GameSessionSwitch.tsx
@@ -14,7 +14,7 @@ import FinalResultsContainer from '../containers/FinalResultsContainer';
 import StartPhase2 from '../pages/StartPhase2';
 import { LocalModel } from '../lib/PlayModels';
 
-interface GameInProgressContainerProps {
+interface GameSessionSwitchProps {
   apiClient: ApiClient;
   currentTimer: number;
   hasRejoined: boolean;
@@ -22,13 +22,13 @@ interface GameInProgressContainerProps {
   localModel: LocalModel;
 }
 
-export default function GameInProgressContainer({
+export default function GameSessionSwitch({
   apiClient,
   currentTimer,
   hasRejoined,
   gameSession,
   localModel,
-}: GameInProgressContainerProps) {
+}: GameSessionSwitchProps) {
   const [isPregameCountdown, setIsPregameCountdown] = useState<boolean>(
     !hasRejoined
   );
@@ -68,6 +68,7 @@ export default function GameInProgressContainer({
           score={score}
           hasRejoined={hasRejoined}
           currentTimer={currentTimer}
+          localModel={localModel}
         />
       );
     case GameSessionState.CHOOSE_TRICKIEST_ANSWER:
@@ -84,6 +85,7 @@ export default function GameInProgressContainer({
           score={score}
           hasRejoined={hasRejoined}
           currentTimer={currentTimer}
+          localModel={localModel}
         />
       );
     case GameSessionState.PHASE_1_RESULTS:

--- a/play/src/components/HeaderContent.tsx
+++ b/play/src/components/HeaderContent.tsx
@@ -4,6 +4,7 @@ import { styled } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { GameSessionState } from '@righton/networking';
 import Timer from './Timer';
+import { LocalModel } from '../lib/PlayModels';
 
 const HeaderContainer = styled('div')({
   width: '100%',
@@ -21,6 +22,7 @@ interface HeaderContentProps {
   handleTimerIsFinished: () => void;
   isCorrect: boolean;
   isIncorrect: boolean;
+  localModel?: LocalModel;
 }
 
 export default function HeaderContent({
@@ -32,6 +34,7 @@ export default function HeaderContent({
   handleTimerIsFinished,
   isCorrect,
   isIncorrect,
+  localModel,
 }: HeaderContentProps) {
   const { t } = useTranslation();
   const stateMap = {
@@ -74,14 +77,15 @@ export default function HeaderContent({
       <Typography variant="h1">
         {stateCheck(currentState, isCorrect, isIncorrect)}
       </Typography>
-      {currentState === GameSessionState.CHOOSE_CORRECT_ANSWER ||
-      currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER ? (
+      {(currentState === GameSessionState.CHOOSE_CORRECT_ANSWER ||
+      currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER) && localModel ? (
         <Timer
           totalTime={totalTime}
           currentTimer={currentTimer}
           isFinished={isFinished}
           isPaused={isPaused}
           handleTimerIsFinished={handleTimerIsFinished}
+          localModel={localModel}
         />
       ) : null}
     </HeaderContainer>

--- a/play/src/components/Timer.tsx
+++ b/play/src/components/Timer.tsx
@@ -3,7 +3,6 @@ import { styled } from '@mui/material/styles';
 import { Container, Typography } from '@mui/material';
 import LinearProgress from '@mui/material/LinearProgress';
 import { LocalModel, StorageKey } from '../lib/PlayModels';
-import { fetchLocalData } from '../lib/HelperFunctions';
 
 const TimerContainer = styled(Container)(({ theme }) => ({
   display: 'flex',
@@ -39,6 +38,7 @@ interface TimerProps {
   isPaused: boolean;
   isFinished: boolean;
   handleTimerIsFinished: () => void;
+  localModel: LocalModel;
 }
 
 export default function Timer({
@@ -47,6 +47,7 @@ export default function Timer({
   isPaused,
   isFinished,
   handleTimerIsFinished,
+  localModel,
 }: TimerProps) {
   const [currentTimeMilli, setCurrentTimeMilli] = useState(currentTimer * 1000); // millisecond updates to smooth out progress bar
   const currentTime = Math.trunc(currentTimeMilli / 1000);
@@ -57,8 +58,6 @@ export default function Timer({
   let originalTime: number;
   const isPausedRef = useRef<boolean>(isPaused);
 
-  // retreive local storage data so that timer has correct value on rejoin
-  const rejoinGameObject = fetchLocalData();
   // updates the current time as well as the localstorage in case of page reset
   // recursive countdown timer function using requestAnimationFrame
   function updateTimer(timestamp: number) {
@@ -87,14 +86,14 @@ export default function Timer({
         secStr = sec < 10 ? `0${sec}` : `${sec}`;
       }
       const storageObject: LocalModel = {
-        ...rejoinGameObject,
+        ...localModel,
         currentTimer: currentTimeInput,
       };
       window.localStorage.setItem(StorageKey, JSON.stringify(storageObject));
       return `${min}:${secStr}`;
     };
     return getTimerString(currentTime);
-  }, [currentTime, rejoinGameObject]);
+  }, [currentTime, localModel]);
 
   // useEffect to start off timer
   useEffect(() => {

--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -22,7 +22,7 @@ import DiscussAnswer from './gameinprogress/DiscussAnswer';
 import FooterStackContainerStyled from '../lib/styledcomponents/layout/FooterStackContainerStyled';
 import { checkForSubmittedAnswerOnRejoin } from '../lib/HelperFunctions';
 import ErrorModal from '../components/ErrorModal';
-import { ErrorType } from '../lib/PlayModels';
+import { ErrorType, LocalModel } from '../lib/PlayModels';
 
 interface GameInProgressProps {
   apiClient: ApiClient;
@@ -44,6 +44,7 @@ interface GameInProgressProps {
   }[];
   hasRejoined: boolean;
   currentTimer: number;
+  localModel: LocalModel;
 }
 
 export default function GameInProgress({
@@ -61,6 +62,7 @@ export default function GameInProgress({
   answerChoices,
   hasRejoined,
   currentTimer,
+  localModel,
 }: GameInProgressProps) {
   const theme = useTheme();
   const [isError, setIsError] = useState(false);
@@ -187,6 +189,7 @@ export default function GameInProgress({
           isPaused={false}
           isFinished={false}
           handleTimerIsFinished={handleTimerIsFinished}
+          localModel={localModel}
         />
       </HeaderStackContainerStyled>
       <BodyStackContainerStyled>


### PR DESCRIPTION
**Issue:**

We were originally importing the localModel at the `Timer` component level. This means that every time the timer rerendered (continuously), we would call `fetchLocalData` and it would retrieve from local data. We need to prevent this from happening.


**Resolution:**

We've passed down the `localModel` all the way from `GameSessionSwitch` to the `Timer` component as a prop. This means that the value won't change when the `Timer` rerenders. So that `fetchLocalData` function only runs on the loaders.

Relevant code:
- `const rejoinGameObject = fetchLocalData()` - removed from `Timer.tsx`
- `localModel={localModel}` - added to `GameInProgress.tsx` and subcomponents through to `Timer.tsx`

