### PR TITLE
[Play] -If there are no ties, only five players should be displayed on the leaderboard #691

### DIFF
--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -81,12 +81,17 @@ export default function Leaderboard({
   const { current: avatarNumbers } = useRef<number[]>(
     teams
       ? // iterates through the team array, if the current element is currentTeam then it uses the team avatar, otherwise generate a random number
-        teams.map((team, index) =>
-          team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)
-        )
+      teams.map((team, index) =>
+        team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)
+      )
       : // if teams is invalid, then return empty array
-        []
+      []
   );
+  // top five scores are taken from sortedTeams
+  const topScores: number[] = sortedTeams.slice(0, 5).map((team) => team.score);
+  // filter through sortedTeams for all teams with the top five scores
+  const topTeams: ITeam[] = sortedTeams.filter((team) => topScores.includes(team.score));
+
 
   return (
     <StackContainerStyled
@@ -103,7 +108,7 @@ export default function Leaderboard({
           currentTimer={0}
           isPaused={false}
           isFinished={false}
-          handleTimerIsFinished={() => {}}
+          handleTimerIsFinished={() => { }}
         />
       </HeaderStackContainerStyled>
       <BodyStackContainerStyled ref={containerRef}>
@@ -115,7 +120,7 @@ export default function Leaderboard({
           isSmallDevice={isSmallDevice}
           spacing={2}
         >
-          {sortedTeams?.map((team: ITeam, index: number) => (
+          {topTeams?.map((team: ITeam, index: number) => (
             <Grid item key={uuidv4()} ref={itemRef} sx={{ width: '100%' }}>
               <LeaderboardSelector
                 teamName={team.name ? team.name : 'Team One'}

--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -81,11 +81,11 @@ export default function Leaderboard({
   const { current: avatarNumbers } = useRef<number[]>(
     teams
       ? // iterates through the team array, if the current element is currentTeam then it uses the team avatar, otherwise generate a random number
-      teams.map((team, index) =>
-        team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)
-      )
+        teams.map((team, index) =>
+          team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)
+        )
       : // if teams is invalid, then return empty array
-      []
+        []
   );
 
   // create a set to store unique scores, makes sure no scores repeat
@@ -93,12 +93,14 @@ export default function Leaderboard({
   sortedTeams.forEach((team) => scoreSet.add(team.score));
 
   // convert the set to an array and sort it in descending order to retrieve only the top five highest scores
-  const topScores: number[] = Array.from(scoreSet).sort((a, b) => b - a).slice(0, 5);
+  const topScores: number[] = Array.from(scoreSet)
+    .sort((a, b) => b - a)
+    .slice(0, 5);
 
   // Filter through sortedTeams for all teams with the top five unique scores
-  const topTeams: ITeam[] = sortedTeams.filter((team) => topScores.includes(team.score));
-
-
+  const topTeams: ITeam[] = sortedTeams.filter((team) =>
+    topScores.includes(team.score)
+  );
 
   return (
     <StackContainerStyled
@@ -115,7 +117,7 @@ export default function Leaderboard({
           currentTimer={0}
           isPaused={false}
           isFinished={false}
-          handleTimerIsFinished={() => { }}
+          handleTimerIsFinished={() => {}}
         />
       </HeaderStackContainerStyled>
       <BodyStackContainerStyled ref={containerRef}>

--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -87,10 +87,17 @@ export default function Leaderboard({
       : // if teams is invalid, then return empty array
       []
   );
-  // top five scores are taken from sortedTeams
-  const topScores: number[] = sortedTeams.slice(0, 5).map((team) => team.score);
-  // filter through sortedTeams for all teams with the top five scores
+
+  // create a set to store unique scores, makes sure no scores repeat
+  const scoreSet = new Set<number>();
+  sortedTeams.forEach((team) => scoreSet.add(team.score));
+
+  // convert the set to an array and sort it in descending order to retrieve only the top five highest scores
+  const topScores: number[] = Array.from(scoreSet).sort((a, b) => b - a).slice(0, 5);
+
+  // Filter through sortedTeams for all teams with the top five unique scores
   const topTeams: ITeam[] = sortedTeams.filter((team) => topScores.includes(team.score));
+
 
 
   return (


### PR DESCRIPTION
**Issue:**

The leaderboard currently shows up to six players on desktop, even when there are no ties.

Location in [Design Comments Document](https://docs.google.com/document/d/1EyyDVn2hgrPhgxTok5Qf0AFVjNPh0PVeWxjKCWQtx2c/edit): issue # 5 (on the bottom of Page 11).

Github item: https://github.com/rightoneducation/righton-app/issues/691

**Resolution:**

Leaderboard should show the teams with top five highest scores, no matter the number of teams or ties. I created a set that added every unique team score and converted that into an array. I sorted the array and took the top five highest scores and then I filtered through the sortedTeams array for any teams that have those scores.

Relevant code:
- Leaderboard.tsx


**Preview:**

<img width="1002" alt="Screen Shot 2023-06-28 at 8 13 18 PM" src="https://github.com/rightoneducation/righton-app/assets/79948102/df75c0eb-8cac-435d-9124-1f1de3fbe05f">

Current leaderboard^^^

<img width="1000" alt="Screen Shot 2023-06-28 at 7 46 47 PM" src="https://github.com/rightoneducation/righton-app/assets/79948102/0f72ac44-ee3f-48f5-8bc4-b23c7480ed8b">

Updated leaderboard ^^^

