### PR TITLE
[Play] - Leaderboard - Tied Teams Sorting #673

### DIFF
--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -37,7 +37,14 @@ export default function Leaderboard({
 }: LeaderboardProps) {
   const currentTeam = teams?.find((team) => team.id === teamId);
   const teamSorter = (inputTeams: ITeam[]) => {
-    inputTeams.sort((a, b) => b.score - a.score);
+    inputTeams.sort((a, b) => {
+      if (a.score !== b.score) {
+        // sort by score descending
+        return b.score - a.score;
+      }
+      // sort alphabetically by name if scores are tied
+      return a.name.localeCompare(b.name);
+    });
     return teams!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
   };
 


### PR DESCRIPTION
Github Issue: https://github.com/rightoneducation/righton-app/issues/673
In the event of a tie, players are not displayed alphabetically.

Location in [Design Comments Document](https://docs.google.com/document/d/1EyyDVn2hgrPhgxTok5Qf0AFVjNPh0PVeWxjKCWQtx2c/edit): issue # 2 (on the bottom of Page 10).


**Resolution:**

The teamSorter function has been modified to detect a tie in the rankings and sort that subset of players alphabetically.

Leaderboard.tsx


**Preview:**

<img width="663" alt="Screen Shot 2023-06-27 at 1 17 58 PM" src="https://github.com/rightoneducation/righton-app/assets/79948102/72668b7c-bc9e-4ef7-807d-2e7e76330f54">

The leaderboard without the alphabetically ordered tied teams ^^

<img width="1502" alt="Screen Shot 2023-06-27 at 1 13 53 PM" src="https://github.com/rightoneducation/righton-app/assets/79948102/a059fc6f-71a2-4342-b7d4-3491e07b3e21">

Here is the updated leaderboard ^^
