### PR TITLE
[Central/Host] - Verify teacher input when creating questions and host bug

### DIFF
--- a/central/src/components/CreateQuestion.jsx
+++ b/central/src/components/CreateQuestion.jsx
@@ -18,6 +18,9 @@ export default function QuestionForm({ updateQuestion, question: initialState, g
   const originalQuestion = location.state || initialState || null;
   const [answerType, setAnswerType] = useState('number');
   const [answerPrecision, setAnswerPrecision] = useState('WHOLE');
+  const numericAnswerRegex = /^-?[0-9]*(\.[0-9]*)?%?$/; 
+  const [isAnswerTypeInvalid, setIsAnswerTypeInvalid] = useState(false);
+  const [isAnswerDecimalInvalid, setIsAnswerDecimalInvalid] = useState(false);
 
   const [question, setQuestion] = useState(() => {
     if (originalQuestion) {
@@ -37,6 +40,17 @@ export default function QuestionForm({ updateQuestion, question: initialState, g
     }
   });
 
+  const decimalValidator = (inputValue) => {
+    const answerPrecisionDictionary = {
+      ['WHOLE']: 0,
+      ['TENTH']: 1,
+      ['HUNDREDTH']: 2,
+      ['THOUSANDTH']: 3
+    }
+    const precisionValue = answerPrecisionDictionary[answerPrecision];
+    const roundedNumberAsString = Number(inputValue).toFixed(precisionValue);
+    return inputValue.toString() === roundedNumberAsString;
+  }
   // Handles which Url to redirect to when clicking the Back to Game Maker button
   const handleBack = useCallback(() => {
     if (gameId != null) {
@@ -60,11 +74,18 @@ export default function QuestionForm({ updateQuestion, question: initialState, g
   const onChangeMaker = useCallback((field) => ({ currentTarget }) => { setQuestion({ ...question, [field]: handleStringInput(currentTarget.value) }); }, [question, setQuestion]);
 
   // When a wrong answer is changed/update this function handles that change
-  const onChoiceTextChangeMaker = useCallback((choiceIndex) => ({ currentTarget }) => {
+  const onChoiceTextChangeMaker = (choiceIndex, answerType) => ({ currentTarget }) => {
+    if (choiceIndex === 0 && answerType === 'number') {
+      setIsAnswerTypeInvalid(!numericAnswerRegex.test(currentTarget.value));
+      currentTarget.value = currentTarget.value.replace(/[^0-9.%-]/g, '');
+      setIsAnswerDecimalInvalid(!decimalValidator(currentTarget.value));
+    } else {
+      setIsAnswerDecimalInvalid(false);
+    }
     const newChoices = [...question.choices];
     newChoices[choiceIndex].text = handleStringInput(currentTarget.value);
     setQuestion({ ...question, choices: newChoices });
-  }, [question, setQuestion]);
+  };
 
   // When the wrong answer reasoning is changed/update this function handles that change
   const onChoiceReasonChangeMaker = useCallback((choiceIndex) => ({ currentTarget }) => {
@@ -192,6 +213,8 @@ export default function QuestionForm({ updateQuestion, question: initialState, g
                 setAnswerType={setAnswerType}
                 answerPrecision={answerPrecision}
                 setAnswerPrecision={setAnswerPrecision}
+                isAnswerTypeInvalid={isAnswerTypeInvalid}
+                isAnswerDecimalInvalid={isAnswerDecimalInvalid}
               />
             ))}
           </Grid>

--- a/central/src/components/CreateQuestionAnswerDropdown.jsx
+++ b/central/src/components/CreateQuestionAnswerDropdown.jsx
@@ -15,13 +15,24 @@ export default function QuestionFormAnswerDropdown({
   answerType,
   setAnswerType,
   answerPrecision,
-  setAnswerPrecision
+  setAnswerPrecision,
+  isAnswerTypeInvalid,
+  isAnswerDecimalInvalid
 }) {
   const classes = useStyles();
   const [expanded, setExpanded] = useState(false);
-
-
-  // instructions can be either null (when empty game is first started), [''] (when an empty instruction is passed back to this component), or an object (when a already created game is being editted)
+  const getAnswerText = (answerType) => {
+    switch (answerType) {
+      case ('string'):
+        return 'Please ensure that your input is a valid string';
+      case ('number'):
+        return 'Please ensure that your input is a valid number. Allowable characters are: 0-9, -, .';
+      case ('expression'):
+        return 'Please ensure that your input is a valid expression';
+    }
+  }
+  const answerText = isAnswerTypeInvalid ? getAnswerText(answerType) : '';
+  // instructio s can be either null (when empty game is first started), [''] (when an empty instruction is passed back to this component), or an object (when a already created game is being editted)
   // TODO: clean up how we are handling instructions for more consistency
   const instructionsHandler = (instructions) => {
     if (!instructions)
@@ -32,7 +43,10 @@ export default function QuestionFormAnswerDropdown({
       return JSON.parse(instructions);
   }
   const instructionsArray = instructionsHandler(instructions);
-
+  const handleOnTypeChange = (event) => {
+    setAnswerType(event.target.value);
+    onChoiceTextChangeMaker(index, event.target.value)({ currentTarget: { value: choice.text } });
+  };
   return (
     <Grid item xs={12}>
       <Card className={choice.isAnswer ? classes.correctCard : classes.wrongCard}>
@@ -45,7 +59,7 @@ export default function QuestionFormAnswerDropdown({
                 style={{ width: 600, margin: 0, position: 'relative', left: 16 }}
                 id={`choice${index + 1}`}
                 value={choice.text}
-                onChange={onChoiceTextChangeMaker(index)}
+                onChange={onChoiceTextChangeMaker(index, answerType)}
                 label="Type Answer Here"
                 variant="outlined"
                 required
@@ -59,7 +73,7 @@ export default function QuestionFormAnswerDropdown({
             <>
               <Box className={classes.answerTypeBox}> 
                 <Typography className={classes.answerType}>{"Answer Type: "}</Typography>
-                <RadioGroup value={answerType} row onChange={(event) => setAnswerType(event.target.value)}>
+                <RadioGroup value={answerType} row onChange={(event) =>{ handleOnTypeChange(event)}}>
                   <FormControlLabel 
                     className={classes.radioLabel} 
                     value={'text'}
@@ -110,7 +124,16 @@ export default function QuestionFormAnswerDropdown({
                   />
                 </RadioGroup>
               </Box>
+             
               : null}
+              <Box>   
+                { isAnswerTypeInvalid &&
+                  <Typography style={{ fontStyle: 'italic' }}> {answerText} </Typography>
+                }
+                 { isAnswerDecimalInvalid &&
+                  <Typography style={{ fontStyle: 'italic' }}> Please ensure the answer has the correct number of decimal places. </Typography>
+                }
+              </Box>
             </>
           : null} 
         </Box>

--- a/central/yarn.lock
+++ b/central/yarn.lock
@@ -5732,9 +5732,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001489:
-  version "1.0.30001492"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz#4a06861788a52b4c81fd3344573b68cc87fe062b"
-  integrity sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==
+  version "1.0.30001565"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz"
+  integrity sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -39,7 +39,6 @@ export default function GameInProgressContentSwitch ({
     handleOnSelectMistake,
   }) {
   const classes = useStyles();
-  console.log(data);
   const gameplayComponents = [
     <>
       {graphClickInfo.graph === null ? (

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -118,7 +118,7 @@ const GameSessionContainer = () => {
                     && answer.isChosen) 
                   ) {
                     setShortAnswerResponses((prev) => {
-                     return buildShortAnswerResponses(prev, getQuestionChoices(response.questions, response.currentQuestionIndex), answer, team.name)
+                     return buildShortAnswerResponses(prev, getQuestionChoices(response.questions, response.currentQuestionIndex), response.questions[response.currentQuestionIndex].answerSettings, answer, team.name)
                    });
                   }
                 });
@@ -236,10 +236,11 @@ const GameSessionContainer = () => {
               team.teamMembers.forEach((teamMember) => {
                 if (teamMember.id === teamAnswerResponse.teamMemberAnswersId) {
                   teamMember.answers.forEach((answer) => {
-                    if (answer.id === teamAnswerResponse.id)
+                    if (answer.id === teamAnswerResponse.id){
                       answer.confidenceLevel =
                         teamAnswerResponse.confidenceLevel;
                       teamName = team.name;
+                    }
                   });
                 }
               });
@@ -250,7 +251,7 @@ const GameSessionContainer = () => {
           let newShortAnswers = JSON.parse(JSON.stringify(existingAnswers));
           newShortAnswers.forEach((answer) => {
             answer.teams.forEach((answerTeam) => {
-              if (answerTeam.team === teamName) {
+              if (answerTeam.name === teamName) {
                 answerTeam.confidence = teamAnswerResponse.confidenceLevel;   
               }
             })

--- a/host/yarn.lock
+++ b/host/yarn.lock
@@ -7214,9 +7214,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001464, caniuse-lite@^1.0.30001489:
-  version "1.0.30001492"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001492.tgz"
-  integrity sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==
+  version "1.0.30001565"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz"
+  integrity sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
This PR adds two updates:

1. Mirrors the same validation logic used on `play` for when a teacher creates a question in `central`. If a teacher were to enter an invalid number, it would cause havoc in the game so we need to ensure that they are following the format they specify with the radio buttons. 
2. Fixes a bug with the confidence levels on `host` that arose from a mismatch of naming.
