### PR TITLE
[Play] - Verify if we can remove the initial team sort on Leaderboard.tsx #696

### DIFF
--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -37,7 +37,18 @@ export default function Leaderboard({
 }: LeaderboardProps) {
   const currentTeam = teams?.find((team) => team.id === teamId);
   const teamSorter = (inputTeams: ITeam[]) => {
-    inputTeams.sort((a, b) => {
+    // create a set to store unique scores with no repeats
+    const scoreSet = new Set<number>();
+    inputTeams.forEach((team) => scoreSet.add(team.score));
+    // convert the set to an array and sort it in descending order to retrieve only the top five highest scores
+    const sortedTopScores: Set<number> = new Set(Array.from(scoreSet)
+      .sort((a, b) => b - a)
+      .slice(0, 5));
+    // Filter through sortedTeams for all teams with the top five unique scores
+    const topTeamsUnsorted: ITeam[] = inputTeams.filter((team) =>
+      sortedTopScores.has(team.score)
+    );
+    const topTeamsSorted: ITeam[] = topTeamsUnsorted.sort((a, b) => {
       if (a.score !== b.score) {
         // sort by score descending
         return b.score - a.score;
@@ -45,7 +56,7 @@ export default function Leaderboard({
       // sort alphabetically by name if scores are tied
       return a.name.localeCompare(b.name);
     });
-    return teams!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    return topTeamsSorted;
   };
 
   let sortedTeams: ITeam[] = [];
@@ -88,20 +99,6 @@ export default function Leaderboard({
         []
   );
 
-  // create a set to store unique scores, makes sure no scores repeat
-  const scoreSet = new Set<number>();
-  sortedTeams.forEach((team) => scoreSet.add(team.score));
-
-  // convert the set to an array and sort it in descending order to retrieve only the top five highest scores
-  const topScores: number[] = Array.from(scoreSet)
-    .sort((a, b) => b - a)
-    .slice(0, 5);
-
-  // Filter through sortedTeams for all teams with the top five unique scores
-  const topTeams: ITeam[] = sortedTeams.filter((team) =>
-    topScores.includes(team.score)
-  );
-
   return (
     <StackContainerStyled
       direction="column"
@@ -129,7 +126,7 @@ export default function Leaderboard({
           isSmallDevice={isSmallDevice}
           spacing={2}
         >
-          {topTeams?.map((team: ITeam, index: number) => (
+          {sortedTeams.map((team: ITeam, index: number) => (
             <Grid item key={uuidv4()} ref={itemRef} sx={{ width: '100%' }}>
               <LeaderboardSelector
                 teamName={team.name ? team.name : 'Team One'}

--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -81,11 +81,11 @@ export default function Leaderboard({
   const { current: avatarNumbers } = useRef<number[]>(
     teams
       ? // iterates through the team array, if the current element is currentTeam then it uses the team avatar, otherwise generate a random number
-      teams.map((team, index) =>
-        team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)
-      )
+        teams.map((team, index) =>
+          team === currentTeam ? teamAvatar : Math.floor(Math.random() * 6)
+        )
       : // if teams is invalid, then return empty array
-      []
+        []
   );
 
   // create a set to store unique scores, makes sure no scores repeat
@@ -93,12 +93,14 @@ export default function Leaderboard({
   sortedTeams.forEach((team) => scoreSet.add(team.score));
 
   // convert the set to an array and sort it in descending order to retrieve only the top five highest scores
-  const topScores: number[] = Array.from(scoreSet).sort((a, b) => b - a).slice(0, 5);
+  const topScores: number[] = Array.from(scoreSet)
+    .sort((a, b) => b - a)
+    .slice(0, 5);
 
   // Filter through sortedTeams for all teams with the top five unique scores
-  const topTeams: ITeam[] = sortedTeams.filter((team) => topScores.includes(team.score));
-
-
+  const topTeams: ITeam[] = sortedTeams.filter((team) =>
+    topScores.includes(team.score)
+  );
 
   return (
     <StackContainerStyled
@@ -115,7 +117,7 @@ export default function Leaderboard({
           currentTimer={0}
           isPaused={false}
           isFinished={false}
-          handleTimerIsFinished={() => { }}
+          handleTimerIsFinished={() => {}}
         />
       </HeaderStackContainerStyled>
       <BodyStackContainerStyled ref={containerRef}>

--- a/play/src/pages/finalresults/Leaderboard.tsx
+++ b/play/src/pages/finalresults/Leaderboard.tsx
@@ -87,10 +87,17 @@ export default function Leaderboard({
       : // if teams is invalid, then return empty array
       []
   );
-  // top five scores are taken from sortedTeams
-  const topScores: number[] = sortedTeams.slice(0, 5).map((team) => team.score);
-  // filter through sortedTeams for all teams with the top five scores
+
+  // create a set to store unique scores, makes sure no scores repeat
+  const scoreSet = new Set<number>();
+  sortedTeams.forEach((team) => scoreSet.add(team.score));
+
+  // convert the set to an array and sort it in descending order to retrieve only the top five highest scores
+  const topScores: number[] = Array.from(scoreSet).sort((a, b) => b - a).slice(0, 5);
+
+  // Filter through sortedTeams for all teams with the top five unique scores
   const topTeams: ITeam[] = sortedTeams.filter((team) => topScores.includes(team.score));
+
 
 
   return (


### PR DESCRIPTION
**Issue:**

Issue:
Issue on github item: "From https://github.com/rightoneducation/righton-app/pull/695. In my review, I missed that we're still using the original sortedTeams logic as well as the new Set-based sorting. I'm pretty sure we can delete the original sortedTeams logic and just convert the set but it'd be good to verify this."

Github item: https://github.com/rightoneducation/righton-app/issues/696


**Resolution:**

Proposed resolution on github item: "This task is to verify that we can remove the original sorting logic (ln 39-53) on Leaderboard.tsx. If possible, delete that code and just use teams."

I've changed the array that the set takes from sortedTeams to just teams. In my review of the code, I'm not sure how it would be possible to get rid of the original sorting logic (In 39-53). I know the main part we discussed for this item is that the sorting twice seems redundant. The first sorting is done on the original teams array, and includes ties being sorted alphabetically, repeats included.
The second sorting is done on the array of team scores, each one is unique, so no repeats. The first one has to be done separately as it considers all of the ties and puts them in order alphabetically. Because the second sorting has to be done on the array of team scores that have been converted from the set, the sorting is actually not being done on the same array of values. The two sorted arrays are necessary to obtain the array of all the teams that have the top five highest scores.

That being said, I could have full well missed a solution right under my nose and I'm open to suggestions.

Relevant code:
- `Leaderboard.tsx`

The leaderboard renders the same as the last PR:
<img width="1004" alt="Screen Shot 2023-06-29 at 10 48 26 PM" src="https://github.com/rightoneducation/righton-app/assets/79948102/30210d9f-c0cd-4356-ab3e-546fb0ae3bc0">

