### PR TITLE
[Networking] - Adds Responses field to Question Object

### DIFF
--- a/networking/amplify/backend/api/mobile/schema.graphql
+++ b/networking/amplify/backend/api/mobile/schema.graphql
@@ -40,6 +40,7 @@ type Question @model(subscriptions: null, timestamps: null) {
   id: Int! @primaryKey(sortKeyFields: ["order", "gameSessionId"])
   text: String!
   choices: AWSJSON
+  responses: AWSJSON
   imageUrl: String
   instructions: AWSJSON
   standard: String

--- a/networking/amplify/team-provider-info.json
+++ b/networking/amplify/team-provider-info.json
@@ -19,6 +19,9 @@
           "userPoolName": "RightOn Central",
           "webClientId": "1qi0l2sm7hr82ou1mqsv4tc1ff"
         }
+      },
+      "api": {
+        "mobile": {}
       }
     }
   }

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -536,6 +536,7 @@ type AWSQuestion = {
     id: number
     text: string
     choices?: string | null
+    responses?: string | null
     imageUrl?: string | null
     instructions?: string | null
     standard?: string | null
@@ -717,6 +718,7 @@ export class GameSessionParser {
                     choices: isNullOrUndefined(awsQuestion.choices)
                         ? []
                         : this.parseServerArray<IChoice>(awsQuestion.choices),
+                    responses: [],
                     imageUrl: awsQuestion.imageUrl,
                     instructions: isNullOrUndefined(awsQuestion.instructions)
                         ? []

--- a/networking/src/Models/IQuestion.ts
+++ b/networking/src/Models/IQuestion.ts
@@ -2,6 +2,7 @@ export interface IQuestion {
     id: number
     text: string
     choices?: Array<IChoice> | null
+    responses?: Array<string> | null
     imageUrl?: string | null
     instructions?: Array<string> | null
     standard?: string | null

--- a/networking/src/graphql/mutations.ts
+++ b/networking/src/graphql/mutations.ts
@@ -26,6 +26,7 @@ export const createGameSession = /* GraphQL */ `mutation CreateGameSession(
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -95,6 +96,7 @@ export const createGameSession = /* GraphQL */ `mutation CreateGameSession(
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -138,6 +140,7 @@ export const updateGameSession = /* GraphQL */ `mutation UpdateGameSession(
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -207,6 +210,7 @@ export const updateGameSession = /* GraphQL */ `mutation UpdateGameSession(
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -250,6 +254,7 @@ export const deleteGameSession = /* GraphQL */ `mutation DeleteGameSession(
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -319,6 +324,7 @@ export const deleteGameSession = /* GraphQL */ `mutation DeleteGameSession(
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -352,6 +358,7 @@ export const createQuestion = /* GraphQL */ `mutation CreateQuestion(
     id
     text
     choices
+    responses
     imageUrl
     instructions
     standard
@@ -378,6 +385,7 @@ export const updateQuestion = /* GraphQL */ `mutation UpdateQuestion(
     id
     text
     choices
+    responses
     imageUrl
     instructions
     standard
@@ -404,6 +412,7 @@ export const deleteQuestion = /* GraphQL */ `mutation DeleteQuestion(
     id
     text
     choices
+    responses
     imageUrl
     instructions
     standard
@@ -433,6 +442,7 @@ export const createTeam = /* GraphQL */ `mutation CreateTeam(
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard
@@ -502,6 +512,7 @@ export const updateTeam = /* GraphQL */ `mutation UpdateTeam(
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard
@@ -571,6 +582,7 @@ export const deleteTeam = /* GraphQL */ `mutation DeleteTeam(
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard

--- a/networking/src/graphql/queries.ts
+++ b/networking/src/graphql/queries.ts
@@ -23,6 +23,7 @@ export const getGameSession = /* GraphQL */ `query GetGameSession($id: ID!) {
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -92,6 +93,7 @@ export const getGameSession = /* GraphQL */ `query GetGameSession($id: ID!) {
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -137,6 +139,7 @@ export const listGameSessions = /* GraphQL */ `query ListGameSessions(
             id
             text
             choices
+            responses
             imageUrl
             instructions
             standard
@@ -206,6 +209,7 @@ export const listGameSessions = /* GraphQL */ `query ListGameSessions(
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -239,6 +243,7 @@ export const getQuestion = /* GraphQL */ `query GetQuestion($id: Int!, $order: I
     id
     text
     choices
+    responses
     imageUrl
     instructions
     standard
@@ -277,6 +282,7 @@ export const listQuestions = /* GraphQL */ `query ListQuestions(
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard
@@ -306,6 +312,7 @@ export const getTeam = /* GraphQL */ `query GetTeam($id: ID!) {
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard
@@ -374,6 +381,7 @@ export const listTeams = /* GraphQL */ `query ListTeams(
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -578,6 +586,7 @@ export const gameSessionByState = /* GraphQL */ `query GameSessionByState(
             id
             text
             choices
+            responses
             imageUrl
             instructions
             standard
@@ -647,6 +656,7 @@ export const gameSessionByState = /* GraphQL */ `query GameSessionByState(
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -703,6 +713,7 @@ export const gameSessionByCode = /* GraphQL */ `query GameSessionByCode(
             id
             text
             choices
+            responses
             imageUrl
             instructions
             standard
@@ -772,6 +783,7 @@ export const gameSessionByCode = /* GraphQL */ `query GameSessionByCode(
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard

--- a/networking/src/graphql/subscriptions.ts
+++ b/networking/src/graphql/subscriptions.ts
@@ -23,6 +23,7 @@ export const onGameSessionUpdatedById = /* GraphQL */ `subscription OnGameSessio
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -92,6 +93,7 @@ export const onGameSessionUpdatedById = /* GraphQL */ `subscription OnGameSessio
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -157,6 +159,7 @@ export const onTeamCreateByGameSessionId = /* GraphQL */ `subscription OnTeamCre
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard
@@ -223,6 +226,7 @@ export const onTeamDeleteByGameSessionId = /* GraphQL */ `subscription OnTeamDel
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard
@@ -298,6 +302,7 @@ export const onCreateGameSession = /* GraphQL */ `subscription OnCreateGameSessi
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -367,6 +372,7 @@ export const onCreateGameSession = /* GraphQL */ `subscription OnCreateGameSessi
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -409,6 +415,7 @@ export const onUpdateGameSession = /* GraphQL */ `subscription OnUpdateGameSessi
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -478,6 +485,7 @@ export const onUpdateGameSession = /* GraphQL */ `subscription OnUpdateGameSessi
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -520,6 +528,7 @@ export const onDeleteGameSession = /* GraphQL */ `subscription OnDeleteGameSessi
           id
           text
           choices
+          responses
           imageUrl
           instructions
           standard
@@ -589,6 +598,7 @@ export const onDeleteGameSession = /* GraphQL */ `subscription OnDeleteGameSessi
         id
         text
         choices
+        responses
         imageUrl
         instructions
         standard
@@ -622,6 +632,7 @@ export const onCreateTeam = /* GraphQL */ `subscription OnCreateTeam($filter: Mo
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard
@@ -688,6 +699,7 @@ export const onUpdateTeam = /* GraphQL */ `subscription OnUpdateTeam($filter: Mo
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard
@@ -754,6 +766,7 @@ export const onDeleteTeam = /* GraphQL */ `subscription OnDeleteTeam($filter: Mo
       id
       text
       choices
+      responses
       imageUrl
       instructions
       standard


### PR DESCRIPTION
**Issue:**

In the interest of accepting Short Answer Responses, we will need to store the short answer response information alongside the `choices` in which we are currently storing the multiple choice information. This information will be stored on an individual answer basis in the `TeamAnswer` object but it will be useful to also store it here during both gameplay and for analytics on a question basis after the fact. This object is currently a string but will be updated with more type-specificity in a following PR


**Resolution:**

```
type Question @model(subscriptions: null, timestamps: null) {
  id: Int! @primaryKey(sortKeyFields: ["order", "gameSessionId"])
  text: String!
  choices: AWSJSON
  responses: AWSJSON // <------ new 
  imageUrl: String
  instructions: AWSJSON
  standard: String
  cluster: String
  domain: String
  grade: String
  order: Int!
  isHintEnabled: Boolean! @default(value: "false")
  isConfidenceEnabled: Boolean! @default(value: "true")
  isShortAnswerEnabled: Boolean! @default(value: "false")
  gameSessionId: ID! @index(name: "byGameSession", sortKeyFields: ["id"])
}
```