### PR TITLE
[Networking] - ConfidenceLevel Parameter

### DIFF
--- a/host/src/mock/MockGameSession.json
+++ b/host/src/mock/MockGameSession.json
@@ -36,7 +36,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -46,7 +47,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -56,7 +58,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -66,7 +69,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -76,7 +80,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -86,7 +91,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -115,7 +121,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -125,7 +132,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -135,7 +143,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -145,7 +154,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -155,7 +165,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -165,7 +176,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -194,7 +206,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -204,7 +217,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -214,7 +228,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -224,7 +239,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -234,7 +250,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -244,7 +261,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -273,7 +291,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -283,7 +302,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -293,7 +313,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -303,7 +324,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -313,7 +335,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -323,7 +346,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -352,7 +376,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -362,7 +387,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -372,7 +398,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -382,7 +409,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -392,7 +420,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -402,7 +431,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -431,7 +461,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -441,7 +472,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -451,7 +483,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -461,7 +494,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -471,7 +505,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -481,7 +516,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -2,6 +2,7 @@ import { GraphQLResult, GRAPHQL_AUTH_MODE } from "@aws-amplify/api"
 import { Amplify, API, graphqlOperation } from "aws-amplify"
 import awsconfig from "./aws-exports"
 import {
+    ConfidenceLevel,
     CreateTeamAnswerInput, CreateTeamAnswerMutation,
     CreateTeamAnswerMutationVariables, CreateTeamInput,
     CreateTeamMemberInput,
@@ -307,6 +308,7 @@ export class ApiClient implements IApiClient {
             isTrickAnswer,
             text,
             teamMemberAnswersId: teamMemberId,
+            confidenceLevel: ConfidenceLevel.NOT_RATED
         }
         const variables: CreateTeamAnswerMutationVariables = { input }
         const answer = await this.callGraphQL<CreateTeamAnswerMutation>(
@@ -504,6 +506,7 @@ type AWSTeamAnswer = {
     createdAt?: string
     updatedAt?: string
     teamMemberAnswersId?: string | null
+    confidenceLevel: ConfidenceLevel
 }
 
 export class GameSessionParser {
@@ -830,6 +833,7 @@ class TeamAnswerParser {
             createdAt,
             updatedAt,
             teamMemberAnswersId,
+            confidenceLevel
         } = awsTeamAnswer || {}
 
         if (isNullOrUndefined(id) ||
@@ -850,6 +854,7 @@ class TeamAnswerParser {
             createdAt,
             updatedAt,
             teamMemberAnswersId,
+            confidenceLevel
         }
         return teamAnswer
     }

--- a/networking/src/Models/ITeamAnswer.ts
+++ b/networking/src/Models/ITeamAnswer.ts
@@ -1,3 +1,4 @@
+import { ConfidenceLevel } from "../AWSMobileApi";
 
 export interface ITeamAnswer {
     id: string,
@@ -8,4 +9,5 @@ export interface ITeamAnswer {
     updatedAt?: string
     teamMemberAnswersId?: string | null
     isTrickAnswer: boolean
+    confidenceLevel: ConfidenceLevel
 }

--- a/play/src/mock/MockGameSession.json
+++ b/play/src/mock/MockGameSession.json
@@ -36,7 +36,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -46,7 +47,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -56,7 +58,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -66,7 +69,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -76,7 +80,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -86,7 +91,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad8663956b",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -115,7 +121,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -125,7 +132,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -135,7 +143,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -145,7 +154,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -155,7 +165,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -165,7 +176,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -194,7 +206,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -204,7 +217,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -214,7 +228,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -224,7 +239,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -234,7 +250,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -244,7 +261,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -273,7 +291,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -283,7 +302,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -293,7 +313,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -303,7 +324,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -313,7 +335,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -323,7 +346,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -352,7 +376,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -362,7 +387,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -372,7 +398,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -382,7 +409,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -392,7 +420,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -402,7 +431,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }
@@ -431,7 +461,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "90%",
-                    "updatedAt": "2023-03-07T17:16:24.160Z"
+                    "updatedAt": "2023-03-07T17:16:24.160Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:39.668Z",
@@ -441,7 +472,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "70%",
-                    "updatedAt": "2023-03-07T17:15:39.668Z"
+                    "updatedAt": "2023-03-07T17:15:39.668Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:14.624Z",
@@ -451,7 +483,8 @@
                     "questionId": 4786,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "72%",
-                    "updatedAt": "2023-03-07T17:16:14.624Z"
+                    "updatedAt": "2023-03-07T17:16:14.624Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:29.282Z",
@@ -461,7 +494,8 @@
                     "questionId": 4790,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "50%",
-                    "updatedAt": "2023-03-07T17:15:29.282Z"
+                    "updatedAt": "2023-03-07T17:15:29.282Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:16:04.347Z",
@@ -471,7 +505,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:16:04.347Z"
+                    "updatedAt": "2023-03-07T17:16:04.347Z",
+                    "confidenceLevel": "NOT_RATED"
                   },
                   {
                     "createdAt": "2023-03-07T17:15:51.121Z",
@@ -481,7 +516,8 @@
                     "questionId": 4789,
                     "teamMemberAnswersId": "2e5c0366-7565-4b71-a191-42ad86sdfasdfasd",
                     "text": "54%",
-                    "updatedAt": "2023-03-07T17:15:51.121Z"
+                    "updatedAt": "2023-03-07T17:15:51.121Z",
+                    "confidenceLevel": "NOT_RATED"
                   }
                 ]
               }


### PR DESCRIPTION
**Issue:**

This PR updates the `networking` layer to reflect the changes in https://github.com/rightoneducation/righton-app/pull/751, namely the addition of the `confidenceLevel` field to `teamAnswers` as well as `ConfidenceLevel` enum to `ITeamAnswer`
