### PR TITLE
[Networking] - Updates TeamAnswerClasses to handle correct answers as well

### DIFF
--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -179,7 +179,6 @@ const GameSessionContainer = () => {
         }
       },
     );
-      
     // set up subscription for teams answering
     let createTeamAnswerSubscription: any | null = null;
     createTeamAnswerSubscription = apiClient.subscribeCreateTeamAnswer(

--- a/host/src/lib/HelperFunctions.jsx
+++ b/host/src/lib/HelperFunctions.jsx
@@ -258,26 +258,26 @@ export const getTeamInfoFromAnswerId = (teamsArray, teamMemberAnswersId) => {
   return {teamName, teamId};
 };
 
-/**
- * Create an new NumberAnswer, StringAnswer, or ExpressionAnswer object for the correct answer
- * based on the teacher's supplied answer type for the correct answer
- * @
- */
-export const createCorrectAnswerObject = (questions, currentQuestionIndex) => {
-  let choices = getQuestionChoices(questions, currentQuestionIndex);
-  const correctAnswerValue = choices.find(choice => choice.isAnswer).text;
-  const answerType = questions[currentQuestionIndex].answerSettings.answerType;
+
+export const createCorrectAnswer = (correctAnswerValue, answerType) => {
+  const answerConfigBase = {
+    answerContent: {
+      rawAnswer:  correctAnswerValue,
+      normAnswer: correctAnswerValue,
+      answerType,
+    },
+  };
   let correctAnswer;
   switch (answerType){
     case (AnswerType.NUMBER):
     default:
-      correctAnswer = new NumberAnswer(correctAnswerValue);
+      correctAnswer = new NumberAnswer(answerConfigBase);
       break;
     case(AnswerType.STRING):
-      correctAnswer = new StringAnswer(correctAnswerValue);
+      correctAnswer = new StringAnswer(answerConfigBase);
       break;
     case(AnswerType.EXPRESSION):
-      correctAnswer = new ExpressionAnswer(correctAnswerValue);
+      correctAnswer = new ExpressionAnswer(answerConfigBase);
       break;
   }
   return correctAnswer;
@@ -300,10 +300,11 @@ export const buildShortAnswerResponses = (prevShortAnswer, choices, newAnswer, n
   }
   // if this is the first answer received, add the correct answer object to prevShortAnswer for comparisons
   if (prevShortAnswer.length === 0) { 
-    let correctAnswer = choices.find(choice => choice.isAnswer).text;
+    const correctAnswerValue = choices.find(choice => choice.isAnswer).text;
+    const correctAnswer = createCorrectAnswer(correctAnswerValue, newAnswer.answerContent.answerType);
     prevShortAnswer.push({
-      rawAnswer: [correctAnswer],
-      normAnswer: [correctAnswer],
+      rawAnswer: correctAnswer.answerContent.rawAnswer,
+      normAnswer: correctAnswer.answerContent.normAnswer,
       isCorrect: true,
       isSelectedMistake: false,
       count: 0,

--- a/networking/package.json
+++ b/networking/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@types/jest": "^29.5.1",
     "@types/node": "^18.16.3",
+    "@types/stopword": "^2.0.3",
     "create-ts-index": "^1.14.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
@@ -13,7 +14,8 @@
   "dependencies": {
     "aws-amplify": "^5.3.1",
     "mathjs": "^11.11.2",
-    "reflect-metadata": "^0.1.13"
+    "reflect-metadata": "^0.1.13",
+    "stopword": "^2.0.8"
   },
   "scripts": {
     "build": "cti s -p ./tsconfig.build.json ./src -s false -b -f index.ts && tsc --build tsconfig.json",

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -697,6 +697,13 @@ export class GameSessionParser {
         return []
     }
 
+    private static parseAnswerType<t>(input: any | t): t {
+        if (typeof input === "string") {
+            return JSON.parse(input as string)
+        }
+        return input
+    }
+
     private static mapQuestions(
         awsQuestions: Array<AWSQuestion | null>
     ): Array<IQuestion> {
@@ -713,7 +720,7 @@ export class GameSessionParser {
                         : this.parseServerArray<IChoice>(awsQuestion.choices),
                     answerSettings: isNullOrUndefined(awsQuestion.answerSettings)
                         ? null
-                        : JSON.parse(JSON.stringify(awsQuestion.answerSettings)) as IAnswerSettings,
+                        : this.parseAnswerType<IAnswerSettings>(awsQuestion.answerSettings),
                     responses: isNullOrUndefined(awsQuestion.responses)
                          ? []
                          : this.parseServerArray<IResponse>(awsQuestion.responses),

--- a/networking/yarn.lock
+++ b/networking/yarn.lock
@@ -2752,6 +2752,11 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/stopword@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/stopword/-/stopword-2.0.3.tgz#4e7c629000a74eb56f772fa0f4eb77775de425de"
+  integrity sha512-hioMj0lOvISM+EDevf7ijG8EMbU+J3pj4SstCyfQC1t39uPYpAe7beSfBdU6c1d9jeECTQQtR3UJWtVoUO8Weg==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz"
@@ -4517,6 +4522,11 @@ stack-utils@^2.0.3:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+stopword@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/stopword/-/stopword-2.0.8.tgz#00239d66b34fded43b0d490684fbd770208abdd3"
+  integrity sha512-btlEC2vEuhCuvshz99hSGsY8GzaP5qzDPQm56j6rR/R38p8xdsOXgU5a6tIgvU/4hcCta1Vlo/2FVXA9m0f8XA==
 
 string-length@^4.0.1:
   version "4.0.2"

--- a/play/src/components/openanswercard/OpenAnswerCard.tsx
+++ b/play/src/components/openanswercard/OpenAnswerCard.tsx
@@ -86,6 +86,7 @@ export default function OpenAnswerCard({
       delta: currentContents,
       currentState,
       currentQuestionIndex,
+      isShortAnswerEnabled,
       isSubmitted: true,
     } as ITeamAnswerContent;
     handleSubmitAnswer(packagedAnswer);

--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -5,7 +5,6 @@ import {
   ApiClient,
   GameSessionState,
   ITeam,
-  ITeamAnswer,
   IQuestion,
   ModelHelper,
   ConfidenceLevel,
@@ -16,7 +15,7 @@ import {
   StringAnswer,
   ExpressionAnswer,
   AnswerType,
-  IBaseAnswerConfig
+  ITeamAnswerConfig
 } from '@righton/networking';
 import HeaderContent from '../components/HeaderContent';
 import FooterContent from '../components/FooterContent';
@@ -173,7 +172,7 @@ export default function GameInProgress({
     return rejoinSelectedConfidence;
   });
 
-  // contents is the quill pad contents and rece
+  // contents is the quill pad contents
   const handleSubmitAnswer = async (packagedAnswer: ITeamAnswerContent) => {
     const answerConfigBase = {
       questionId: currentQuestion.id,
@@ -184,48 +183,42 @@ export default function GameInProgress({
       isTrickAnswer: currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER && !isShortAnswerEnabled,
       confidenceLevel: ConfidenceLevel.NOT_RATED
     };
-    let rawAnswer;
-    let normAnswer;
+    let answer;
     const currentQuestionType = currentQuestion.answerSettings?.answerType;
     switch (currentQuestionType) {
       case (AnswerType.STRING): {
-        const answerConfig: IBaseAnswerConfig<string> = {
+        const answerConfig: ITeamAnswerConfig<string> = {
           ...answerConfigBase,
           value: ''
         }
-        rawAnswer = new StringAnswer(answerConfig);
-        normAnswer = rawAnswer.normalize({isShortAnswerEnabled});
+        answer = new StringAnswer(answerConfig);
         break;
       }
       case (AnswerType.EXPRESSION): {
-        const answerConfig: IBaseAnswerConfig<string> = {
+        const answerConfig: ITeamAnswerConfig<string> = {
           ...answerConfigBase,
           value: ''
         }
-        rawAnswer = new ExpressionAnswer(answerConfig);
-        normAnswer = rawAnswer.normalize({isShortAnswerEnabled});
+        answer = new ExpressionAnswer(answerConfig);
         break;
       }
       case (AnswerType.NUMBER):
       default: {
-        const answerConfig: IBaseAnswerConfig<number> = {
+        const answerConfig: ITeamAnswerConfig<number> = {
           ...answerConfigBase,
           value: 0
         }
-        rawAnswer = new NumberAnswer(answerConfig);
-        normAnswer = rawAnswer.normalize({isShortAnswerEnabled});
+        answer = new NumberAnswer(answerConfig);
         break;
       }
     }
-
     try {
-      const response = await apiClient.addTeamAnswer(normAnswer);
-      window.localStorage.setItem(StorageKeyAnswer, JSON.stringify(normAnswer.answerContent));
+      const response = await apiClient.addTeamAnswer(answer);
+      window.localStorage.setItem(StorageKeyAnswer, JSON.stringify(answer.answerContent));
       setTeamAnswerId(response.id);
-      setAnswerContent(normAnswer?.answerContent as ITeamAnswerContent);
+      setAnswerContent(answer?.answerContent as ITeamAnswerContent);
       setDisplaySubmitted(true);
     } catch (e) {
-      console.log(e)
       setIsAnswerError(true);
     }
   };


### PR DESCRIPTION
The `TeamAnswerClasses` initially were configured only for answers from the student side. However, we need to compare to a correct answer that is just a `string` on the `gameSession`. As such, I rewrote the `TeamAnswerClass` so that we have a minimal base class that then extends into `CorrectAnswer` and `abstract TeamAnswer`. `TeamAnswer` then extends into `NumberAnswer`, `StringAnswer` and `ExpressionAnswer`. This allows us to share all the normalization functions etc and avoids having either helper functions or having to initialize a correct answer object with a bunch of empty parameters.
