### PR TITLE
[Host] - Real Time Responses Graph - Open Ended Response Mode#798

### DIFF
--- a/host/build-storybook.log
+++ b/host/build-storybook.log
@@ -1,0 +1,533 @@
+warning ../../../../package.json: No license field
+$ storybook build -s public --output-dir /var/folders/sj/td3pyjhj1k90_kym21brg8gc0000gn/T/chromatic--42860-IvSAG67QuU4r
+@storybook/cli v7.0.27
+
+info => Cleaning outputDir: /var/folders/sj/td3pyjhj1k90_kym21brg8gc0000gn/T/chromatic--42860-IvSAG67QuU4r
+info => Loading presets
+WARN Could not resolve addon "@chromaui/storybook-addon", skipping. Is it installed?
+WARN Could not resolve addon "@chromaui/storybook-addon", skipping. Is it installed?
+info => Building manager..
+info => Manager built (929 ms)
+info => Compiling preview..
+info => Copying static files: ./public => ./
+info => Copying static files: /Users/josephinaim/Downloads/RightOn/righton-app/host/node_modules/@storybook/manager/static at /var/folders/sj/td3pyjhj1k90_kym21brg8gc0000gn/T/chromatic--42860-IvSAG67QuU4r/sb-common-assets
+info Addon-docs: using MDX2
+info => Loading Webpack configuration from `node_modules/react-scripts`
+info => Removing existing JavaScript and TypeScript rules.
+info => Modifying Create React App rules.
+info => Using default Webpack5 setup
+<s> [webpack.Progress] 0% 
+
+<s> [webpack.Progress] 1% setup before run
+<s> [webpack.Progress] 1% setup before run NodeEnvironmentPlugin
+<s> [webpack.Progress] 1% setup before run
+<s> [webpack.Progress] 2% setup run
+<s> [webpack.Progress] 2% setup run ForkTsCheckerWebpackPlugin
+<s> [webpack.Progress] 2% setup run ESLintWebpackPlugin_1
+<s> [webpack.Progress] 2% setup run
+<s> [webpack.Progress] 4% setup normal module factory
+<s> [webpack.Progress] 4% setup normal module factory CaseSensitivePathsPlugin
+<s> [webpack.Progress] 4% setup normal module factory ModuleNotFoundPlugin
+<s> [webpack.Progress] 4% setup normal module factory IgnorePlugin
+<s> [webpack.Progress] 4% setup normal module factory
+<s> [webpack.Progress] 5% setup context module factory
+<s> [webpack.Progress] 5% setup context module factory IgnorePlugin
+<s> [webpack.Progress] 5% setup context module factory
+<s> [webpack.Progress] 6% setup before compile
+<s> [webpack.Progress] 6% setup before compile ProgressPlugin
+<s> [webpack.Progress] 6% setup before compile
+<s> [webpack.Progress] 7% setup compile
+<s> [webpack.Progress] 7% setup compile ExternalsPlugin
+<s> [webpack.Progress] 7% setup compile ExternalsPlugin
+<s> [webpack.Progress] 7% setup compile
+<s> [webpack.Progress] 8% setup compilation
+<s> [webpack.Progress] 8% setup compilation unplugin-csf
+<s> [webpack.Progress] 8% setup compilation mini-css-extract-plugin
+<s> [webpack.Progress] 8% setup compilation ArrayPushCallbackChunkFormatPlugin
+<s> [webpack.Progress] 8% setup compilation JsonpChunkLoadingPlugin
+<s> [webpack.Progress] 8% setup compilation StartupChunkDependenciesPlugin
+<s> [webpack.Progress] 8% setup compilation ImportScriptsChunkLoadingPlugin
+<s> [webpack.Progress] 8% setup compilation FetchCompileWasmPlugin
+<s> [webpack.Progress] 8% setup compilation FetchCompileAsyncWasmPlugin
+<s> [webpack.Progress] 8% setup compilation WorkerPlugin
+<s> [webpack.Progress] 8% setup compilation SplitChunksPlugin
+<s> [webpack.Progress] 8% setup compilation RuntimeChunkPlugin
+<s> [webpack.Progress] 8% setup compilation ResolverCachePlugin
+<s> [webpack.Progress] 8% setup compilation HtmlWebpackPlugin
+<s> [webpack.Progress] 8% setup compilation
+<s> [webpack.Progress] 9% setup compilation
+<s> [webpack.Progress] 9% setup compilation DefinePlugin
+<s> [webpack.Progress] 9% setup compilation ProvidePlugin
+<s> [webpack.Progress] 9% setup compilation ProgressPlugin
+<s> [webpack.Progress] 9% setup compilation InlineChunkHtmlPlugin
+<s> [webpack.Progress] 9% setup compilation InterpolateHtmlPlugin
+<s> [webpack.Progress] 9% setup compilation mini-css-extract-plugin
+<s> [webpack.Progress] 9% setup compilation ForkTsCheckerWebpackPlugin
+<s> [webpack.Progress] 9% setup compilation DocGenPlugin
+<s> [webpack.Progress] 9% setup compilation ChunkPrefetchPreloadPlugin
+<s> [webpack.Progress] 9% setup compilation SourceMapDevToolPlugin
+<s> [webpack.Progress] 9% setup compilation JavascriptModulesPlugin
+<s> [webpack.Progress] 9% setup compilation JsonModulesPlugin
+<s> [webpack.Progress] 9% setup compilation AssetModulesPlugin
+<s> [webpack.Progress] 9% setup compilation EntryPlugin
+<s> [webpack.Progress] 9% setup compilation RuntimePlugin
+<s> [webpack.Progress] 9% setup compilation InferAsyncModulesPlugin
+<s> [webpack.Progress] 9% setup compilation DataUriPlugin
+<s> [webpack.Progress] 9% setup compilation FileUriPlugin
+<s> [webpack.Progress] 9% setup compilation CompatibilityPlugin
+<s> [webpack.Progress] 9% setup compilation HarmonyModulesPlugin
+<s> [webpack.Progress] 9% setup compilation AMDPlugin
+<s> [webpack.Progress] 9% setup compilation RequireJsStuffPlugin
+<s> [webpack.Progress] 9% setup compilation CommonJsPlugin
+<s> [webpack.Progress] 9% setup compilation LoaderPlugin
+<s> [webpack.Progress] 9% setup compilation LoaderPlugin
+<s> [webpack.Progress] 9% setup compilation NodeStuffPlugin
+<s> [webpack.Progress] 9% setup compilation APIPlugin
+<s> [webpack.Progress] 9% setup compilation ExportsInfoApiPlugin
+<s> [webpack.Progress] 9% setup compilation WebpackIsIncludedPlugin
+<s> [webpack.Progress] 9% setup compilation ConstPlugin
+<s> [webpack.Progress] 9% setup compilation UseStrictPlugin
+<s> [webpack.Progress] 9% setup compilation RequireIncludePlugin
+<s> [webpack.Progress] 9% setup compilation RequireEnsurePlugin
+<s> [webpack.Progress] 9% setup compilation RequireContextPlugin
+<s> [webpack.Progress] 9% setup compilation ImportPlugin
+<s> [webpack.Progress] 9% setup compilation ImportMetaContextPlugin
+<s> [webpack.Progress] 9% setup compilation SystemPlugin
+<s> [webpack.Progress] 9% setup compilation ImportMetaPlugin
+<s> [webpack.Progress] 9% setup compilation URLPlugin
+<s> [webpack.Progress] 9% setup compilation DefaultStatsFactoryPlugin
+<s> [webpack.Progress] 9% setup compilation DefaultStatsPresetPlugin
+<s> [webpack.Progress] 9% setup compilation DefaultStatsPrinterPlugin
+<s> [webpack.Progress] 9% setup compilation JavascriptMetaInfoPlugin
+<s> [webpack.Progress] 9% setup compilation EnsureChunkConditionsPlugin
+<s> [webpack.Progress] 9% setup compilation RemoveEmptyChunksPlugin
+<s> [webpack.Progress] 9% setup compilation MergeDuplicateChunksPlugin
+<s> [webpack.Progress] 9% setup compilation FlagIncludedChunksPlugin
+<s> [webpack.Progress] 9% setup compilation SideEffectsFlagPlugin
+<s> [webpack.Progress] 9% setup compilation FlagDependencyExportsPlugin
+<s> [webpack.Progress] 9% setup compilation FlagDependencyUsagePlugin
+<s> [webpack.Progress] 9% setup compilation InnerGraphPlugin
+<s> [webpack.Progress] 9% setup compilation MangleExportsPlugin
+<s> [webpack.Progress] 9% setup compilation ModuleConcatenationPlugin
+<s> [webpack.Progress] 9% setup compilation NoEmitOnErrorsPlugin
+<s> [webpack.Progress] 9% setup compilation RealContentHashPlugin
+<s> [webpack.Progress] 9% setup compilation WasmFinalizeExportsPlugin
+<s> [webpack.Progress] 9% setup compilation NamedModuleIdsPlugin
+<s> [webpack.Progress] 9% setup compilation DeterministicChunkIdsPlugin
+<s> [webpack.Progress] 9% setup compilation DefinePlugin
+<s> [webpack.Progress] 9% setup compilation TerserPlugin
+<s> [webpack.Progress] 9% setup compilation TemplatedPathPlugin
+<s> [webpack.Progress] 9% setup compilation RecordIdsPlugin
+<s> [webpack.Progress] 9% setup compilation WarnCaseSensitiveModulesPlugin
+<s> [webpack.Progress] 9% setup compilation IgnoreWarningsPlugin
+<s> [webpack.Progress] 9% setup compilation ESLintWebpackPlugin_1
+<s> [webpack.Progress] 9% setup compilation
+<s> [webpack.Progress] 10% building
+<s> [webpack.Progress] 10% building 0/1 entries 0/0 dependencies 0/0 modules
+<s> [webpack.Progress] 10% building 0/1 entries 1/1 dependencies 0/0 modules
+<s> [webpack.Progress] 10% building 0/1 entries 7/29 dependencies 3/6 modules
+<s> [webpack.Progress] 10% building import loader ./node_modules/react-scripts/node_modules/babel-loader/lib/index.js
+<s> [webpack.Progress] 10% building import loader ./node_modules/source-map-loader/dist/cjs.js
+<s> [webpack.Progress] 10% building 0/1 entries 16/30 dependencies 3/16 modules
+<s> [webpack.Progress] 10% building 0/1 entries 19/39 dependencies 3/17 modules
+<s> [webpack.Progress] 10% building import loader ./node_modules/unplugin/dist/webpack/loaders/load.js
+<s> [webpack.Progress] 10% building 0/1 entries 35/45 dependencies 4/28 modules
+<s> [webpack.Progress] 11% building 0/1 entries 44/67 dependencies 9/31 modules
+<s> [webpack.Progress] 11% building 0/1 entries 68/121 dependencies 9/43 modules
+<s> [webpack.Progress] 16% building 0/1 entries 147/199 dependencies 35/74 modules
+<s> [webpack.Progress] 18% building 0/1 entries 207/400 dependencies 44/104 modules
+<s> [webpack.Progress] 19% building 0/1 entries 300/421 dependencies 46/171 modules
+<s> [webpack.Progress] 19% building 0/1 entries 400/540 dependencies 48/237 modules
+<s> [webpack.Progress] 16% building 0/1 entries 583/601 dependencies 49/415 modules
+<s> [webpack.Progress] 18% building 0/1 entries 618/800 dependencies 68/432 modules
+<s> [webpack.Progress] 15% building 0/1 entries 1000/6345 dependencies 74/770 modules
+<s> [webpack.Progress] 13% building 0/1 entries 1400/6345 dependencies 74/1166 modules
+<s> [webpack.Progress] 12% building 0/1 entries 2000/6345 dependencies 74/1766 modules
+<s> [webpack.Progress] 11% building 0/1 entries 2500/6345 dependencies 74/2266 modules
+<s> [webpack.Progress] 11% building 0/1 entries 3100/6345 dependencies 74/2866 modules
+<s> [webpack.Progress] 11% building 0/1 entries 3700/6345 dependencies 74/3466 modules
+<s> [webpack.Progress] 11% building 0/1 entries 4233/6345 dependencies 74/4000 modules
+<s> [webpack.Progress] 10% building 0/1 entries 4733/6345 dependencies 74/4500 modules
+<s> [webpack.Progress] 10% building 0/1 entries 4933/6345 dependencies 74/4700 modules
+<s> [webpack.Progress] 10% building 0/1 entries 5300/6345 dependencies 74/5066 modules
+<s> [webpack.Progress] 10% building 0/1 entries 5800/6345 dependencies 74/5566 modules
+<s> [webpack.Progress] 10% building 0/1 entries 6340/6400 dependencies 77/6073 modules
+<s> [webpack.Progress] 11% building 0/1 entries 6600/6714 dependencies 112/6126 modules
+<s> [webpack.Progress] 11% building 0/1 entries 6727/7000 dependencies 127/6142 modules
+<s> [webpack.Progress] 11% building 0/1 entries 7063/7100 dependencies 132/6192 modules
+<s> [webpack.Progress] 11% building 0/1 entries 7300/7497 dependencies 163/6204 modules
+<s> [webpack.Progress] 11% building 0/1 entries 7739/7800 dependencies 163/6294 modules
+<s> [webpack.Progress] 11% building 0/1 entries 8140/8200 dependencies 165/6311 modules
+<s> [webpack.Progress] 11% building 0/1 entries 8499/8600 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 8920/9000 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 9294/9300 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 9704/9800 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 10100/10154 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 10494/10500 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 10894/10900 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 11094/11100 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 11495/11500 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 11694/11700 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 12116/12200 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 12600/12694 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 13126/13200 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 13400/13494 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 13942/14000 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 14514/14600 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 14970/15000 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 15553/15600 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 16129/16200 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 16716/16800 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 17294/17300 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 17894/17900 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building import loader ./node_modules/@svgr/webpack/lib/index.js
+<s> [webpack.Progress] 11% building import loader ./node_modules/file-loader/dist/cjs.js
+<s> [webpack.Progress] 11% building 0/1 entries 18494/18494 dependencies 197/6322 modules
+<s> [webpack.Progress] 11% building 0/1 entries 18550/18600 dependencies 197/6322 modules
+<s> [webpack.Progress] 12% building 0/1 entries 19063/19169 dependencies 300/6349 modules
+<s> [webpack.Progress] 13% building 0/1 entries 19196/19300 dependencies 356/6380 modules
+<s> [webpack.Progress] 13% building 0/1 entries 19421/19500 dependencies 390/6465 modules
+<s> [webpack.Progress] 14% building 0/1 entries 19495/19541 dependencies 500/6468 modules
+<s> [webpack.Progress] 61% building 0/1 entries 19700/19903 dependencies 6094/6525 modules
+<s> [webpack.Progress] 61% building 0/1 entries 20113/20200 dependencies 6149/6599 modules
+<s> [webpack.Progress] 61% building 0/1 entries 20500/20584 dependencies 6251/6671 modules
+<s> [webpack.Progress] 61% building 0/1 entries 20879/20930 dependencies 6400/6776 modules
+<s> [webpack.Progress] 62% building 0/1 entries 21076/21200 dependencies 6551/6846 modules
+<s> [webpack.Progress] 61% building 0/1 entries 21541/21600 dependencies 6660/7106 modules
+<s> [webpack.Progress] 62% building 0/1 entries 21799/21900 dependencies 6827/7168 modules
+<s> [webpack.Progress] 62% building 0/1 entries 22055/22100 dependencies 6957/7233 modules
+<s> [webpack.Progress] 61% building 0/1 entries 22362/22400 dependencies 7016/7458 modules
+<s> [webpack.Progress] 60% building 0/1 entries 22767/22924 dependencies 7073/7700 modules
+<s> [webpack.Progress] 60% building 0/1 entries 22882/23200 dependencies 7073/7724 modules
+<s> [webpack.Progress] 59% building 0/1 entries 23424/23500 dependencies 7098/7956 modules
+<s> [webpack.Progress] 59% building 0/1 entries 23870/24173 dependencies 7133/8000 modules
+<s> [webpack.Progress] 58% building 0/1 entries 24400/24484 dependencies 7151/8091 modules
+<s> [webpack.Progress] 58% building 0/1 entries 24660/24800 dependencies 7157/8103 modules
+<s> [webpack.Progress] 58% building 0/1 entries 24984/25100 dependencies 7195/8147 modules
+<s> [webpack.Progress] 57% building 0/1 entries 25300/25549 dependencies 7202/8272 modules
+<s> [webpack.Progress] 57% building 0/1 entries 25632/25800 dependencies 7203/8287 modules
+<s> [webpack.Progress] 57% building 0/1 entries 26000/26077 dependencies 7218/8295 modules
+<s> [webpack.Progress] 57% building 0/1 entries 26300/26334 dependencies 7289/8393 modules
+<s> [webpack.Progress] 58% building 0/1 entries 26381/26490 dependencies 7345/8400 modules
+<s> [webpack.Progress] 57% building 0/1 entries 26448/26500 dependencies 7357/8451 modules
+<s> [webpack.Progress] 58% building 0/1 entries 26600/26622 dependencies 7437/8493 modules
+<s> [webpack.Progress] 58% building 0/1 entries 26698/26800 dependencies 7489/8516 modules
+<s> [webpack.Progress] 58% building 0/1 entries 26731/26830 dependencies 7500/8522 modules
+<s> [webpack.Progress] 58% building 0/1 entries 26800/26874 dependencies 7556/8554 modules
+<s> [webpack.Progress] 58% building 0/1 entries 26814/26900 dependencies 7574/8560 modules
+<s> [webpack.Progress] 59% building 0/1 entries 27073/27100 dependencies 7716/8604 modules
+<s> [webpack.Progress] 59% building 0/1 entries 27300/27324 dependencies 7798/8609 modules
+<s> [webpack.Progress] 60% building 0/1 entries 27471/27495 dependencies 7910/8700 modules
+<s> [webpack.Progress] 60% building 0/1 entries 27700/27753 dependencies 8107/8788 modules
+<s> [webpack.Progress] 63% building 0/1 entries 27845/27900 dependencies 8557/8852 modules
+<s> [webpack.Progress] 65% building 1/1 entries 27984/27984 dependencies 8911/8911 modules
+<s> [webpack.Progress] 65% building
+<s> [webpack.Progress] 69% building finish
+<s> [webpack.Progress] 69% building finish
+<s> [webpack.Progress] 70% sealing finish module graph
+<s> [webpack.Progress] 70% sealing finish module graph ResolverCachePlugin
+<s> [webpack.Progress] 70% sealing finish module graph InferAsyncModulesPlugin
+<s> [webpack.Progress] 70% sealing finish module graph FlagDependencyExportsPlugin
+<s> [webpack.Progress] 70% sealing finish module graph InnerGraphPlugin
+<s> [webpack.Progress] 70% sealing finish module graph WasmFinalizeExportsPlugin
+<s> [webpack.Progress] 70% sealing finish module graph ESLintWebpackPlugin_1
+<s> [webpack.Progress] 70% sealing finish module graph
+<s> [webpack.Progress] 70% sealing plugins
+<s> [webpack.Progress] 70% sealing plugins DocGenPlugin
+<s> [webpack.Progress] 70% sealing plugins WarnCaseSensitiveModulesPlugin
+<s> [webpack.Progress] 70% sealing plugins
+<s> [webpack.Progress] 71% sealing dependencies optimization
+<s> [webpack.Progress] 71% sealing dependencies optimization SideEffectsFlagPlugin
+<s> [webpack.Progress] 71% sealing dependencies optimization FlagDependencyUsagePlugin
+<s> [webpack.Progress] 71% sealing dependencies optimization
+<s> [webpack.Progress] 71% sealing after dependencies optimization
+<s> [webpack.Progress] 71% sealing after dependencies optimization
+<s> [webpack.Progress] 72% sealing chunk graph
+<s> [webpack.Progress] 72% sealing chunk graph
+<s> [webpack.Progress] 73% sealing after chunk graph
+<s> [webpack.Progress] 73% sealing after chunk graph
+<s> [webpack.Progress] 73% sealing optimizing
+<s> [webpack.Progress] 73% sealing optimizing
+<s> [webpack.Progress] 74% sealing module optimization
+<s> [webpack.Progress] 74% sealing module optimization
+<s> [webpack.Progress] 75% sealing after module optimization
+<s> [webpack.Progress] 75% sealing after module optimization
+<s> [webpack.Progress] 75% sealing chunk optimization
+<s> [webpack.Progress] 75% sealing chunk optimization EnsureChunkConditionsPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization RemoveEmptyChunksPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization MergeDuplicateChunksPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization SplitChunksPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization RemoveEmptyChunksPlugin
+<s> [webpack.Progress] 75% sealing chunk optimization
+<s> [webpack.Progress] 76% sealing after chunk optimization
+<s> [webpack.Progress] 76% sealing after chunk optimization
+<s> [webpack.Progress] 77% sealing module and chunk tree optimization
+<s> [webpack.Progress] 77% sealing module and chunk tree optimization PersistentChildCompilerSingletonPlugin
+<s> [webpack.Progress] 77% sealing module and chunk tree optimization
+<s> [webpack.Progress] 77% sealing after module and chunk tree optimization
+<s> [webpack.Progress] 77% sealing after module and chunk tree optimization
+<s> [webpack.Progress] 78% sealing chunk modules optimization
+<s> [webpack.Progress] 78% sealing chunk modules optimization ModuleConcatenationPlugin
+<s> [webpack.Progress] 78% sealing chunk modules optimization
+<s> [webpack.Progress] 78% sealing after chunk modules optimization
+<s> [webpack.Progress] 78% sealing after chunk modules optimization
+<s> [webpack.Progress] 79% sealing module reviving
+<s> [webpack.Progress] 79% sealing module reviving RecordIdsPlugin
+<s> [webpack.Progress] 79% sealing module reviving
+<s> [webpack.Progress] 80% sealing before module ids
+<s> [webpack.Progress] 80% sealing before module ids
+<s> [webpack.Progress] 80% sealing module ids
+<s> [webpack.Progress] 80% sealing module ids NamedModuleIdsPlugin
+<s> [webpack.Progress] 80% sealing module ids
+<s> [webpack.Progress] 81% sealing module id optimization
+<s> [webpack.Progress] 81% sealing module id optimization
+<s> [webpack.Progress] 82% sealing module id optimization
+<s> [webpack.Progress] 82% sealing module id optimization
+<s> [webpack.Progress] 82% sealing chunk reviving
+<s> [webpack.Progress] 82% sealing chunk reviving RecordIdsPlugin
+<s> [webpack.Progress] 82% sealing chunk reviving
+<s> [webpack.Progress] 83% sealing before chunk ids
+<s> [webpack.Progress] 83% sealing before chunk ids
+<s> [webpack.Progress] 84% sealing chunk ids
+<s> [webpack.Progress] 84% sealing chunk ids DeterministicChunkIdsPlugin
+<s> [webpack.Progress] 84% sealing chunk ids
+<s> [webpack.Progress] 84% sealing chunk id optimization
+<s> [webpack.Progress] 84% sealing chunk id optimization FlagIncludedChunksPlugin
+<s> [webpack.Progress] 84% sealing chunk id optimization
+<s> [webpack.Progress] 85% sealing after chunk id optimization
+<s> [webpack.Progress] 85% sealing after chunk id optimization
+<s> [webpack.Progress] 86% sealing record modules
+<s> [webpack.Progress] 86% sealing record modules RecordIdsPlugin
+<s> [webpack.Progress] 86% sealing record modules
+<s> [webpack.Progress] 86% sealing record chunks
+<s> [webpack.Progress] 86% sealing record chunks RecordIdsPlugin
+<s> [webpack.Progress] 86% sealing record chunks
+<s> [webpack.Progress] 87% sealing module hashing
+<s> [webpack.Progress] 87% sealing module hashing
+<s> [webpack.Progress] 87% sealing code generation
+<s> [webpack.Progress] 87% sealing code generation
+<s> [webpack.Progress] 88% sealing runtime requirements
+<s> [webpack.Progress] 88% sealing runtime requirements
+<s> [webpack.Progress] 89% sealing hashing
+<s> [webpack.Progress] 89% sealing hashing
+<s> [webpack.Progress] 89% sealing after hashing
+<s> [webpack.Progress] 89% sealing after hashing
+<s> [webpack.Progress] 90% sealing record hash
+<s> [webpack.Progress] 90% sealing record hash
+<s> [webpack.Progress] 91% sealing module assets processing
+<s> [webpack.Progress] 91% sealing module assets processing
+<s> [webpack.Progress] 91% sealing chunk assets processing
+<s> [webpack.Progress] 91% sealing chunk assets processing
+<s> [webpack.Progress] 92% sealing asset processing
+<s> [webpack.Progress] 92% sealing asset processing ESLintWebpackPlugin_1
+<s> [webpack.Progress] 92% sealing asset processing PersistentChildCompilerSingletonPlugin
+<s> [webpack.Progress] 92% sealing asset processing TerserPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin main.e5a5787f.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin main.e5a5787f.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin runtime~main.3a491057.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin runtime~main.3a491057.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin components-FooterGame-stories.43a20548.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin components-FooterGame-stories.43a20548.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin components-HeaderGame-stories.932117bc.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin components-HeaderGame-stories.932117bc.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin components-Responses-ResponsesGraph-stories.9d744829.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin components-Responses-ResponsesGraph-stories.9d744829.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin components-Timer-stories.9d360e3a.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin components-Timer-stories.9d360e3a.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin pages-GameInProgress-stories.3c5f1eff.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin pages-GameInProgress-stories.3c5f1eff.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin pages-StartGame-stories.1566f7b7.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin pages-StartGame-stories.1566f7b7.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 888.25d85bf9.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 888.25d85bf9.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 341.0a7d6530.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 341.0a7d6530.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 333.ff06a53e.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 333.ff06a53e.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 58.a9d0efd3.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 58.a9d0efd3.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 463.3f91ba11.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 463.3f91ba11.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 760.6e397b87.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 760.6e397b87.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 923.b8ca2978.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 923.b8ca2978.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 446.2e338062.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 446.2e338062.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 252.3c956f71.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 252.3c956f71.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 720.d99df275.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 720.d99df275.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 546.73acc117.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 546.73acc117.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 282.a8b01c4a.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 282.a8b01c4a.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 371.b88e0602.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 371.b88e0602.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 143.19a479c6.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 143.19a479c6.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 661.fc5c2310.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 661.fc5c2310.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 87.c4a5ca92.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 87.c4a5ca92.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 209.79038be7.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 209.79038be7.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 455.6b69ade3.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 455.6b69ade3.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 856.8be4ca04.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 856.8be4ca04.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin resolve sources
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 888.25d85bf9.iframe.bundle.js attach SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 888.25d85bf9.iframe.bundle.js attached SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 463.3f91ba11.iframe.bundle.js attach SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 463.3f91ba11.iframe.bundle.js attached SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 661.fc5c2310.iframe.bundle.js attach SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin 661.fc5c2310.iframe.bundle.js attached SourceMap
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin resolve sources
+<s> [webpack.Progress] 92% sealing asset processing SourceMapDevToolPlugin
+<s> [webpack.Progress] 92% sealing asset processing HtmlWebpackPlugin
+<s> [webpack.Progress] 92% sealing asset processing HtmlWebpackPlugin
+<s> [webpack.Progress] 92% sealing asset processing HtmlWebpackPlugin resolve sources
+<s> [webpack.Progress] 92% sealing asset processing HtmlWebpackPlugin
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin main.5ca1731a.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin main.5ca1731a.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin runtime~main.8e6d1163.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin runtime~main.8e6d1163.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin components-FooterGame-stories.c81c0a55.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin components-FooterGame-stories.c81c0a55.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin components-HeaderGame-stories.692a886e.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin components-HeaderGame-stories.692a886e.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin components-Responses-ResponsesGraph-stories.3d403fc2.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin components-Responses-ResponsesGraph-stories.3d403fc2.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin components-Timer-stories.a012a90a.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin components-Timer-stories.a012a90a.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin pages-GameInProgress-stories.774e0a04.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin pages-GameInProgress-stories.774e0a04.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin pages-StartGame-stories.b4f63947.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin pages-StartGame-stories.b4f63947.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 341.c85205cd.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 341.c85205cd.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 333.0712dd48.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 333.0712dd48.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 58.8f57a7f5.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 58.8f57a7f5.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 760.b5f8a63d.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 760.b5f8a63d.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 923.34e12eaa.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 923.34e12eaa.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 446.7a9763a9.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 446.7a9763a9.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 720.f400d1a9.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 720.f400d1a9.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 546.0cdd2004.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 546.0cdd2004.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 371.0fcfa657.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 371.0fcfa657.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 143.72b78d29.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 143.72b78d29.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 209.9a06c424.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 209.9a06c424.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 455.f4d80691.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 455.f4d80691.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 856.1ea9626f.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 856.1ea9626f.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 252.67d4b8ea.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 252.67d4b8ea.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 282.07ad8af7.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 282.07ad8af7.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 87.97c2328e.iframe.bundle.js generate SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin 87.97c2328e.iframe.bundle.js generated SourceMap
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin resolve sources
+<s> [webpack.Progress] 92% sealing asset processing RealContentHashPlugin
+<s> [webpack.Progress] 92% sealing asset processing
+<s> [webpack.Progress] 93% sealing after asset optimization
+<s> [webpack.Progress] 93% sealing after asset optimization
+<s> [webpack.Progress] 93% sealing recording
+<s> [webpack.Progress] 93% sealing recording
+<s> [webpack.Progress] 94% sealing after seal
+<s> [webpack.Progress] 94% sealing after seal
+<s> [webpack.Progress] 95% emitting emit
+<s> [webpack.Progress] 95% emitting emit
+<s> [webpack.Progress] 98% emitting after emit
+<s> [webpack.Progress] 98% emitting after emit SizeLimitsPlugin
+<s> [webpack.Progress] 98% emitting after emit
+<s> [webpack.Progress] 99% done plugins
+<s> [webpack.Progress] 99% done plugins CaseSensitivePathsPlugin
+<s> [webpack.Progress] 99% done plugins ForkTsCheckerWebpackPlugin
+<s> [webpack.Progress] 99% done plugins
+<s> [webpack.Progress] 99% 
+
+<s> [webpack.Progress] 99% cache store build dependencies
+<s> [webpack.Progress] 99% cache store build dependencies
+<s> [webpack.Progress] 99% cache begin idle
+<s> [webpack.Progress] 99% cache begin idle
+<s> [webpack.Progress] 100% 
+
+info => Preview built (2.22 min)
+WARN [eslint] 
+WARN src/components/FooterStartGame.jsx
+WARN   Line 3:40:  'Paper' is defined but never used  no-unused-vars
+WARN 
+WARN src/components/GameAnswers.jsx
+WARN   Line 6:10:   'getTeamAnswer' is defined but never used                         no-unused-vars
+WARN   Line 27:68:  Array.prototype.map() expects a return value from arrow function  array-callback-return
+WARN 
+WARN src/components/GameAnswersDropdown.jsx
+WARN   Line 153:3:  Duplicate key 'colorPrimary'     no-dupe-keys
+WARN   Line 157:3:  Duplicate key 'barColorPrimary'  no-dupe-keys
+WARN   Line 161:3:  Duplicate key 'expand'           no-dupe-keys
+WARN   Line 170:3:  Duplicate key 'expanded'         no-dupe-keys
+WARN 
+WARN src/components/GameCard.jsx
+WARN   Line 54:5:  Duplicate key 'lineHeight'  no-dupe-keys
+WARN   Line 68:5:  Duplicate key 'lineHeight'  no-dupe-keys
+WARN   Line 81:5:  Duplicate key 'lineHeight'  no-dupe-keys
+WARN   Line 82:5:  Duplicate key 'textAlign'   no-dupe-keys
+WARN 
+WARN src/components/HostHeader.jsx
+WARN   Line 4:8:  'ModeToggle' is defined but never used  no-unused-vars
+WARN   Line 5:8:  'ClearIcon' is defined but never used   no-unused-vars
+WARN 
+WARN src/components/LoadingIndicator.jsx
+WARN   Line 66:3:  React Hook useEffect contains a call to 'setTimerFinished'. Without a list of dependencies, this can lead to an infinite chain of updates. To fix this, pass [timeInterval, timerFinished, remainingTimeInSecond, colors, remainingSecondsInMilliSeconds, handleStartGameModalTimerFinished] as a second argument to the useEffect Hook  react-hooks/exhaustive-deps
+WARN 
+WARN src/components/Responses/CustomBar.jsx
+WARN   Line 15:10:  'x' is assigned a value but never used  no-unused-vars
+WARN 
+WARN src/components/Responses/ResponsesGraph.jsx
+WARN   Line 37:9:  'xLargePadding' is assigned a value but never used  no-unused-vars
+WARN 
+WARN src/pages/GameInProgress.jsx
+WARN   Line 10:47:   'getGameSession' is defined but never used               no-unused-vars
+WARN   Line 232:33:  'teamsPickedChoices' is assigned a value but never used  no-unused-vars
+WARN 
+WARN src/pages/StartGame.jsx
+WARN   Line 1:17:  'useEffect' is defined but never used  no-unused-vars
+WARN   Line 1:28:  'useState' is defined but never used   no-unused-vars
+WARN 
+WARN 
+WARN asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
+WARN This can impact web performance.
+WARN Assets: 
+WARN   371.0fcfa657.iframe.bundle.js (549 KiB)
+WARN   888.93d673c0.iframe.bundle.js (672 KiB)
+WARN   463.f4a88cd0.iframe.bundle.js (583 KiB)
+WARN   661.f0eedc1e.iframe.bundle.js (715 KiB)
+WARN entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
+WARN Entrypoints:
+WARN   main (728 KiB)
+WARN       runtime~main.8e6d1163.iframe.bundle.js
+WARN       661.f0eedc1e.iframe.bundle.js
+WARN       main.5ca1731a.iframe.bundle.js
+WARN 
+<s> [webpack.Progress] 99% cache shutdown
+<s> [webpack.Progress] 99% cache shutdown
+<s> [webpack.Progress] 100% 
+
+info => Output directory: /var/folders/sj/td3pyjhj1k90_kym21brg8gc0000gn/T/chromatic--42860-IvSAG67QuU4r

--- a/host/src/components/Responses/CustomBar.jsx
+++ b/host/src/components/Responses/CustomBar.jsx
@@ -15,6 +15,19 @@ const CustomBar = (props) => {
   const {x, y, xSmallPadding, mediumPadding, xxxLargePadding, selectedWidth, selectedHeight, datum, index, selectedBarIndex, setSelectedBarIndex} = props;
   const classes = useStyles();
   
+  const isSelected = selectedBarIndex === index;
+
+  // Toggle the selected state when the bar is clicked
+  const toggleSelection = () => {
+    if (isSelected) {
+      // If the bar is already selected, deselect it
+      setSelectedBarIndex(null);
+    } else {
+      // If the bar is not selected, select it
+      setSelectedBarIndex(index);
+    }
+  };
+
   return (
       <g  style={{pointerEvents: 'bounding-box'}}>
         <Bar {...props} />
@@ -29,7 +42,7 @@ const CustomBar = (props) => {
               stroke="transparent"
               rx={8}
               ry={8}
-              onClick={() => setSelectedBarIndex(index)}
+              onClick={toggleSelection}
               style={{cursor: 'pointer'}}
             />
         }

--- a/host/src/components/Responses/CustomBar.jsx
+++ b/host/src/components/Responses/CustomBar.jsx
@@ -9,21 +9,32 @@ const useStyles = makeStyles((selectedBarIndex, index) => ({
     }
   }
 }));
-const isOpenEnded = true;
 
 const CustomBar = (props) => {
-  const {x, y, xSmallPadding, mediumPadding, xxxLargePadding, selectedWidth, selectedHeight, datum, index, selectedBarIndex, setSelectedBarIndex} = props;
+  const {
+    x, 
+    y, 
+    xSmallPadding,
+    mediumPadding, 
+    xxxLargePadding, 
+    selectedWidth, 
+    selectedHeight, 
+    datum, 
+    index, 
+    selectedBarIndex, 
+    setSelectedBarIndex, 
+    isOpenEnded,
+    xxLargePadding,
+    xxxxLargePadding
+  } = props;
   const classes = useStyles();
   
   const isSelected = selectedBarIndex === index;
 
-  // Toggle the selected state when the bar is clicked
   const toggleSelection = () => {
     if (isSelected) {
-      // If the bar is already selected, deselect it
       setSelectedBarIndex(null);
     } else {
-      // If the bar is not selected, select it
       setSelectedBarIndex(index);
     }
   };
@@ -35,9 +46,9 @@ const CustomBar = (props) => {
           <rect
               className={classes.highlight}
               x={isOpenEnded ? 0 : xxxLargePadding}
-              y={isOpenEnded ? y-40 : y-mediumPadding}
+              y={isOpenEnded ? y-xxLargePadding : y-mediumPadding}
               width={selectedWidth}
-              height={isOpenEnded ? 56 : selectedHeight+mediumPadding-(xSmallPadding/2)}
+              height={isOpenEnded ? xxxxLargePadding : selectedHeight+mediumPadding-(xSmallPadding/2)}
               fill={selectedBarIndex === index ? "rgba(255, 255, 255, 0.2)" : "transparent"}
               stroke="transparent"
               rx={8}

--- a/host/src/components/Responses/CustomBar.jsx
+++ b/host/src/components/Responses/CustomBar.jsx
@@ -9,20 +9,22 @@ const useStyles = makeStyles((selectedBarIndex, index) => ({
     }
   }
 }));
+const isOpenEnded = true;
 
 const CustomBar = (props) => {
   const {x, y, xSmallPadding, mediumPadding, xxxLargePadding, selectedWidth, selectedHeight, datum, index, selectedBarIndex, setSelectedBarIndex} = props;
   const classes = useStyles();
+  
   return (
       <g  style={{pointerEvents: 'bounding-box'}}>
         <Bar {...props} />
         {datum.answerCount > 0 && 
           <rect
               className={classes.highlight}
-              x={xxxLargePadding}
-              y={y-mediumPadding}
+              x={isOpenEnded ? 0 : xxxLargePadding}
+              y={isOpenEnded ? y-40 : y-mediumPadding}
               width={selectedWidth}
-              height={selectedHeight+mediumPadding-(xSmallPadding/2)}
+              height={isOpenEnded ? 56 : selectedHeight+mediumPadding-(xSmallPadding/2)}
               fill={selectedBarIndex === index ? "rgba(255, 255, 255, 0.2)" : "transparent"}
               stroke="transparent"
               rx={8}

--- a/host/src/components/Responses/CustomLabel.jsx
+++ b/host/src/components/Responses/CustomLabel.jsx
@@ -5,13 +5,13 @@ import check from '../../images/Pickedcheck.svg';
 const isOpenEnded = true;
 
 const CustomLabel = (props) => {
-  const { x, y, datum, barThickness, labelOffset, xSmallPadding, mediumLargePadding, defaultVictoryPadding, noResponseLabel, index, reversedResponses, correctChoiceIndex } = props;
+  const { statePosition, x, y, datum, barThickness, labelOffset, xSmallPadding, mediumLargePadding, defaultVictoryPadding, noResponseLabel, index, reversedResponses, correctChoiceIndex } = props;
   const showCustomTick = index === reversedResponses.length - 1 - correctChoiceIndex;
   return (
     <g>
       {datum.answerCount !== 0 &&
         <>
-          {showCustomTick && (
+          {(showCustomTick && isOpenEnded && statePosition < 6) && (
             <foreignObject x={10} y={y-32} width={16} height={18}>
               <span>
               <img src={check} alt="correct answer"/>
@@ -21,10 +21,16 @@ const CustomLabel = (props) => {
           <VictoryLabel
             {...props}
             x={
-              isOpenEnded && showCustomTick ? 32 :
-              isOpenEnded ? 10 :
-              defaultVictoryPadding + xSmallPadding
-            }            
+              isOpenEnded
+                ? showCustomTick
+                  ? statePosition < 6
+                    ? 32
+                    : defaultVictoryPadding + xSmallPadding
+                  : statePosition < 6
+                  ? 10
+                  : defaultVictoryPadding + xSmallPadding
+                : defaultVictoryPadding + xSmallPadding
+            }                      
             y={y - labelOffset}
             dx={0}
             dy={(-barThickness / 2) - xSmallPadding}

--- a/host/src/components/Responses/CustomLabel.jsx
+++ b/host/src/components/Responses/CustomLabel.jsx
@@ -1,40 +1,57 @@
 import React from 'react';
 import { VictoryLabel } from 'victory';
+import check from '../../images/Pickedcheck.svg';
+
+const isOpenEnded = true;
 
 const CustomLabel = (props) => {
-  const { x, y, datum, barThickness,labelOffset, xSmallPadding, mediumLargePadding, defaultVictoryPadding, noResponseLabel } = props;
+  const { x, y, datum, barThickness, labelOffset, xSmallPadding, mediumLargePadding, defaultVictoryPadding, noResponseLabel, index, reversedResponses, correctChoiceIndex } = props;
+  const showCustomTick = index === reversedResponses.length - 1 - correctChoiceIndex;
   return (
-      <g>
-        {datum.answerCount !== 0 && 
-          <VictoryLabel 
+    <g>
+      {datum.answerCount !== 0 &&
+        <>
+          {showCustomTick && (
+            <foreignObject x={10} y={y-32} width={16} height={18}>
+              <span>
+              <img src={check} alt="correct answer"/>
+            </span>
+            </foreignObject>
+          )}
+          <VictoryLabel
             {...props}
-            x={defaultVictoryPadding + xSmallPadding} 
+            x={
+              isOpenEnded && showCustomTick ? 32 :
+              isOpenEnded ? 10 :
+              defaultVictoryPadding + xSmallPadding
+            }            
             y={y - labelOffset}
             dx={0}
-            dy={(-barThickness/2) - xSmallPadding}
+            dy={(-barThickness / 2) - xSmallPadding}
             textAnchor="start"
             verticalAnchor="end"
             text={`${datum.answerText}`}
             style={{
               fontSize: 15,
               fill: 'white',
-            }} 
+            }}
           />
-        }
-        <VictoryLabel 
-          {...props}
-          x={x > 70 ? x - labelOffset : x + mediumLargePadding }
-          y={y}
-          textAnchor="end"
-          verticalAnchor="middle"
-          text={ datum.answerCount > 0 ? `${datum.answerCount}` : ''}
-          style={{
-            fontSize: 15,
-            fill: datum.answerCount === 0 || datum.answerChoice === noResponseLabel || x <= 70 ? '#FFF' : '#384466',
-          }} 
-        />
-   </g>
-    );
+        </>
+      }
+      <VictoryLabel
+        {...props}
+        x={x > 70 ? x - labelOffset : x + mediumLargePadding}
+        y={y}
+        textAnchor="end"
+        verticalAnchor="middle"
+        text={datum.answerCount > 0 ? `${datum.answerCount}` : ''}
+        style={{
+          fontSize: 15,
+          fill: datum.answerCount === 0 || datum.answerChoice === noResponseLabel || x <= 70 ? '#FFF' : '#384466',
+        }}
+      />
+    </g>
+  );
 };
 
 export default CustomLabel;

--- a/host/src/components/Responses/CustomLabel.jsx
+++ b/host/src/components/Responses/CustomLabel.jsx
@@ -2,17 +2,15 @@ import React from 'react';
 import { VictoryLabel } from 'victory';
 import check from '../../images/Pickedcheck.svg';
 
-const isOpenEnded = true;
-
 const CustomLabel = (props) => {
-  const { statePosition, x, y, datum, barThickness, labelOffset, xSmallPadding, mediumLargePadding, defaultVictoryPadding, noResponseLabel, index, reversedResponses, correctChoiceIndex } = props;
+  const { isOpenEnded, statePosition, x, y, datum, barThickness, labelOffset, xSmallPadding, mediumLargePadding, xLargePadding, defaultVictoryPadding, noResponseLabel, index, reversedResponses, correctChoiceIndex } = props;
   const showCustomTick = index === reversedResponses.length - 1 - correctChoiceIndex;
   return (
     <g>
       {datum.answerCount !== 0 &&
         <>
           {(showCustomTick && isOpenEnded && statePosition < 6) && (
-            <foreignObject x={10} y={y-32} width={16} height={18}>
+            <foreignObject x={10} y={y-xLargePadding} width={16} height={18}>
               <span>
               <img src={check} alt="correct answer"/>
             </span>
@@ -24,7 +22,7 @@ const CustomLabel = (props) => {
               isOpenEnded
                 ? showCustomTick
                   ? statePosition < 6
-                    ? 32
+                    ? xLargePadding
                     : defaultVictoryPadding + xSmallPadding
                   : statePosition < 6
                   ? 10

--- a/host/src/components/Responses/CustomTick.jsx
+++ b/host/src/components/Responses/CustomTick.jsx
@@ -4,7 +4,7 @@ import check from '../../images/Pickedcheck.svg';
 import noResponse from '../../images/noResponse.svg'
 import { Tooltip } from '@material-ui/core';
 
-const CustomTick = ({ x, y, index, text, reversedResponses, correctChoiceIndex, statePosition, mediumPadding, largePadding }) => {
+const CustomTick = ({ x, y, index, text, reversedResponses, correctChoiceIndex, statePosition, mediumPadding, largePadding, isOpenEnded }) => {
   const showCustomTick = index === reversedResponses.length - 1 - correctChoiceIndex;
   const fillTick = statePosition === 6 && showCustomTick;
 
@@ -16,8 +16,6 @@ const CustomTick = ({ x, y, index, text, reversedResponses, correctChoiceIndex, 
     fontWeight: '800',
     fontSize: '16px',
   };
-
-  const isOpenEnded = true;
 
   return (
     <g>

--- a/host/src/components/Responses/CustomTick.jsx
+++ b/host/src/components/Responses/CustomTick.jsx
@@ -21,7 +21,7 @@ const CustomTick = ({ x, y, index, text, reversedResponses, correctChoiceIndex, 
 
   return (
     <g>
-      {!isOpenEnded && (
+      {isOpenEnded && (
         <>
           {showCustomTick && (
             <foreignObject x={x - largePadding} y={y - largePadding / 2.5} width={16} height={18}>

--- a/host/src/components/Responses/CustomTick.jsx
+++ b/host/src/components/Responses/CustomTick.jsx
@@ -17,29 +17,35 @@ const CustomTick = ({ x, y, index, text, reversedResponses, correctChoiceIndex, 
     fontSize: '16px',
   };
 
+  const isOpenEnded = true;
 
   return (
     <g>
-      {showCustomTick && (
-        <foreignObject x={x - largePadding} y={y - largePadding / 2.5} width={16} height={18}>
-          <Tooltip title="This is the correct answer" placement="top" >
-            <span>
-              <img src={check} alt="correct answer" />
-            </span>
-          </Tooltip>
-        </foreignObject>
+      {!isOpenEnded && (
+        <>
+          {showCustomTick && (
+            <foreignObject x={x - largePadding} y={y - largePadding / 2.5} width={16} height={18}>
+              <Tooltip title="This is the correct answer" placement="top">
+                <span>
+                  <img src={check} alt="correct answer" />
+                </span>
+              </Tooltip>
+            </foreignObject>
+          )}
+          {isNoResponse ? (
+            <foreignObject x={x - 1} y={y - mediumPadding} width={16} height={32}>
+              <Tooltip title="Players who have not responded" placement="top">
+                <span>
+                  <img src={noResponse} alt="no response" />
+                </span>
+              </Tooltip>
+            </foreignObject>
+          ) : (
+            <VictoryLabel x={x} y={y} text={text} style={commonStyle} />
+          )}
+        </>
       )}
-        {isNoResponse ? (
-          <foreignObject x={x-1} y={y - mediumPadding} width={16} height={32}>
-            <Tooltip title="Players who have not responded" placement="top">
-              <span>
-                <img src={noResponse} alt="no response"/>
-              </span>
-            </Tooltip>
-          </foreignObject>
-        ) : (
-          <VictoryLabel x={x} y={y} text={text} style={commonStyle} />
-        )}
+
     </g>
   );
 };

--- a/host/src/components/Responses/Responses.jsx
+++ b/host/src/components/Responses/Responses.jsx
@@ -29,7 +29,7 @@ export default function Responses({ questions, teams, studentResponses, numPlaye
 
   return (
     <Grid className={classes.centerContent}>
-        <Typography className={classes.titleStyle}>Real-time Responses</Typography>
+        <Typography className={classes.titleStyle}>Responses</Typography>
         <ResponsesGraph questions={questions} teams={teams} studentResponses={studentResponses} numPlayers={numPlayers} totalAnswers={totalAnswers} questionChoices={questionChoices} statePosition={statePosition} teamsPickedChoices={teamsPickedChoices}/>
     </Grid>
   );

--- a/host/src/components/Responses/ResponsesGraph.jsx
+++ b/host/src/components/Responses/ResponsesGraph.jsx
@@ -23,6 +23,8 @@ const useStyles = makeStyles({
 });
 
 const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalAnswers, questionChoices, statePosition, teamsPickedChoices }) => {
+  const isOpenEnded = true;
+
   const [boundingRect, setBoundingRect] = useState({ width: 0, height: 0 });
   const graphRef = useRef(null);
   const barThickness = 18;
@@ -134,17 +136,19 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
       </div>
       <div ref={graphRef} >
         <VictoryChart
-          domainPadding={36}
-          padding={defaultVictoryPadding}
+          // domainPadding={!isOpenEnded ? 36 : 46}
+          domainPadding={0}
+          padding={!isOpenEnded ? {defaultVictoryPadding} : {top: defaultVictoryPadding, bottom: defaultVictoryPadding, left: smallPadding, right: smallPadding}}
           containerComponent={<VictoryContainer />}
           theme={customTheme}
           width={boundingRect.width}
-          height={400}
+          height={!isOpenEnded ? 400 : 390}
         >
           <VictoryAxis
             standalone={false}
             tickLabelComponent={
               <CustomTick mediumPadding={mediumPadding} largePadding={largePadding} reversedResponses={reversedResponses} correctChoiceIndex={correctChoiceIndex} statePosition={statePosition} />}
+              domain={[1,6]}
           />
           {largestAnswerCount < 5 && (
             <VictoryAxis
@@ -179,7 +183,7 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
                 xSmallPadding={xSmallPadding}
                 mediumPadding={mediumPadding}
                 xxxLargePadding={xxxLargePadding}
-                selectedWidth={boundingRect.width - (defaultVictoryPadding + xxLargePadding * 2)}
+                selectedWidth={isOpenEnded ? boundingRect.width : boundingRect.width - (defaultVictoryPadding + xxLargePadding * 2)}
                 selectedHeight={18}
                 selectedBarIndex={selectedBarIndex}
                 setSelectedBarIndex={setSelectedBarIndex}
@@ -194,6 +198,8 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
                 defaultVictoryPadding={defaultVictoryPadding}
                 questionChoices={questionChoices}
                 noResponseLabel={noResponseLabel}
+                reversedResponses={reversedResponses}
+                correctChoiceIndex={correctChoiceIndex}
               />
             }
           />

--- a/host/src/components/Responses/ResponsesGraph.jsx
+++ b/host/src/components/Responses/ResponsesGraph.jsx
@@ -138,7 +138,15 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
         <VictoryChart
           // domainPadding={!isOpenEnded ? 36 : 46}
           domainPadding={0}
-          padding={!isOpenEnded ? {defaultVictoryPadding} : {top: defaultVictoryPadding, bottom: defaultVictoryPadding, left: smallPadding, right: smallPadding}}
+          padding={
+            !isOpenEnded
+              ? { defaultVictoryPadding }
+              : (statePosition < 6)
+              ? { top: defaultVictoryPadding, bottom: defaultVictoryPadding, left: smallPadding, right: smallPadding }
+              : statePosition >= 6
+              ? { top: defaultVictoryPadding, bottom: defaultVictoryPadding, left: defaultVictoryPadding, right: smallPadding }
+              : { defaultVictoryPadding }
+          }          
           containerComponent={<VictoryContainer />}
           theme={customTheme}
           width={boundingRect.width}
@@ -148,7 +156,7 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
             standalone={false}
             tickLabelComponent={
               <CustomTick mediumPadding={mediumPadding} largePadding={largePadding} reversedResponses={reversedResponses} correctChoiceIndex={correctChoiceIndex} statePosition={statePosition} />}
-              domain={[1,6]}
+            domain={[1, 6]}
           />
           {largestAnswerCount < 5 && (
             <VictoryAxis
@@ -191,6 +199,7 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
             }
             labelComponent={
               <CustomLabel
+                statePosition={statePosition}
                 labelOffset={labelOffset}
                 barThickness={barThickness}
                 xSmallPadding={xSmallPadding}

--- a/host/src/components/Responses/ResponsesGraph.jsx
+++ b/host/src/components/Responses/ResponsesGraph.jsx
@@ -37,11 +37,14 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
   const xLargePadding = 32;
   const xxLargePadding = 40;
   const xxxLargePadding = 48;
+  const xxxxLargePadding = 56;
   const labelOffset = 3;
   const noResponseLabel = '–';
   // victory applies a default of 50px to the VictoryChart component
   // we intentionally set this so that we can reference it programmatically throughout the chart
   const defaultVictoryPadding = 50;
+
+  const customBarSelectedWidth = isOpenEnded ? boundingRect.width : boundingRect.width - (defaultVictoryPadding + xxLargePadding * 2);
 
   const [selectedBarIndex, setSelectedBarIndex] = useState(null);
 
@@ -155,7 +158,15 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
           <VictoryAxis
             standalone={false}
             tickLabelComponent={
-              <CustomTick mediumPadding={mediumPadding} largePadding={largePadding} reversedResponses={reversedResponses} correctChoiceIndex={correctChoiceIndex} statePosition={statePosition} />}
+              <CustomTick 
+                mediumPadding={mediumPadding} 
+                largePadding={largePadding} 
+                reversedResponses={reversedResponses} 
+                correctChoiceIndex={correctChoiceIndex} 
+                statePosition={statePosition} 
+                isOpenEnded={isOpenEnded}
+              />
+            }
             domain={[1, 6]}
           />
           {largestAnswerCount < 5 && (
@@ -188,10 +199,13 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
             barWidth={({ datum }) => datum.answerCount !== 0 ? barThickness : barThicknessZero}
             dataComponent={
               <CustomBar
+                isOpenEnded={isOpenEnded}
                 xSmallPadding={xSmallPadding}
                 mediumPadding={mediumPadding}
+                xxLargePadding={xxLargePadding}
                 xxxLargePadding={xxxLargePadding}
-                selectedWidth={isOpenEnded ? boundingRect.width : boundingRect.width - (defaultVictoryPadding + xxLargePadding * 2)}
+                xxxxLargePadding={xxxxLargePadding}
+                selectedWidth={customBarSelectedWidth}
                 selectedHeight={18}
                 selectedBarIndex={selectedBarIndex}
                 setSelectedBarIndex={setSelectedBarIndex}
@@ -199,11 +213,13 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
             }
             labelComponent={
               <CustomLabel
+                isOpenEnded={isOpenEnded}
                 statePosition={statePosition}
                 labelOffset={labelOffset}
                 barThickness={barThickness}
                 xSmallPadding={xSmallPadding}
                 mediumLargePadding={mediumLargePadding}
+                xLargePadding={xLargePadding}
                 defaultVictoryPadding={defaultVictoryPadding}
                 questionChoices={questionChoices}
                 noResponseLabel={noResponseLabel}
@@ -216,6 +232,7 @@ const ResponsesGraph = ({ questions, teams, studentResponses, numPlayers, totalA
       </div>
       <div className={classes.answerContainer}>
         <SelectedAnswer
+          isOpenEnded={isOpenEnded}
           questions={questions}
           teams={teams}
           data={data}

--- a/host/src/components/Responses/SelectedAnswer.jsx
+++ b/host/src/components/Responses/SelectedAnswer.jsx
@@ -77,6 +77,8 @@ const SelectedAnswer = (props) => {
 
   const showCustomTick = selectedBarIndex === reversedResponses.length - 1 - correctChoiceIndex;
 
+  const isOpenEnded = true;
+
   return (
     <div className={classes.parentContainer}>
       {selectedBarIndex === null ? (
@@ -89,7 +91,7 @@ const SelectedAnswer = (props) => {
             Showing players who answered:
           </Typography>
           <div className={classes.rectangleStyle}>
-            <div className={classes.choiceContainer}>{data[selectedBarIndex].answerChoice}</div>
+            <div className={classes.choiceContainer}>{statePosition < 6 && isOpenEnded ? null : data[selectedBarIndex].answerChoice}</div>
             <div className={classes.textContainer}>{data[selectedBarIndex].answerText}</div>
             {showCustomTick && (
               <Tooltip title="This is the correct answer" placement="top">

--- a/host/src/components/Responses/SelectedAnswer.jsx
+++ b/host/src/components/Responses/SelectedAnswer.jsx
@@ -71,13 +71,12 @@ const SelectedAnswer = (props) => {
     numPlayers,
     teamsPickedChoices,
     statePosition,
+    isOpenEnded
   } = props;
 
   const classes = useStyles();
 
   const showCustomTick = selectedBarIndex === reversedResponses.length - 1 - correctChoiceIndex;
-
-  const isOpenEnded = true;
 
   return (
     <div className={classes.parentContainer}>


### PR DESCRIPTION
**Issue:**

When a question is played that in Open Ended Response Mode (expecting a user generated answer, not a multiple choice answer), the Real Time Responses component should change its display so per [this](https://www.figma.com/file/PadzU8GqyhFLCjIt7rQkpE/RightOn-Apps?type=design&node-id=15530-200259&mode=dev) Figma design.

GIthub item: https://github.com/rightoneducation/righton-app/issues/798


**Resolution:**

I used a temporary variable (isOpenEnded) to create tenrary operators that switch dependent on the boolean. This switches padding, styling, and the placement of text on the ResponsesGraph.

Relevant code:
- `CustomBar.jsx`
- `CustomLabel.jsx`
- `ResponsesGraph.jsx`


**Preview:**

Multiple Choice Version:
![image](https://github.com/rightoneducation/righton-app/assets/79948102/d4a55176-a0c4-4088-bd61-f4ed7ac39940)

Open Ended Version:
 
<img width="524" alt="Screenshot 2023-09-12 at 1 55 48 PM" src="https://github.com/rightoneducation/righton-app/assets/79948102/ae4ea9c4-8c9d-4689-8006-689b2f553580">

