### PR TITLE
[Play] - timer fix - hasRejoined Condition

### DIFF
--- a/play/src/components/Timer.tsx
+++ b/play/src/components/Timer.tsx
@@ -88,6 +88,7 @@ export default function Timer({
       const storageObject: LocalModel = {
         ...localModel,
         currentTimer: currentTimeInput,
+        hasRejoined: true,
       };
       window.localStorage.setItem(StorageKey, JSON.stringify(storageObject));
       return `${min}:${secStr}`;


### PR DESCRIPTION
**Issue:**
I missed this issue in https://github.com/rightoneducation/righton-app/pull/677. If we are passing the `localModel` that was loaded from the loader and then updating it continuously from the `Timer.tsx` it will always have `hasRejoined: false` on this screen. 


**Resolution:**

We need to updated `hasRejoined: true` when we are also updating with the `currentTimer` value, so that if a user reloads the page, they are routed through the correct rejoin logic. We can set `hasRejoined: true` here unilaterally because we only ever `fetchLocalData` in the loader functions on the pages. Therefore, we know that once they hit this timer function, any time we are updating `localModel` it will be in the `hasRejoined: true` condition.

Relevant code:
- `hasRejoined: true` in `Timer.tsx`
