### PR TITLE
[Play] - Swaps out Quill.JS pad for mui TextField

### DIFF
--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -206,7 +206,7 @@ const GameSessionContainer = () => {
               // we are nesting the short answer response in here because we need to use the teamName and teamId to build the shortAnswerResponses object
               // if we did this outside of the setTeamsArray function we would be using stale state values
               setShortAnswerResponses((prevShortAnswerState) => {
-                const newShortAnswerState = buildShortAnswerResponses(prevShortAnswerState, choices, teamAnswerResponse, teamName, teamId);
+                const newShortAnswerState = buildShortAnswerResponses(prevShortAnswerState, choices, gameSession.questions[gameSession.currentQuestionIndex].answerSettings, teamAnswerResponse, teamName, teamId);
                 apiClient
                   .updateQuestion({
                     gameSessionId: gameSession.id, 

--- a/host/src/lib/HelperFunctions.jsx
+++ b/host/src/lib/HelperFunctions.jsx
@@ -259,15 +259,16 @@ export const getTeamInfoFromAnswerId = (teamsArray, teamMemberAnswersId) => {
 };
 
 
-export const createCorrectAnswer = (correctAnswerValue, answerType) => {
+export const createCorrectAnswer = (correctAnswerValue, answerSettings) => {
   const answerConfigBase = {
     answerContent: {
       rawAnswer:  correctAnswerValue,
-      answerType,
+      answerType: answerSettings.answerType,
+      answerPrecision: answerSettings.answerPrecision
     },
   };
   let correctAnswer;
-  switch (answerType){
+  switch (answerSettings.answerType){
     case (AnswerType.NUMBER):
     default:
       correctAnswer = new NumberAnswer(answerConfigBase);
@@ -291,7 +292,7 @@ export const createCorrectAnswer = (correctAnswerValue, answerType) => {
  * @param {string} teamId 
  * @returns {IResponse[]}
  */
-export const buildShortAnswerResponses = (prevShortAnswer, choices, newAnswer, newAnswerTeamName, teamId) => {
+export const buildShortAnswerResponses = (prevShortAnswer, choices, answerSettings, newAnswer, newAnswerTeamName, teamId) => {
   // if the answer is empty, skip and return the previous answer
   // an empty answer could mean that a user was able to submit an answer of the wrong type
   if (newAnswer.answerContent.normAnswer.length === 0) {
@@ -300,7 +301,7 @@ export const buildShortAnswerResponses = (prevShortAnswer, choices, newAnswer, n
   // if this is the first answer received, add the correct answer object to prevShortAnswer for comparisons
   if (prevShortAnswer.length === 0) { 
     const correctAnswerValue = choices.find(choice => choice.isAnswer).text;
-    const correctAnswer = createCorrectAnswer(correctAnswerValue, newAnswer.answerContent.answerType);
+    const correctAnswer = createCorrectAnswer(correctAnswerValue, answerSettings);
     prevShortAnswer.push({
       rawAnswer: correctAnswer.answerContent.rawAnswer,
       normAnswer: correctAnswer.answerContent.normAnswer,

--- a/host/src/lib/HelperFunctions.jsx
+++ b/host/src/lib/HelperFunctions.jsx
@@ -263,7 +263,6 @@ export const createCorrectAnswer = (correctAnswerValue, answerType) => {
   const answerConfigBase = {
     answerContent: {
       rawAnswer:  correctAnswerValue,
-      normAnswer: correctAnswerValue,
       answerType,
     },
   };

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -967,7 +967,7 @@ class TeamAnswerParser {
             default: {
                 const answerConfig = {
                     ...answerConfigBase,
-                    value: 0
+                    value: ''
                 }
                 teamAnswer = new NumberAnswer(answerConfig);
                 break;

--- a/networking/src/Models/AnswerClasses.ts
+++ b/networking/src/Models/AnswerClasses.ts
@@ -9,9 +9,15 @@ export enum AnswerType {
   EXPRESSION = 'expression'
 }
 
+export enum AnswerPrecision {
+  WHOLE = 'whole',
+  TENTH = 'tenth',
+  HUNDREDTH = 'hundredth',
+  THOUSANDTH = 'thousandth',
+}
+
 export interface ITeamAnswerContent {
-  delta?: string;
-  rawAnswer?: string; 
+  rawAnswer: string; 
   normAnswer?: (string | number)[] | null;
   answerType?: AnswerType;
   percent?: number;
@@ -91,85 +97,56 @@ abstract class TeamAnswer<T> extends BaseAnswer<T> {
   abstract isEqualTo(otherAnswers: T[]): Boolean;
 }
 
-function isNumeric (num: any){ // eslint-disable-line @typescript-eslint/no-explicit-any
-  return (typeof num === 'number' || (typeof num === 'string' && num.trim() !== '')) && 
-    !isNaN(num as number); // eslint-disable-line no-restricted-globals
-}
-
-function normalizeAnswers(currentItem: any, answerType: AnswerType) {
-  const rawAnswers = [];
+function normalizeAnswers(currentItem: string, answerType: AnswerType) {
   const normAnswers = [];
-  switch (answerType) {
-    case AnswerType.NUMBER:
-      if (!currentItem?.formula) {
+  if (!isNullOrUndefined(currentItem)) {
+    switch (answerType) {
+      case AnswerType.NUMBER:
         // if it's a number, check for percentages and convert to decimal
         const percentagesRegex = /(\d+(\.\d+)?)%/g;
         const extractPercents = currentItem.match(percentagesRegex);
         const percentages = extractPercents ? parseFloat(extractPercents[0]) / 100 : null
-        if (!isNullOrUndefined(percentages) && !isNullOrUndefined(percentages)){
-          rawAnswers.push(extractPercents[0]); 
+        if (!isNullOrUndefined(percentages)){
           normAnswers.push(percentages);
           break;
         }
         // then remove commas and spaces and push
         const noCommas = currentItem.replace(/,/g, '');
         const normItem = Number(noCommas.trim());
-        if (!isNullOrUndefined(currentItem) && !isNullOrUndefined(normItem)) {
-          rawAnswers.push(normItem);
+        if (!isNullOrUndefined(normItem)) {
           normAnswers.push(normItem);
         }
-      }
-      break;
-    case AnswerType.STRING:
-      if (!currentItem?.formula && !isNumeric(currentItem)) {
+        break;
+      case AnswerType.STRING:
         // if it's a string, pull out any numbers and remove spaces, and remove stopwords
         const normArray = currentItem.toLowerCase().replace(/[\d\r\n]+/g, '').trim().split(' ');
         const normNoStopwords = removeStopwords(normArray, eng).join(' ');
-        if (!isNullOrUndefined(currentItem) && !isNullOrUndefined(normNoStopwords)) {
-          rawAnswers.push(normNoStopwords);
+        if (!isNullOrUndefined(normNoStopwords)) {
           normAnswers.push(normNoStopwords);
         }
-      }
-      break;
-    case AnswerType.EXPRESSION:
-      if (currentItem) {
+        break;
+      case AnswerType.EXPRESSION:
         // if it's an expression, use parse and toString to extract expression trees and compare
         // anything more complex than this will require a custom parser (and is probably not worth it)
         // https://mathjs.org/docs/expressions/parsing.html
-        const normItem = parse(currentItem.toString()).toString();
-        if (!isNullOrUndefined(currentItem) && !isNullOrUndefined(normItem)) {
-          rawAnswers.push(normItem);
-          normAnswers.push(normItem);
+        const normItemExp = parse(currentItem.toString()).toString();
+        if (!isNullOrUndefined(normItemExp)) {
+          normAnswers.push(normItemExp);
         }
-      }
-      break;
-  }
-  const joinedRawAnswers = rawAnswers.join(' ');
-  return { rawAnswers: joinedRawAnswers, normAnswers};
-};
-
-function extractFromDelta(currentContents: any) {
- return currentContents.ops.map((item: any) => {
-    if (!isNullOrUndefined(item.insert)) {
-      if (!isNullOrUndefined(item.insert.formula)) {
-        return item.insert.formula;
-      } else {
-        return item.insert;
-      }
+        break;
     }
-  }).join(' ');
-}
+  }
+  return normAnswers;
+};
 
 export class CorrectNumberAnswer extends BaseAnswer<number> {
   constructor(config: IBaseAnswerConfig<number>) {
     super(config); // Pass the config to the BaseAnswer constructor
-
     const normalizedAnswers = normalizeAnswers(this.answerContent.rawAnswer, AnswerType.NUMBER);
 
     this.answerContent = {
       ...this.answerContent,
-      rawAnswer: normalizedAnswers.rawAnswers,
-      normAnswer: normalizedAnswers.normAnswers,
+      normAnswer: normalizedAnswers,
       answerType: AnswerType.NUMBER
     };
     return this;
@@ -179,13 +156,11 @@ export class CorrectNumberAnswer extends BaseAnswer<number> {
 export class CorrectStringAnswer extends BaseAnswer<string> {
   constructor(config: IBaseAnswerConfig<string>) {
     super(config); // Pass the config to the BaseAnswer constructor
-
     const normalizedAnswers = normalizeAnswers(this.answerContent.rawAnswer, AnswerType.STRING);
 
     this.answerContent = {
       ...this.answerContent,
-      rawAnswer: normalizedAnswers.rawAnswers,
-      normAnswer: normalizedAnswers.normAnswers,
+      normAnswer: normalizedAnswers,
       answerType: AnswerType.STRING
     };
     return this;
@@ -195,13 +170,11 @@ export class CorrectStringAnswer extends BaseAnswer<string> {
 export class CorrectExpressionAnswer extends BaseAnswer<string> {
   constructor(config: IBaseAnswerConfig<string>) {
     super(config); // Pass the config to the BaseAnswer constructor
-
     const normalizedAnswers = normalizeAnswers(this.answerContent.rawAnswer, AnswerType.EXPRESSION);
 
     this.answerContent = {
       ...this.answerContent,
-      rawAnswer: normalizedAnswers.rawAnswers,
-      normAnswer: normalizedAnswers.normAnswers,
+      normAnswer: normalizedAnswers,
       answerType: AnswerType.EXPRESSION
     };
     return this;
@@ -211,13 +184,11 @@ export class CorrectExpressionAnswer extends BaseAnswer<string> {
 export class NumberAnswer extends TeamAnswer<number> {
   constructor(config: ITeamAnswerConfig<number>) {
     super(config); // Pass the config to the TeamAnswer constructor
-    const extractedAnswers = this.answerContent.isShortAnswerEnabled ? extractFromDelta(this.answerContent.delta) : this.answerContent.rawAnswer;
-    const normalizedAnswers = normalizeAnswers(extractedAnswers, AnswerType.NUMBER);
+    const normalizedAnswers = normalizeAnswers(this.answerContent.rawAnswer, AnswerType.NUMBER);
     
     this.answerContent = {
       ...this.answerContent,
-      rawAnswer: normalizedAnswers.rawAnswers,
-      normAnswer: normalizedAnswers.normAnswers,
+      normAnswer: normalizedAnswers,
       answerType: AnswerType.NUMBER
     };
     return this;
@@ -234,12 +205,11 @@ export class NumberAnswer extends TeamAnswer<number> {
 export class StringAnswer extends TeamAnswer<string> {
   constructor(config: ITeamAnswerConfig<string>) {
     super(config); // Pass the config to the TeamAnswer constructor
-    const extractedAnswers = this.answerContent.isShortAnswerEnabled ? extractFromDelta(this.answerContent.delta) : this.answerContent.rawAnswer;
-    const normalizedAnswers = normalizeAnswers(extractedAnswers, AnswerType.STRING);
+    const normalizedAnswers = normalizeAnswers(this.answerContent.rawAnswer, AnswerType.STRING);
+
     this.answerContent = {
       ...this.answerContent,
-      rawAnswer: normalizedAnswers.rawAnswers,
-      normAnswer: normalizedAnswers.normAnswers,
+      normAnswer: normalizedAnswers,
       answerType: AnswerType.STRING
     };
     return this;
@@ -257,15 +227,11 @@ export class StringAnswer extends TeamAnswer<string> {
 export class ExpressionAnswer extends TeamAnswer<string> {
   constructor(config: ITeamAnswerConfig<string>) {
     super(config); // Pass the config to the TeamAnswer constructor
+    const normalizedAnswers = normalizeAnswers(this.answerContent.rawAnswer, AnswerType.EXPRESSION);
 
-    const extractedAnswers = this.answerContent.isShortAnswerEnabled ? extractFromDelta(this.answerContent.delta) : this.answerContent.rawAnswer;
-    console.log(extractedAnswers);
-    const normalizedAnswers = normalizeAnswers(extractedAnswers, AnswerType.EXPRESSION);
-    console.log(normalizedAnswers);
     this.answerContent = {
       ...this.answerContent,
-      rawAnswer: normalizedAnswers.rawAnswers,
-      normAnswer: normalizedAnswers.normAnswers,
+      normAnswer: normalizedAnswers,
       answerType: AnswerType.EXPRESSION
     };
     return this;

--- a/play/public/locales/en/translation.json
+++ b/play/public/locales/en/translation.json
@@ -85,7 +85,15 @@
       "questioncard": "Question",
       "answercard": "Choose the correct answer",
       "openanswercard": "Enter your answer",
-      "openanswercardplaceholder": "Enter your answer here..."
+      "openanswercarddescription": "Your teacher is expecting a",
+      "openanswercardnumberanswer1": "numeric answer as a whole number.",
+      "openanswercardnumberanswer2": "numeric as to one decimal place.",
+      "openanswercardnumberanswer3": "numeric as to two decimal places.",
+      "openanswercardnumberanswer4": "numeric as to three decimal places.",
+      "openanswercardwordanswer": "short word answer.",
+      "openanswercardexpressionanswer": "math expression.",
+      "openanswercardplaceholder": "Enter your answer here...",
+      "openanswercardnumberwarning": "Only the following inputs are allowed: . - % 0-9 "
     },
     "discussanswer": {
       "questionanswercolumn": "Question and Correct Answer",

--- a/play/src/components/openanswercard/OpenAnswerCard.tsx
+++ b/play/src/components/openanswercard/OpenAnswerCard.tsx
@@ -10,7 +10,6 @@ import {
   AnswerType,
   AnswerPrecision
 } from '@righton/networking';
-import ReactQuill from 'react-quill';
 import katex from 'katex';
 import './ReactQuill.css';
 import 'katex/dist/katex.min.css';
@@ -43,13 +42,9 @@ export default function OpenAnswerCard({
 }: OpenAnswerCardProps) {
   const theme = useTheme();
   const { t } = useTranslation();
-  const modules = {
-    toolbar: [['formula']],
-  };
-  const formats = ['formula'];
   const [isBadInput, setIsBadInput] = useState(false); 
   const answerType = AnswerType[answerSettings?.answerType as keyof typeof AnswerType] ?? AnswerType.STRING;
-  const numericAnswerRegex = /^-?[0-9]+(\.[0-9]+)?%?$/;
+  const numericAnswerRegex = /^-?[0-9]*(\.[0-9]*)?%?$/;
   const getAnswerText = (inputAnswerSettings: IAnswerSettings | null) => {
     switch (inputAnswerSettings?.answerType) {
       case AnswerType.STRING:
@@ -83,7 +78,7 @@ export default function OpenAnswerCard({
     let isBadInputDetected = false;
     if (answerSettings?.answerType === AnswerType.NUMBER) {
       isBadInputDetected = !numericAnswerRegex.test(currentAnswer);
-      currentAnswer = currentAnswer.replace(/(?!-?[0-9]+(\.[0-9]+)?%?)./g, '');
+      currentAnswer = currentAnswer.replace(/[^0-9.%-]/g, '');
       setIsBadInput(isBadInputDetected);
     }
     const extractedAnswer: ITeamAnswerContent = {
@@ -107,6 +102,7 @@ export default function OpenAnswerCard({
       currentQuestionIndex,
       isShortAnswerEnabled,
       isSubmitted: true,
+      answerPrecision: answerSettings?.answerPrecision,
     } as ITeamAnswerContent;
     handleSubmitAnswer(packagedAnswer);
   };

--- a/play/src/components/openanswercard/OpenAnswerCard.tsx
+++ b/play/src/components/openanswercard/OpenAnswerCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, RefObject } from 'react';
+import React, { ChangeEvent, useState, RefObject } from 'react';
 import { useTheme } from '@mui/material/styles';
 import { useTranslation } from 'react-i18next';
 import { Typography, Box } from '@mui/material';
@@ -7,10 +7,8 @@ import {
   ITeamAnswerContent,
   IAnswerSettings,
   GameSessionState,
-  NumberAnswer,
-  StringAnswer,
-  ExpressionAnswer,
-  AnswerType
+  AnswerType,
+  AnswerPrecision
 } from '@righton/networking';
 import ReactQuill from 'react-quill';
 import katex from 'katex';
@@ -20,6 +18,7 @@ import { StorageKeyAnswer} from '../../lib/PlayModels';
 import BodyCardStyled from '../../lib/styledcomponents/BodyCardStyled';
 import BodyCardContainerStyled from '../../lib/styledcomponents/BodyCardContainerStyled';
 import ButtonSubmitAnswer from '../ButtonSubmitAnswer';
+import ShortAnswerTextFieldStyled from '../../lib/styledcomponents/ShortAnswerTextFieldStyled';
 
 window.katex = katex;
 
@@ -48,27 +47,47 @@ export default function OpenAnswerCard({
     toolbar: [['formula']],
   };
   const formats = ['formula'];
+  const [isBadInput, setIsBadInput] = useState(false); 
   const answerType = AnswerType[answerSettings?.answerType as keyof typeof AnswerType] ?? AnswerType.STRING;
-  // these two functions isolate the quill data structure (delta) from the rest of the app
-  // this allows for the use of a different editor in the future by just adjusting the parsing in these functions
-  const insertQuillDelta = (inputAnswer: ITeamAnswerContent) => {
-    return inputAnswer.delta ?? [];
-  };
-
+  const numericAnswerRegex = /^-?[0-9]+(\.[0-9]+)?%?$/;
+  const getAnswerText = (inputAnswerSettings: IAnswerSettings | null) => {
+    switch (inputAnswerSettings?.answerType) {
+      case AnswerType.STRING:
+        return t('gameinprogress.chooseanswer.openanswercardwordanswer');
+      case AnswerType.EXPRESSION:
+        return t('gameinprogress.chooseanswer.openanswercardexpressionanswer');
+      case AnswerType.NUMBER:
+        default: 
+          switch(inputAnswerSettings?.answerPrecision){
+            case (AnswerPrecision.THOUSANDTH):
+              return t('gameinprogress.chooseanswer.openanswercardnumberanswer4');
+            case (AnswerPrecision.HUNDREDTH):
+              return t('gameinprogress.chooseanswer.openanswercardnumberanswer3');
+            case (AnswerPrecision.TENTH):
+              return t('gameinprogress.chooseanswer.openanswercardnumberanswer2');
+            case (AnswerPrecision.WHOLE):
+              default:
+                return t('gameinprogress.chooseanswer.openanswercardnumberanswer1');
+          }
+    }
+  }
+  const answerText = getAnswerText(answerSettings);
   const [editorContents, setEditorContents] = useState<any>(() => // eslint-disable-line @typescript-eslint/no-explicit-any
-    insertQuillDelta(answerContent)
+    answerContent?.rawAnswer ?? ''
   );
-
   // ReactQuill onChange expects four parameters
   const handleEditorContentsChange = (
-    content: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    delta: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    source: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    editor: any // eslint-disable-line @typescript-eslint/no-explicit-any
+    event: ChangeEvent<HTMLInputElement>
   ) => {
-    const currentAnswer = editor.getContents();
+    let currentAnswer = event.target.value;
+    let isBadInputDetected = false;
+    if (answerSettings?.answerType === AnswerType.NUMBER) {
+      isBadInputDetected = !numericAnswerRegex.test(currentAnswer);
+      currentAnswer = currentAnswer.replace(/(?!-?[0-9]+(\.[0-9]+)?%?)./g, '');
+      setIsBadInput(isBadInputDetected);
+    }
     const extractedAnswer: ITeamAnswerContent = {
-      delta: currentAnswer,
+      rawAnswer: currentAnswer,
       currentState,
       currentQuestionIndex,
       isShortAnswerEnabled,
@@ -80,10 +99,10 @@ export default function OpenAnswerCard({
     );
     setEditorContents(currentAnswer);
   };
-
+  
   const handlePresubmit = (currentContents: any) => { // eslint-disable-line @typescript-eslint/no-explicit-any
     const packagedAnswer: ITeamAnswerContent = {
-      delta: currentContents,
+      rawAnswer: currentContents,
       currentState,
       currentQuestionIndex,
       isShortAnswerEnabled,
@@ -101,6 +120,18 @@ export default function OpenAnswerCard({
         >
           {t('gameinprogress.chooseanswer.openanswercard')}
         </Typography>
+        <Typography
+          variant="body1"
+          sx={{ width: '100%', textAlign: 'center' }}
+        >
+          {t('gameinprogress.chooseanswer.openanswercarddescription')}
+          <Typography
+          variant="body1"
+          sx={{ width: '100%', textAlign: 'center', fontWeight: 700 }}
+        >
+          {answerText}
+        </Typography>
+        </Typography>
         <Box
           style={{
             display: 'flex',
@@ -111,26 +142,34 @@ export default function OpenAnswerCard({
             gap: '20px',
           }}
         >
-          <ReactQuill
+          <ShortAnswerTextFieldStyled
             className="swiper-no-swiping"
-            theme="snow"
-            readOnly={isSubmitted}
-            value={editorContents}
+            data-testid="gameCode-inputtextfield"
+            fullWidth
+            variant="filled"
+            autoComplete="off"
+            multiline
+            minRows={2}
+            maxRows={2}
+            placeholder={t('gameinprogress.chooseanswer.openanswercardplaceholder') ?? ''}
             onChange={handleEditorContentsChange}
-            placeholder={
-              t('gameinprogress.chooseanswer.openanswercardplaceholder') ?? ''
-            }
-            modules={modules}
-            formats={formats}
-            bounds={`[data-text-editor="name"]`}
-            style={{
-              width: '100%',
-              backgroundColor: !isSubmitted
-                ? ''
-                : `${theme.palette.primary.lightGrey}`,
-              borderRadius: '4px',
+            value={editorContents}
+            InputProps={{
+              disableUnderline: true,
+              style: {
+                paddingTop: '9px',
+              },
             }}
           />
+          { isBadInput
+            ? <Typography
+                variant="body1"
+                sx={{ width: '100%', textAlign: 'center' }}
+              >
+                  {t('gameinprogress.chooseanswer.openanswercardnumberwarning')}
+              </Typography>
+            : null
+          }
           <ButtonSubmitAnswer
             isSelected={
               !isNullOrUndefined(editorContents) && editorContents !== ''

--- a/play/src/lib/HelperFunctions.tsx
+++ b/play/src/lib/HelperFunctions.tsx
@@ -61,7 +61,6 @@ export const checkForSubmittedAnswerOnRejoin = (
   isShortAnswerEnabled: boolean,
 ): ITeamAnswerContent => {
   let returnedAnswer: ITeamAnswerContent = {
-    delta: '',
     rawAnswer: '',
     normAnswer: [],
     multiChoiceAnswerIndex: null,

--- a/play/src/lib/styledcomponents/ShortAnswerTextFieldStyled.tsx
+++ b/play/src/lib/styledcomponents/ShortAnswerTextFieldStyled.tsx
@@ -1,0 +1,24 @@
+import { styled } from '@mui/material/styles';
+import { TextField } from '@mui/material';
+
+export default styled(TextField)(({ theme }) => ({
+  '& .MuiFilledInput-root': {
+    borderRadius: 5,
+    overflow: 'hidden',
+    backgroundColor: 'white',
+    border: `1px solid ${theme.palette.primary.darkGrey}`,
+    width: 'auto',
+    transition: theme.transitions.create([
+      'border-color',
+      'background-color',
+      'box-shadow',
+    ]),
+    '&:hover': {
+      backgroundColor: 'white',
+    },
+    '&.Mui-focused': {
+      border: `1px solid ${theme.palette.primary.darkGrey}`,
+      backgroundColor: 'white',
+    },
+  },
+}));

--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -204,9 +204,9 @@ export default function GameInProgress({
       }
       case (AnswerType.NUMBER):
       default: {
-        const answerConfig: ITeamAnswerConfig<number> = {
+        const answerConfig: ITeamAnswerConfig<string> = {
           ...answerConfigBase,
-          value: 0
+          value: ''
         }
         answer = new NumberAnswer(answerConfig);
         break;


### PR DESCRIPTION
This PR includes one update:

1. If we allow the teacher to specify the answer type up front, we don't have a huge need for the Quill pad, as we can just convert any math expressions directly into Latex ourselves. As such, we no longer need to deal with the handling of the Quill delta object and we can probably get a better user experience using mui TextFields to keep things consistent. 
