### PR TITLE
[Play] - Remove .storybook config folder from .gitignore

### DIFF
--- a/play/.gitignore
+++ b/play/.gitignore
@@ -98,3 +98,4 @@ $RECYCLE.BIN/
 # Hidden Files
 .*
 !/.gitignore
+!/.storybook/

--- a/play/.storybook/main.js
+++ b/play/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions', '@storybook/preset-create-react-app'],
   framework: {
     name: '@storybook/react-webpack5',

--- a/play/.storybook/main.js
+++ b/play/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions', '@storybook/preset-create-react-app'],
   framework: {
     name: '@storybook/react-webpack5',

--- a/play/.storybook/main.js
+++ b/play/.storybook/main.js
@@ -1,0 +1,8 @@
+module.exports = {
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions', '@storybook/preset-create-react-app'],
+  framework: {
+    name: '@storybook/react-webpack5',
+    options: {}
+  }
+};

--- a/play/.storybook/preview-head.html
+++ b/play/.storybook/preview-head.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@500&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Karla&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Karla:wght@800&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body></body>
+</html>

--- a/play/.storybook/preview.js
+++ b/play/.storybook/preview.js
@@ -1,0 +1,18 @@
+export const parameters = {
+  actions: { argTypesRegex: '^on[A-Z].*' },
+  controls: {
+    matchers: {
+      color: /(background|color)$/i,
+      date: /Date$/,
+    },
+  },
+  backgrounds: {
+    default: 'dark',
+  },
+  options: {
+    storySort: {
+      method: 'alphabetical',
+    },
+  },
+  layout: 'fullscreen',
+};


### PR DESCRIPTION
**Issue:**

Storybook configuration files are stored by default in a `.storybook` folder. Our `.gitignore` contains `.*` effectively ignoring the config files, meaning that multiple devs may have different configs. 


**Resolution:**

An exception has been added to `.gitignore` so that the folder is no longer ignored and we have a single source of truth for storybook config files.

Relevant code:
- `!/.storybook/` - in `.gitignore`