### PR TITLE
[Host] - Enable scroll on mobile for Victory Charts

### DIFF
--- a/host/src/components/ConfidenceResponses/ConfidenceResponseGraph.jsx
+++ b/host/src/components/ConfidenceResponses/ConfidenceResponseGraph.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Typography } from '@material-ui/core';
 import {
   VictoryChart,
+  VictoryContainer,
   VictoryStack,
   VictoryBar,
   VictoryLabel,
@@ -111,7 +112,17 @@ export default function ConfidenceResponsesGraph({
         </Typography>
       </div>
       <div ref={graphRef}>
-        <VictoryChart theme={customThemeGraph} height={200}>
+        <VictoryChart 
+          theme={customThemeGraph} 
+          height={200}
+          containerComponent={
+            <VictoryContainer 
+              style={{
+              touchAction: "auto"
+              }}
+            />
+          }
+        >
           <VictoryStack
             standalone={false}
             labelComponent={

--- a/host/src/components/Responses/ResponsesGraph.jsx
+++ b/host/src/components/Responses/ResponsesGraph.jsx
@@ -129,7 +129,13 @@ export default function ResponsesGraph({
               left: defaultVictoryPadding,
               right: smallPadding,
             }}
-            containerComponent={<VictoryContainer />}
+            containerComponent={
+              <VictoryContainer 
+                style={{
+                touchAction: "auto"
+                }}
+              />
+            }
             theme={customTheme}
             width={boundingRect.width}
             height={300}


### PR DESCRIPTION
**Issue:**

By default, Victory charts process scroll events for subcomponents, as described [here](https://github.com/FormidableLabs/victory/issues/2565). This prevents scroll events from working when the user touchs the Victory graph on mobile. 


**Resolution:**

Per the thread above, we can add a custom container component styled with `touchActions: auto` to override this default behaviour and reenable scrolling when touching Victory charts. 

Relevant code:
On all `<VictoryChart>` components:

```
<VictoryChart
  ... 
    containerComponent={ // <--- add this
      <VictoryContainer 
        style={{
        touchAction: "auto"
        }}
      />
    }
  ...
 >
```
