### PR TITLE
[Host] - Restyles Confidence Switch

### DIFF
--- a/host/src/components/EnableConfidenceCard.jsx
+++ b/host/src/components/EnableConfidenceCard.jsx
@@ -15,7 +15,6 @@ export default function EnableConfidenceCard({
           className={classes.switch}
           checked={isConfidenceEnabled}
           onChange={handleConfidenceSwitchChange}
-          // color="default"
         />
       </div>
       <div className={classes.answerContainer}>
@@ -77,7 +76,7 @@ const useStyles = makeStyles({
       color: '#FFFFFF',
     },
     '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
-      backgroundColor: '#3874CB',
+      backgroundColor: '#111111',
     },
   },
 });

--- a/host/src/components/EnableConfidenceCard.jsx
+++ b/host/src/components/EnableConfidenceCard.jsx
@@ -15,6 +15,7 @@ export default function EnableConfidenceCard({
           className={classes.switch}
           checked={isConfidenceEnabled}
           onChange={handleConfidenceSwitchChange}
+          // color="default"
         />
       </div>
       <div className={classes.answerContainer}>
@@ -66,8 +67,14 @@ const useStyles = makeStyles({
     justifyContent: 'center',
   },
   switch: {
+    '& .MuiSwitch-switchBase': {
+      color: "#C0C0C0"
+    },
+    '& .MuiSwitch-track': {
+      backgroundColor: "#EAEAEA",
+    },
     '& .MuiSwitch-switchBase.Mui-checked': {
-      color: '#3874CB',
+      color: '#FFFFFF',
     },
     '& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track': {
       backgroundColor: '#3874CB',


### PR DESCRIPTION
**Issue:**

It was determined that the existing styling of the switch on in `host` that enables the Confidence features was confusing. Instead of using a blue color to denote an enabled state, it was decided that enabled would have a white toggle switch with a darker track and disabled would be a greyed out version of that. Please see the videos below for a preview.

Existing:

https://github.com/rightoneducation/righton-app/assets/79417944/008efc06-a118-4791-a0f8-382acec038fc

Restyled:

https://github.com/rightoneducation/righton-app/assets/79417944/db468e67-37bd-4078-89f7-2b5e38cf4ec8
