### PR TITLE
[Play] - Randomization of team avatars on leaderboard

### DIFF
--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -73,13 +73,13 @@ export default function Leaderboard({
 
   const { current: avatarNumbers } = useRef<number[]>(
     teams
-    // iterates through the team array, if the current element is currentTeam then it uses the team avatar, otherwise generate a random number
-      ? teams.map((team, index) => (team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)))
-    // if teams is invalid, then return empty array
-      : []
+      ? // iterates through the team array, if the current element is currentTeam then it uses the team avatar, otherwise generate a random number
+        teams.map((team, index) =>
+          team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)
+        )
+      : // if teams is invalid, then return empty array
+        []
   );
-  
-  console.log(avatarNumbers);
 
   return (
     <StackContainerStyled
@@ -96,7 +96,7 @@ export default function Leaderboard({
           currentTimer={0}
           isPaused={false}
           isFinished={false}
-          handleTimerIsFinished={() => { }}
+          handleTimerIsFinished={() => {}}
         />
       </HeaderStackContainerStyled>
       <BodyStackContainerStyled ref={containerRef}>

--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -71,6 +71,16 @@ export default function Leaderboard({
     }
   }, [containerRef.current?.clientHeight, subContainerHeight]); // updates whenever the container is resized
 
+  const { current: avatarNumbers } = useRef<number[]>(
+    teams
+    // iterates through the team array, if the current element is currentTeam then it uses the team avatar, otherwise generate a random number
+      ? teams.map((team, index) => (team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)))
+    // if teams is invalid, then return empty array
+      : []
+  );
+  
+  console.log(avatarNumbers);
+
   return (
     <StackContainerStyled
       direction="column"
@@ -86,7 +96,7 @@ export default function Leaderboard({
           currentTimer={0}
           isPaused={false}
           isFinished={false}
-          handleTimerIsFinished={() => {}}
+          handleTimerIsFinished={() => { }}
         />
       </HeaderStackContainerStyled>
       <BodyStackContainerStyled ref={containerRef}>
@@ -98,15 +108,11 @@ export default function Leaderboard({
           isSmallDevice={isSmallDevice}
           spacing={2}
         >
-          {sortedTeams?.map((team: ITeam) => (
+          {sortedTeams?.map((team: ITeam, index: number) => (
             <Grid item key={uuidv4()} ref={itemRef} sx={{ width: '100%' }}>
               <LeaderboardSelector
                 teamName={team.name ? team.name : 'Team One'}
-                teamAvatar={
-                  team === currentTeam
-                    ? teamAvatar
-                    : Math.floor(Math.random() * 6)
-                }
+                teamAvatar={avatarNumbers[index]}
                 teamScore={team.score}
               />
             </Grid>


### PR DESCRIPTION
**Issue:**

Solves the issue of the team avatar values being regenerated and randomized every time the screen is resized. Github: https://github.com/rightoneducation/righton-app/issues/652

Previous PR: https://github.com/rightoneducation/righton-app/pull/656

I had to create a new branch due to merge errors.


**Resolution:**

Originally the team avatars were being set at a random value which would regenerate each time the component was re-rendering, including when the screen would be resized. I took it outside of the component function and used a useRef hook so that it is randomized only once and then stored and returned. It is only regenerated when the teams or teamId also changes.

To deal with the runtime errors when the player is not in last place, I made a few adjustments. The function maps over the team array and if the current element is the current team, it is assigned the teamAvatar accordingly, if not, it is assigned a randomized number.

Leaderboard.tsx - this is where the team avatars values are being generated

**Preview:**

https://github.com/rightoneducation/righton-app/assets/79948102/4d8331e1-dc84-410a-b935-75b2f2f5a8f8

Video of the problem ^^^


https://github.com/rightoneducation/righton-app/assets/79948102/1af9d34e-5cfc-4548-b9b6-0094c1c5eeb7

Video of the solution^^^
