### PR TITLE
[Host/Play/Networking] - Updates across the apps to handle intaking/sending to lambda hints by `host`

### DIFF
--- a/host/src/components/FooterGame.jsx
+++ b/host/src/components/FooterGame.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles, BottomNavigation } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
-import PlayersAnsweredBar from './PlayersAnsweredBar';
+import LinearProgressBar from './LinearProgressBar';
 import ModuleNavigator from './ModuleNavigator';
 
 export default function FooterGame({
@@ -39,9 +39,9 @@ export default function FooterGame({
           <>
             <div style={{ opacity: gameTimer ? 1 : 0.4, width: '100%' }}>
               <div className={classes.playerNum}>Players who have answered</div>
-              <PlayersAnsweredBar
-                numPlayers={numPlayers}
-                totalAnswers={totalAnswers}
+              <LinearProgressBar
+                inputNum={totalAnswers}
+                totalNum={numPlayers}
               />
             </div>
             <ModuleNavigator

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -45,7 +45,9 @@ export default function GameInProgressContentSwitch ({
     handleHintChange,
     hints,
     gptHints,
-    handleProcessHintsClick,
+    hintsError,
+    isHintLoading,
+    handleProcessHints
   }) {
   const classes = useStyles();
   const graphClickRenderSwitch = (graphClickInfo) => {
@@ -117,7 +119,10 @@ export default function GameInProgressContentSwitch ({
               statePosition={statePosition}
               graphClickInfo={graphClickInfo}
               handleGraphClick={handleGraphClick}
-              handleProcessHintsClick={handleProcessHintsClick}
+              hintsError={hintsError}
+              currentState={currentState}
+              isHintLoading={isHintLoading}
+              handleProcessHints={handleProcessHints}
             />
             <PlayerThinkingSelectedAnswer
               gptHints={gptHints}
@@ -198,7 +203,10 @@ export default function GameInProgressContentSwitch ({
                 statePosition={statePosition}
                 graphClickInfo={graphClickInfo}
                 handleGraphClick={handleGraphClick}
-                handleProcessHintsClick={handleProcessHintsClick}
+                hintsError={hintsError}
+                currentState={currentState}
+                isHintLoading={isHintLoading}
+                handleProcessHints={handleProcessHints}
               />
             </div>
           ) : null}

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -11,6 +11,8 @@ import ConfidenceResponseDropdown from "./ConfidenceResponses/ConfidenceResponse
 import EnableShortAnswerCard from "./EnableShortAnswerCard";
 import EnableHintCard from "./EnableHintCard";
 import FeaturedMistakes from "./FeaturedMistakes";
+import PlayerThinking from "./PlayerThinking/PlayerThinking";
+import PlayerThinkingSelectedAnswer from './PlayerThinking/PlayerThinkingSelectedAnswer';
 
 export default function GameInProgressContentSwitch ({ 
     questions, 
@@ -41,8 +43,91 @@ export default function GameInProgressContentSwitch ({
     hintCardRef,
     isHintEnabled,
     handleHintChange,
+    hints,
+    gptHints,
+    handleProcessHintsClick,
   }) {
   const classes = useStyles();
+  const graphClickRenderSwitch = (graphClickInfo) => {
+    switch (graphClickInfo.graph){
+      case ('realtime'):
+        return (
+          <div 
+            id="responses-scrollbox" 
+            ref={responsesRef}     
+            className={classes.contentContainer}
+          >
+            <Responses
+              data={data}
+              numPlayers={numPlayers}
+              totalAnswers={totalAnswers}
+              questionChoices={questionChoices}
+              statePosition={statePosition}
+              graphClickInfo={graphClickInfo}
+              handleGraphClick={handleGraphClick}
+              isShortAnswerEnabled={isShortAnswerEnabled}
+            />
+            <SelectedAnswer
+              data={data}
+              graphClickInfo={graphClickInfo}
+              correctChoiceIndex={correctChoiceIndex}
+              numPlayers={numPlayers}
+              statePosition={statePosition}
+              isShortAnswerEnabled={isShortAnswerEnabled}
+            />
+          </div>
+        );
+      case ('confidence'):
+        return (
+          <div 
+            id="confidencecard-scrollbox" 
+            ref={confidenceCardRef}
+            className={classes.contentContainer}
+          >
+            <ConfidenceResponseCard
+              confidenceData={confidenceData}
+              orderedAnswers={answers}
+              graphClickInfo={graphClickInfo}
+              handleGraphClick={handleGraphClick}
+            />
+            <ConfidenceResponseDropdown
+              graphClickInfo={graphClickInfo}
+              selectedConfidenceData={
+                confidenceData[graphClickInfo.selectedIndex]
+              }
+            />
+          </div>
+        );
+      case ('hint'):
+        return (
+          <div 
+            id="hint-scrollbox" 
+            ref={hintCardRef}
+            className={classes.contentContainer}
+          >
+            <PlayerThinking
+              hints={hints}
+              gptHints={gptHints}
+              questions={questions}
+              questionChoices={questionChoices}
+              currentQuestionIndex={currentQuestionIndex}
+              answers={answers}
+              totalAnswers={totalAnswers}
+              numPlayers={numPlayers}
+              statePosition={statePosition}
+              graphClickInfo={graphClickInfo}
+              handleGraphClick={handleGraphClick}
+              handleProcessHintsClick={handleProcessHintsClick}
+            />
+            <PlayerThinkingSelectedAnswer
+              gptHints={gptHints}
+              graphClickInfo={graphClickInfo}
+              numPlayers={numPlayers}
+            />
+          </div>
+        );
+    }
+  }
   const gameplayComponents = [
     <Box className={classes.configContainer}>
       {graphClickInfo.graph === null ? (
@@ -89,11 +174,7 @@ export default function GameInProgressContentSwitch ({
                 shortAnswerResponses={shortAnswerResponses} 
                 totalAnswers={totalAnswers}
                 handleOnSelectMistake={handleOnSelectMistake}
-                handleProcessAnswersClick={handleProcessAnswersClick}
-                handleModelChange={handleModelChange}
                 numPlayers={numPlayers}
-                gptAnswers={gptAnswers}
-                gptModel={gptModel}
               />
             </div>
           ) : null}
@@ -102,13 +183,12 @@ export default function GameInProgressContentSwitch ({
             currentState === GameSessionState.PHASE_2_DISCUSS) ? (
             <div
               id="hint-scrollbox"
-              ref={hintRef}
+              ref={hintCardRef}
               className={classes.contentContainer}
             >
               <PlayerThinking
                 hints={hints}
                 gptHints={gptHints}
-                gptModel={gptModel}
                 questions={questions}
                 questionChoices={questionChoices}
                 currentQuestionIndex={currentQuestionIndex}
@@ -119,7 +199,6 @@ export default function GameInProgressContentSwitch ({
                 graphClickInfo={graphClickInfo}
                 handleGraphClick={handleGraphClick}
                 handleProcessHintsClick={handleProcessHintsClick}
-                handleModelChange={handleModelChange}
               />
             </div>
           ) : null}

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -44,7 +44,7 @@ export default function GameInProgressContentSwitch ({
   }) {
   const classes = useStyles();
   const gameplayComponents = [
-    <>
+    <Box className={classes.configContainer}>
       {graphClickInfo.graph === null ? (
         <>
           <div id="questioncard-scrollbox" ref={questionCardRef}>
@@ -89,6 +89,37 @@ export default function GameInProgressContentSwitch ({
                 shortAnswerResponses={shortAnswerResponses} 
                 totalAnswers={totalAnswers}
                 handleOnSelectMistake={handleOnSelectMistake}
+                handleProcessAnswersClick={handleProcessAnswersClick}
+                handleModelChange={handleModelChange}
+                numPlayers={numPlayers}
+                gptAnswers={gptAnswers}
+                gptModel={gptModel}
+              />
+            </div>
+          ) : null}
+          {isHintEnabled &&
+           (currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER ||
+            currentState === GameSessionState.PHASE_2_DISCUSS) ? (
+            <div
+              id="hint-scrollbox"
+              ref={hintRef}
+              className={classes.contentContainer}
+            >
+              <PlayerThinking
+                hints={hints}
+                gptHints={gptHints}
+                gptModel={gptModel}
+                questions={questions}
+                questionChoices={questionChoices}
+                currentQuestionIndex={currentQuestionIndex}
+                answers={answers}
+                totalAnswers={totalAnswers}
+                numPlayers={numPlayers}
+                statePosition={statePosition}
+                graphClickInfo={graphClickInfo}
+                handleGraphClick={handleGraphClick}
+                handleProcessHintsClick={handleProcessHintsClick}
+                handleModelChange={handleModelChange}
               />
             </div>
           ) : null}
@@ -109,47 +140,10 @@ export default function GameInProgressContentSwitch ({
           </div>
         </>
       ) : (
-        <div className={classes.contentContainer}>
-          {graphClickInfo.graph === 'realtime' ? (
-            <div id="responses-scrollbox" ref={responsesRef}>
-              <Responses
-                data={data}
-                numPlayers={numPlayers}
-                totalAnswers={totalAnswers}
-                questionChoices={questionChoices}
-                statePosition={statePosition}
-                graphClickInfo={graphClickInfo}
-                handleGraphClick={handleGraphClick}
-                isShortAnswerEnabled={isShortAnswerEnabled}
-              />
-              <SelectedAnswer
-                data={data}
-                graphClickInfo={graphClickInfo}
-                correctChoiceIndex={correctChoiceIndex}
-                numPlayers={numPlayers}
-                statePosition={statePosition}
-                isShortAnswerEnabled={isShortAnswerEnabled}
-              />
-            </div>
-          ) : (
-            <div id="confidencecard-scrollbox" ref={confidenceCardRef}>
-              <ConfidenceResponseCard
-                confidenceData={confidenceData}
-                orderedAnswers={answers}
-                graphClickInfo={graphClickInfo}
-                handleGraphClick={handleGraphClick}
-              />
-              <ConfidenceResponseDropdown
-                graphClickInfo={graphClickInfo}
-                selectedConfidenceData={
-                  confidenceData[graphClickInfo.selectedIndex]
-                }
-              />
-            </div>
-          )}
-        </div>
-      )}
-    </>,
+        graphClickRenderSwitch(graphClickInfo)
+      )
+    };
+    </Box>,
   ];
 
   const questionCofigurationComponents = [

--- a/host/src/components/LinearProgressBar.jsx
+++ b/host/src/components/LinearProgressBar.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core';
 import LinearProgress from '@material-ui/core/LinearProgress';
 
-export default function PlayersAnsweredBar({ numPlayers, totalAnswers }) {
+export default function LinearProgressBar({ inputNum, totalNum }) {
   const classes = useStyles();
   const progressPercent =
-    numPlayers !== 0 ? (totalAnswers / numPlayers) * 100 : 0;
+    inputNum !== 0 ? (inputNum / totalNum) * 100 : 0;
 
   return (
     <div className={classes.bargroup}>
@@ -33,10 +33,10 @@ export default function PlayersAnsweredBar({ numPlayers, totalAnswers }) {
             lineHeight: '18px',
           }}
         >
-          {totalAnswers}
+          {inputNum}
         </div>
       </div>
-      <div className={classes.totalPlayers}>{numPlayers}</div>
+      <div className={classes.totalNum}>{totalNum}</div>
     </div>
   );
 }
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
     gap: '10px',
     width: '100%',
   },
-  totalPlayers: {
+  totalNum: {
     fontSize: '12px',
     lineHeight: '12px',
     color: 'white',

--- a/host/src/components/PlayerThinking/CustomBar.jsx
+++ b/host/src/components/PlayerThinking/CustomBar.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Bar } from 'victory';
+import { makeStyles } from '@material-ui/core';
+import { isNullOrUndefined } from '@righton/networking';
+
+export default function CustomBar(props) {
+  const {
+    y,
+    xSmallPadding,
+    mediumPadding,
+    defaultVictoryPadding,
+    selectedWidth,
+    selectedHeight,
+    datum,
+    index,
+    graphClickInfo,
+    handleGraphClick
+  } = props;
+  const classes = useStyles();
+  return (
+    <g style={{ pointerEvents: 'bounding-box' }}>
+      <Bar {...props} />
+      {datum.teams.length > 0 && (
+        <rect
+          className={classes.highlight}
+          x={0}
+          y={y - mediumPadding}
+          width={selectedWidth + defaultVictoryPadding}
+          height={selectedHeight + mediumPadding - xSmallPadding / 2}
+          fill={
+            graphClickInfo.selectedIndex &&
+            graphClickInfo.selectedIndex === index &&
+            graphClickInfo.graph === 'hint'
+              ? 'rgba(255, 255, 255, 0.2)'
+              : 'transparent'
+          }
+          stroke="transparent"
+          rx={8}
+          ry={8}
+          onClick={() =>
+            handleGraphClick({ graph: 'hint', selectedIndex: index })
+          }
+          style={{ cursor: 'pointer' }}
+        />
+      )}
+    </g>
+  );
+}
+
+const useStyles = makeStyles(() => ({
+  highlight: {
+    '&:hover': {
+      fill: 'rgba(255, 255, 255, 0.2)',
+    },
+  },
+}));

--- a/host/src/components/PlayerThinking/CustomLabel.jsx
+++ b/host/src/components/PlayerThinking/CustomLabel.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { VictoryLabel } from 'victory';
+
+export default function CustomLabel(props) {
+  const {
+    x,
+    y,
+    datum,
+    barThickness,
+    labelOffset,
+    xSmallPadding,
+    mediumLargePadding,
+    noResponseLabel
+  } = props;
+  return (
+    <g>
+      {datum.teams.length !== 0 && (
+        <VictoryLabel
+          {...props}
+          x={mediumLargePadding}
+          y={y- labelOffset}
+          dx={0}
+          dy={-barThickness / 2 - xSmallPadding}
+          textAnchor="start"
+          verticalAnchor="end"
+          text={datum.themeText}
+          style={{
+            fontSize: 15,
+            fill: 'white',
+          }}
+        />
+      )}
+      <VictoryLabel
+        {...props}
+        x={x > 70 ? x - labelOffset : x + mediumLargePadding}
+        y={y}
+        textAnchor="end"
+        verticalAnchor="middle"
+        text={datum.teams.length > 0 ? `${Math.ceil(datum.teams.length)}` : ''}
+        style={{
+          fontSize: 15,
+          fill:
+            datum.teams.length === 0 ||
+            datum.themeText === noResponseLabel ||
+            x <= 70
+              ? '#FFF'
+              : '#384466',
+        }}
+      />
+    </g>
+  );
+}

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -48,7 +48,7 @@ export default function PlayerThinking({
       : 
       <Box style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: 16}}>
         <Typography className={classes.infoText}>
-        {hints.prevSubmittedHints.length} / {numPlayers} players have submitted a hint
+        {hints.length} / {numPlayers} players have submitted a hint
         </Typography>
           <Button
           className={classes.button}

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -7,7 +7,6 @@ import PlayerThinkingGraph from './PlayerThinkingGraph';
 export default function PlayerThinking({
   hints,
   gptHints,
-  gptModel,
   numPlayers,
   totalAnswers,
   questionChoices,
@@ -15,33 +14,18 @@ export default function PlayerThinking({
   graphClickInfo,
   isShortAnswerEnabled,
   handleGraphClick,
-  handleProcessHintsClick,
-  handleModelChange
+  handleProcessHintsClick
 }) {
   const classes = useStyles();
-  const handleChange = (event) => {
-  };
   return (
     <Box className={classes.centerContent}>
       <Box style={{display: 'flex', aligntItems: 'center', justifyContent: 'space-between', width: '100%'}}>
         <Typography className={classes.titleStyle}>
           Player Thinking
         </Typography>
-        <RadioGroup
-          aria-labelledby="demo-controlled-radio-buttons-group"
-          name="controlled-radio-buttons-group"
-          value={gptModel}
-          row
-          onChange={() => handleModelChange()}
-        >
-          <FormControlLabel value="gpt-3.5-turbo" control={<Radio
-           color="default"
-          />} label="GPT-3.5" />
-          <FormControlLabel value="gpt-4" control={<Radio color="default" />} label="GPT-4" />
-        </RadioGroup>
       </Box>
       <Typography className={classes.infoText}>
-        Players are asked how sure they are of their answer for this question.
+        Players have optionally submitted hints to help other players.
       </Typography>
       { !isNullOrUndefined(gptHints)? 
         <>
@@ -85,9 +69,6 @@ const useStyles = makeStyles({
     justifyContent: 'center',
     width: '100%',
     maxWidth: '500px',
-    borderRadius: 34,
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-    padding: 34,
     boxSizing: 'border-box',
     gap: 16
   },

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -1,7 +1,8 @@
 import React, {useState} from 'react';
-import { Box, Typography, Button, RadioGroup, FormControlLabel, Radio } from '@material-ui/core';
+import { Box, CircularProgress, Typography, Button } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core';
-import { isNullOrUndefined } from '@righton/networking';
+import { GameSessionState, isNullOrUndefined } from '@righton/networking';
+import LinearProgressBar from '../LinearProgressBar';
 import PlayerThinkingGraph from './PlayerThinkingGraph';
 
 export default function PlayerThinking({
@@ -14,7 +15,10 @@ export default function PlayerThinking({
   graphClickInfo,
   isShortAnswerEnabled,
   handleGraphClick,
-  handleProcessHintsClick
+  hintsError,
+  currentState,
+  isHintLoading,
+  handleProcessHints
 }) {
   const classes = useStyles();
   return (
@@ -27,37 +31,69 @@ export default function PlayerThinking({
       <Typography className={classes.infoText}>
         Players have optionally submitted hints to help other players.
       </Typography>
-      { !isNullOrUndefined(gptHints)? 
-        <>
-          <PlayerThinkingGraph
-            data={gptHints}
-            numPlayers={numPlayers}
-            totalAnswers={totalAnswers}
-            questionChoices={questionChoices}
-            statePosition={statePosition}
-            graphClickInfo={graphClickInfo}
-            isShortAnswerEnabled={isShortAnswerEnabled && statePosition < 6}
-            handleGraphClick={handleGraphClick}
-          />
-          {graphClickInfo.graph === null ? (
-            <Typography className={classes.subText}>
-              Tap on a response to see more details.
-            </Typography>
-          ) : null}
-        </>
-      : 
-      <Box style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: 16}}>
+      <Box style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: 16 }}>
+    { currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER ? (
+      <>
         <Typography className={classes.infoText}>
-        {hints.length} / {numPlayers} players have submitted a hint
+            Players that have submitted a hint:
         </Typography>
-          <Button
-          className={classes.button}
-          onClick={() => handleProcessHintsClick(hints)}
-        >
-          Process Hints
-        </Button>
-       </Box>
-      }
+        <LinearProgressBar
+            inputNum={hints.length}
+            totalNum={numPlayers}
+        />
+        <Typography className={classes.subText}>
+            Hints will be displayed in the next phase
+        </Typography>
+      </>
+    ) : (
+        <>
+          {!isNullOrUndefined(gptHints) && !isHintLoading && !hintsError ? (
+            <>      
+              <PlayerThinkingGraph
+                  data={gptHints}
+                  numPlayers={numPlayers}
+                  totalAnswers={totalAnswers}
+                  questionChoices={questionChoices}
+                  statePosition={statePosition}
+                  graphClickInfo={graphClickInfo}
+                  isShortAnswerEnabled={isShortAnswerEnabled && statePosition < 6}
+                  handleGraphClick={handleGraphClick}
+              />
+              {graphClickInfo.graph === null && (
+                  <Typography className={classes.subText}>
+                      Tap on a response to see more details.
+                  </Typography>
+              )}
+            </>
+          ) : (
+              <>
+                {(isHintLoading && !hintsError) && (
+                  <>
+                    <CircularProgress style={{color:'#159EFA'}}/>
+                    <Typography className={classes.subText}>
+                       The hints are loading ...
+                    </Typography>
+                    </>
+                )}
+                {hintsError && (
+                    <>
+                      <Button
+                        className={classes.button}
+                        onClick={() => handleProcessHints(hints)}
+                      >
+                        Retry
+                      </Button>
+                      <Typography className={classes.subText}>
+                          There was an error processing the hints. Please try again.
+                      </Typography>
+                    </>
+                )}
+              </>
+            )}
+        </>
+    )}
+</Box>
+
     </Box>
   );
 }
@@ -85,7 +121,7 @@ const useStyles = makeStyles({
   infoText: {
     color: '#FFF',
     alignSelf: 'stretch',
-    textAlign: 'center',
+    textAlign: 'left',
     fontFamily: 'Poppins',
     fontSize: '14px',
     fontStyle: 'normal',
@@ -111,5 +147,14 @@ const useStyles = makeStyles({
     fontWeight: '700',
     lineHeight: '30px',
     textTransform: 'none',
+    '&:disabled': {
+      background: `#909090`,
+      color: '#FFF',
+      boxShadow: 'none',
+      border: '4px solid #909090',
+      '&:hover': {
+        background: `#909090`,
+      },
+    }
   },
 });

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -1,0 +1,134 @@
+import React, {useState} from 'react';
+import { Box, Typography, Button, RadioGroup, FormControlLabel, Radio } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core';
+import { isNullOrUndefined } from '@righton/networking';
+import PlayerThinkingGraph from './PlayerThinkingGraph';
+
+export default function PlayerThinking({
+  hints,
+  gptHints,
+  gptModel,
+  numPlayers,
+  totalAnswers,
+  questionChoices,
+  statePosition,
+  graphClickInfo,
+  isShortAnswerEnabled,
+  handleGraphClick,
+  handleProcessHintsClick,
+  handleModelChange
+}) {
+  const classes = useStyles();
+  const handleChange = (event) => {
+  };
+  return (
+    <Box className={classes.centerContent}>
+      <Box style={{display: 'flex', aligntItems: 'center', justifyContent: 'space-between', width: '100%'}}>
+        <Typography className={classes.titleStyle}>
+          Player Thinking
+        </Typography>
+        <RadioGroup
+          aria-labelledby="demo-controlled-radio-buttons-group"
+          name="controlled-radio-buttons-group"
+          value={gptModel}
+          row
+          onChange={() => handleModelChange()}
+        >
+          <FormControlLabel value="gpt-3.5-turbo" control={<Radio
+           color="default"
+          />} label="GPT-3.5" />
+          <FormControlLabel value="gpt-4" control={<Radio color="default" />} label="GPT-4" />
+        </RadioGroup>
+      </Box>
+      <Typography className={classes.infoText}>
+        Players are asked how sure they are of their answer for this question.
+      </Typography>
+      { !isNullOrUndefined(gptHints)? 
+        <>
+          <PlayerThinkingGraph
+            data={gptHints}
+            numPlayers={numPlayers}
+            totalAnswers={totalAnswers}
+            questionChoices={questionChoices}
+            statePosition={statePosition}
+            graphClickInfo={graphClickInfo}
+            isShortAnswerEnabled={isShortAnswerEnabled && statePosition < 6}
+            handleGraphClick={handleGraphClick}
+          />
+          {graphClickInfo.graph === null ? (
+            <Typography className={classes.subText}>
+              Tap on a response to see more details.
+            </Typography>
+          ) : null}
+        </>
+      : 
+      <Box style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: 16}}>
+        <Typography className={classes.infoText}>
+        {hints.prevSubmittedHints.length} / {numPlayers} players have submitted a hint
+        </Typography>
+          <Button
+          className={classes.button}
+          onClick={() => handleProcessHintsClick(hints)}
+        >
+          Process Hints
+        </Button>
+       </Box>
+      }
+    </Box>
+  );
+}
+
+const useStyles = makeStyles({
+  centerContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    width: '100%',
+    maxWidth: '500px',
+    borderRadius: 34,
+    backgroundColor: 'rgba(255, 255, 255, 0.1)',
+    padding: 34,
+    boxSizing: 'border-box',
+    gap: 16
+  },
+  titleStyle: {
+    color: 'var(--teacher-element-foreground, #FFF)',
+    fontFamily: 'Poppins',
+    fontSize: '24px',
+    fontStyle: 'normal',
+    fontWeight: '700',
+    lineHeight: 'normal',
+    textTransform: 'none',
+    textAlign: 'left',
+  },
+  infoText: {
+    color: '#FFF',
+    alignSelf: 'stretch',
+    textAlign: 'center',
+    fontFamily: 'Poppins',
+    fontSize: '14px',
+    fontStyle: 'normal',
+    fontWeight: 400,
+    lineHeight: 'normal',
+  },
+  subText: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    textAlign: 'center',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '400',
+  },
+  button: {
+    border: '4px solid #159EFA',
+    background: 'linear-gradient(#159EFA 100%,#19BCFB 100%)',
+    borderRadius: '34px',
+    width: '150px',
+    height: '24px',
+    color: 'white',
+    fontSize: '15px',
+    bottom: '0',
+    fontWeight: '700',
+    lineHeight: '30px',
+    textTransform: 'none',
+  },
+});

--- a/host/src/components/PlayerThinking/PlayerThinkingGraph.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinkingGraph.jsx
@@ -1,0 +1,223 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Typography, makeStyles } from '@material-ui/core';
+import {
+  VictoryChart,
+  VictoryAxis,
+  VictoryBar,
+  VictoryContainer,
+} from 'victory';
+import CustomLabel from './CustomLabel';
+import CustomBar from './CustomBar';
+
+export default function PlayerThinkingGraph({
+  data,
+  questionChoices,
+  graphClickInfo,
+  handleGraphClick,
+}) {
+  const classes = useStyles();
+  const [boundingRect, setBoundingRect] = useState({ width: 0, height: 0 });
+  const graphRef = useRef(null);
+  const barThickness = 18;
+  const barThicknessZero = 26;
+  const xSmallPadding = 4;
+  const smallPadding = 8;
+  const mediumPadding = 16;
+  const mediumLargePadding = 20;
+  const largePadding = 24;
+  const xLargePadding = 32;
+  const xxLargePadding = 40;
+  const labelOffset = 3;
+  const noResponseLabel = 'No Response';
+  // victory applies a default of 50px to the VictoryChart component
+  // we intentionally set this so that we can reference it programmatically throughout the chart
+  
+  const defaultVictoryPadding = 50;
+  const customBarSelectedWidth = boundingRect.width - defaultVictoryPadding;
+  const largestHintCount = Math.max(
+    ...data.map((response) => response.teams.length),
+  );
+  const calculateRoundedTicks = () => {
+    const maxHintCount = Math.max(
+      ...data.map((response) => response.teams.length),
+    );
+    const tickInterval = 5;
+    const tickCount = Math.ceil(maxHintCount / tickInterval);
+    return Array.from(
+      { length: tickCount + 1 },
+      (_, index) => index * tickInterval,
+    );
+  };
+
+  useEffect(() => {
+    const handleResize = () => {
+      const node = graphRef.current;
+      if (node) {
+        const { width } = node.getBoundingClientRect();
+        setBoundingRect((prevRect) => ({
+          ...prevRect,
+          width,
+        }));
+      }
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  // theme to eventually be wrapped into a mui theme when host is upgraded to mui v5
+  const customTheme = {
+    axis: {
+      style: {
+        axis: { stroke: 'rgba(255, 255, 255, 0.2)', strokeWidth: 2 },
+        grid: { stroke: 'transparent' },
+        tickLabels: {
+          padding: mediumLargePadding,
+        },
+      },
+    },
+    dependentAxis: {
+      style: {
+        axis: { stroke: 'transparent' },
+        grid: { stroke: 'rgba(255, 255, 255, 0.2)', strokeWidth: 2 },
+        tickLabels: {
+          fill: 'rgba(255, 255, 255, 0.5)',
+          fontFamily: 'Rubik',
+          fontWeight: '400',
+          fontSize: '12px',
+        },
+      },
+    },
+    bar: {
+      style: {
+        data: {
+          fill: '#FFF',
+          stroke: '#FFF',
+          strokeWidth: 1,
+        },
+        labels: {
+          fill: ({ datum, index }) => datum.team.length === 0
+              ? '#FFF'
+              : '#384466',
+          fontFamily: 'Rubik',
+          fontWeight: '400',
+          textAnchor: 'end',
+          fontSize: '12px',
+        },
+      },
+    },
+  };
+  return (
+    <div className={classes.container}>
+      <div className={classes.titleContainer}>
+        <Typography className={classes.title}>Responses aggregated by common phrases</Typography>
+      </div>
+      <div ref={graphRef}>
+        {data.length >= 1  && (
+        <VictoryChart
+          domainPadding={{ x: 36, y: 0 }}
+          padding={{
+            top: mediumPadding,
+            bottom: smallPadding,
+            left:  smallPadding,
+            right: smallPadding,
+          }}
+          containerComponent={
+            <VictoryContainer 
+              style={{
+              touchAction: "auto"
+              }}
+            />
+          }
+          theme={customTheme}
+          width={boundingRect.width}
+          height={data.length * 65}
+        >
+          <VictoryAxis
+            standalone={false}
+          />
+          {largestHintCount < 5 && (
+            <VictoryAxis
+              dependentAxis
+              crossAxis={false}
+              standalone={false}
+              orientation="top"
+              tickValues={[0]}
+            />
+          )}
+          {largestHintCount >= 5 && (
+            <VictoryAxis
+              dependentAxis
+              crossAxis={false}
+              standalone={false}
+              orientation="top"
+              tickValues={calculateRoundedTicks()}
+              tickFormat={(tick) => Math.round(tick)}
+            />
+          )}
+          <VictoryBar
+            data={data}
+            y="teams.length"
+            x="themeText"
+            horizontal
+            standalone={false}
+            cornerRadius={{ topLeft: 4, topRight: 4 }}
+            labels={({ datum }) => `${datum.teams.length}`}
+            barWidth={({ datum }) =>
+              datum.teams.length !== 0 ? barThickness : barThicknessZero
+            }
+            animate={{
+              onLoad: { duration: 200 },
+              duration: 200,
+            }}
+            dataComponent={
+              <CustomBar
+                xSmallPadding={xSmallPadding}
+                mediumPadding={mediumPadding}
+                defaultVictoryPadding={defaultVictoryPadding}
+                selectedWidth={customBarSelectedWidth}
+                selectedHeight={18}
+                graphClickInfo={graphClickInfo}
+                handleGraphClick={handleGraphClick}
+              />
+            }
+            labelComponent={
+              <CustomLabel
+                labelOffset={labelOffset}
+                barThickness={barThickness}
+                xSmallPadding={xSmallPadding}
+                xLargePadding={xLargePadding}
+                mediumLargePadding={mediumLargePadding}
+                defaultVictoryPadding={defaultVictoryPadding}
+                questionChoices={questionChoices}
+                noResponseLabel={noResponseLabel}
+              />
+            }
+          />
+        </VictoryChart>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const useStyles = makeStyles({
+  container: {
+    textAlign: 'center',
+    width: '100%',
+    maxWidth: '500px',
+  },
+  title: {
+    color: 'rgba(255, 255, 255, 0.5)',
+    fontFamily: 'Rubik',
+    fontSize: '12px',
+    paddingBottom: '12px',
+  },
+  titleContainer: {
+    marginTop: '3%',
+  },
+});

--- a/host/src/components/PlayerThinking/PlayerThinkingGraph.stories.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinkingGraph.stories.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { GameSessionParser } from '@righton/networking';
+import MockGameSession from '../../mock/MockGameSession.json';
+import PlayerThinkingGraph from './PlayerThinkingGraph';
+
+export default {
+  title: 'PlayerThinkingGraph',
+  component: PlayerThinkingGraph,
+};
+
+const gameSession =
+  GameSessionParser.gameSessionFromAWSGameSession(MockGameSession);
+
+const Template = (args) => <PlayerThinkingGraph {...args} />;
+
+export const differentAnswers = Template.bind({});
+differentAnswers.args = {
+  ...gameSession,
+  studentResponses: [
+    { label: 'A', count: 10, answer: '4x^4 − x^3 + 7x^2 − 6x' },
+    { label: 'B', count: 20, answer: '2x^4 + 6x^2 − 3x' },
+    { label: 'C', count: 15, answer: 'x^2 − 4x − 12' },
+    { label: 'D', count: 0, answer: 'x^9 + 3x -15' },
+  ],
+  numPlayers: 55,
+  totalAnswers: 45,
+  currentState: 'CHOOSE_CORRECT_ANSWER',
+  questionChoices: [
+    { isAnswer: false, text: 'A' },
+    { isAnswer: true, text: 'B' },
+    { isAnswer: false, text: 'C' },
+    { isAnswer: false, text: 'D' },
+  ],
+  statePosition: 1, 
+};
+
+export const sameAnswer = Template.bind({});
+sameAnswer.args = {
+  ...gameSession,
+  studentResponses: [
+    { label: 'A', count: 0, answer: '4x^4 − x^3 + 7x^2 − 6x' },
+    { label: 'B', count: 0, answer: '2x^4 + 6x^2 − 3x' },
+    { label: 'C', count: 10, answer: 'x^2 − 4x − 12' },
+    { label: 'D', count: 0, answer: 'x^9 + 3x -15' },
+  ],
+  numPlayers: 10,
+  totalAnswers: 10,
+  currentState: 'CHOOSE_TRICKEST_ANSWER',
+  questionChoices: [
+    { isAnswer: false, text: 'A' },
+    { isAnswer: true, text: 'B' },
+    { isAnswer: false, text: 'C' },
+    { isAnswer: false, text: 'D' },
+  ],
+  statePosition: 6,
+};
+
+export const oneAnswer = Template.bind({});
+oneAnswer.args = {
+  ...gameSession,
+  studentResponses: [
+    { label: 'A', count: 0, answer: '4x^4 − x^3 + 7x^2 − 6x' },
+    { label: 'B', count: 0, answer: '2x^4 + 6x^2 − 3x' },
+    { label: 'C', count: 0, answer: 'x^2 − 4x − 12' },
+    { label: 'D', count: 1, answer: 'x^9 + 3x -15' },
+  ],
+  numPlayers: 1,
+  totalAnswers: 1,
+  currentState: 'CHOOSE_TRICKEST_ANSWER',
+  questionChoices: [
+    { isAnswer: false, text: 'A' },
+    { isAnswer: true, text: 'B' },
+    { isAnswer: false, text: 'C' },
+    { isAnswer: false, text: 'D' },
+  ],
+  statePosition: 6,
+};
+
+export const noAnswer = Template.bind({});
+noAnswer.args = {
+  ...gameSession,
+  studentResponses: [
+    { label: 'A', count: 0, answer: '4x^4 − x^3 + 7x^2 − 6x' },
+    { label: 'B', count: 0, answer: '2x^4 + 6x^2 − 3x' },
+    { label: 'C', count: 0, answer: 'x^2 − 4x − 12' },
+    { label: 'D', count: 0, answer: 'x^9 + 3x -15' },
+  ],
+  numPlayers: 10,
+  totalAnswers: 0,
+  currentState: 'CHOOSE_TRICKEST_ANSWER',
+  questionChoices: [
+    { isAnswer: false, text: 'A' },
+    { isAnswer: true, text: 'B' },
+    { isAnswer: false, text: 'C' },
+    { isAnswer: false, text: 'D' },
+  ],
+  statePosition: 6,
+};
+
+export const lessThanFivePlayers = Template.bind({});
+lessThanFivePlayers.args = {
+  ...gameSession,
+  studentResponses: [
+    { label: 'A', count: 0, answer: '4x^4 − x^3 + 7x^2 − 6x' },
+    { label: 'B', count: 3, answer: '2x^4 + 6x^2 − 3x' },
+    { label: 'C', count: 1, answer: 'x^2 − 4x − 12' },
+    { label: 'D', count: 0, answer: 'x^9 + 3x -15' },
+  ],
+  numPlayers: 4,
+  totalAnswers: 4,
+  currentState: 'CHOOSE_TRICKEST_ANSWER',
+  questionChoices: [
+    { isAnswer: false, text: 'A' },
+    { isAnswer: true, text: 'B' },
+    { isAnswer: false, text: 'C' },
+    { isAnswer: false, text: 'D' },
+  ],
+  statePosition: 6,
+};
+
+export const fivePlayers = Template.bind({});
+fivePlayers.args = {
+  ...gameSession,
+  studentResponses: [
+    { label: 'A', count: 0, answer: '4x^4 − x^3 + 7x^2 − 6x' },
+    { label: 'B', count: 3, answer: '2x^4 + 6x^2 − 3x' },
+    { label: 'C', count: 1, answer: 'x^2 − 4x − 12' },
+    { label: 'D', count: 1, answer: 'x^9 + 3x -15' },
+  ],
+  numPlayers: 5,
+  totalAnswers: 5,
+  currentState: 'CHOOSE_TRICKEST_ANSWER',
+  questionChoices: [
+    { isAnswer: false, text: 'A' },
+    { isAnswer: true, text: 'B' },
+    { isAnswer: false, text: 'C' },
+    { isAnswer: false, text: 'D' },
+  ],
+  statePosition: 6,
+};

--- a/host/src/components/PlayerThinking/PlayerThinkingSelectedAnswer.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinkingSelectedAnswer.jsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Typography, makeStyles } from '@material-ui/core';
+import check from '../../images/Pickedcheck.svg';
+import { Tooltip } from '@material-ui/core';
+import PlayersSelectedAnswer from './PlayersSelectedAnswer';
+
+export default function PlayerThinkingSelectedAnswer(props) {
+  const {
+    gptHints,
+    numPlayers,
+    statePosition,
+    graphClickInfo
+  } = props;
+  const classes = useStyles();
+
+  return (
+    <div>
+      <div style={{ width: '100%' }}>
+        <Typography className={classes.titleText}>
+          Showing players who submitted this hint:
+        </Typography>
+        <div className={classes.rectStyle}>
+          <div className={classes.textContainer}>
+            {gptHints[graphClickInfo.selectedIndex].themeText}
+          </div>
+        </div>
+        <PlayersSelectedAnswer
+          gptHints={gptHints}
+          graphClickInfo={graphClickInfo}
+          numPlayers={numPlayers}
+          statePosition={statePosition}
+        />
+      </div>
+    </div>
+  );
+}
+
+const useStyles = makeStyles({
+  text: {
+    color: 'rgba(255, 255, 255, 0.6)',
+    textAlign: 'center',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '400',
+  },
+  choiceContainer: {
+    color: 'rgba(255, 255, 255, 0.5)',
+    fontFamily: 'Poppins',
+    fontSize: '16px',
+    fontWeight: '800',
+    lineHeight: '20px',
+    paddingRight: '8px',
+  },
+  textContainer: {
+    color: '#FFF',
+    fontFamily: 'Rubik',
+    fontSize: '18px',
+    fontWeight: '400',
+    lineHeight: '22px',
+  },
+  titleText: {
+    color: '#FFF',
+    textAlign: 'left',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '400',
+    paddingBottom: '10px',
+  },
+  tooltip: {
+    whiteSpace: 'pre-line',
+    textAlign: 'center',
+  },
+  rectStyle: {
+    width: '100%',
+    height: '40px',
+    display: 'flex',
+    alignItems: 'center',
+    color: 'white',
+    fontSize: '16px',
+    padding: '10px',
+    borderRadius: '22px',
+    border: '1px solid #B1BACB',
+    position: 'relative',
+    maxWidth: '500px',
+    boxSizing: 'border-box',
+  },
+  checkIconStyle: {
+    position: 'absolute',
+    top: '50%',
+    right: '16px',
+    transform: 'translateY(-50%)',
+    display: 'flex',
+    alignItems: 'center',
+  },
+});

--- a/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
+++ b/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { Typography, makeStyles } from '@material-ui/core';
+
+export default function PlayersSelectedAnswer(props) {
+  const {
+    gptHints,
+    graphClickInfo,
+    numPlayers
+  } = props;
+  const classes = useStyles(props);
+  const hintCount = gptHints[graphClickInfo.selectedIndex].teamCount;
+  const percentage = (hintCount / numPlayers) * 100;
+  const teamsWithSelectedAnswer = gptHints[graphClickInfo.selectedIndex].teams.map((team) => team);
+
+  return (
+    <div>
+      <div className={classes.textContainer}>
+        <Typography className={classes.titleText}>
+          Players who submitted this hint:
+        </Typography>
+        <div className={classes.numberContainer}>
+          <Typography className={classes.countText}>
+            {/* count from stateposition === 6 saved and displayed here for stateposition === 6 */}
+            {hintCount}
+          </Typography>
+          <Typography className={classes.percentageText}>
+            {/* percentage from  stateposition === 6saved and displayed here for stateposition === 6 */}
+            ({Math.round(percentage)}%)
+          </Typography>
+        </div>
+      </div>
+      {teamsWithSelectedAnswer.map((teamChoice, index) => (
+        <div key={index} className={classes.rectStyle}>
+          <Typography className={classes.nameText}>
+            {teamChoice}
+          </Typography>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const useStyles = makeStyles({
+  titleText: {
+    color: '#FFF',
+    textAlign: 'left',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '400',
+    paddingTop: '16px',
+    opacity: (props) => (props.statePosition === 6 ? 0.5 : 1),
+  },
+  percentageText: {
+    color: '#FFF',
+    textAlign: 'left',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '400',
+    paddingTop: '16px',
+    paddingLeft: '4px',
+    opacity: (props) => (props.statePosition === 6 ? 0.5 : 1),
+  },
+  countText: {
+    color: '#FFF',
+    textAlign: 'right',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '700',
+    paddingTop: '16px',
+    opacity: (props) => (props.statePosition === 6 ? 0.5 : 1),
+  },
+  nameText: {
+    textAlign: 'left',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '400',
+  },
+  phaseTwoTitleText: {
+    color: '#FFF',
+    textAlign: 'left',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '400',
+  },
+  phaseTwoPercentageText: {
+    color: '#FFF',
+    textAlign: 'left',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '400',
+    paddingLeft: '4px',
+  },
+  phaseTwoCountText: {
+    color: '#FFF',
+    textAlign: 'right',
+    fontFamily: 'Rubik',
+    fontSize: '14px',
+    fontWeight: '700',
+  },
+  textContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingBottom: '8px',
+  },
+  numberContainer: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  phaseTwoNumberContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    marginTop: '-20px',
+  },
+  rectStyle: {
+    width: '100%',
+    height: '40px',
+    color: 'white',
+    backgroundColor: '#063772',
+    fontSize: '16px',
+    padding: '10px 16px',
+    borderRadius: '8px',
+    marginBottom: '8px',
+    maxWidth: '500px',
+    boxSizing: 'border-box'
+  },
+});

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -33,7 +33,7 @@ const GameSessionContainer = () => {
   // we aren't going to subscribe to question objects on either app to prevent a bunch of updates
   // or maybe we just build shortanswerresponses based on reload logic like how we do it in create answer subscription
   const [shortAnswerResponses, setShortAnswerResponses] = useState([]);
-  const [hints, setHints] = useState({prevSubmittedHints: [], finalArray: []});
+  const [hints, setHints] = useState([]);
   const [gptHints, setGptHints] = React.useState(null);
   const [selectedMistakes, setSelectedMistakes] = useState([]);
   const [isTimerActive, setIsTimerActive] = useState(false);
@@ -270,20 +270,7 @@ const GameSessionContainer = () => {
         });
         console.log(teamAnswerResponse);
         if (!isNullOrUndefined(teamAnswerResponse.hint)) {
-          setHints((prevHints) => {
-              const newHints = buildHints(prevHints.prevSubmittedHints, teamAnswerResponse.hint) 
-              apiClient.getGameSession(gameSessionId).then((gameSession) => {
-                apiClient
-                  .updateQuestion({
-                    gameSessionId: gameSession.id, 
-                    id: gameSession.questions[gameSession.currentQuestionIndex].id,
-                    order: gameSession.questions[gameSession.currentQuestionIndex].order,
-                    hints: JSON.stringify(newHints),
-                });
-              });
-              return newHints;
-            }
-          );
+          setHints((prevHints) => {return [...prevHints, teamAnswerResponse.hint]});
         }
         setShortAnswerResponses((existingAnswers) => {
           let newShortAnswers = JSON.parse(JSON.stringify(existingAnswers));
@@ -469,7 +456,7 @@ const GameSessionContainer = () => {
       });
   };
   const handleProcessHintsClick = async (hints) => {
-    apiClient.groupHints(hints.prevSubmittedHints).then((response) => {
+    apiClient.groupHints(hints).then((response) => {
       const parsedHints = JSON.parse(response.gptHints);
       setGptHints(parsedHints);
     });

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -268,6 +268,7 @@ const GameSessionContainer = () => {
           });
           return newState;
         });
+        console.log(teamAnswerResponse);
         if (!isNullOrUndefined(teamAnswerResponse.hint)) {
           setHints((prevHints) => {
               const newHints = buildHints(prevHints.prevSubmittedHints, teamAnswerResponse.hint) 

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -53,7 +53,9 @@ export default function GameInProgress({
   handleHintChange,
   hints,
   gptHints,
-  handleProcessHintsClick
+  hintsError,
+  isHintLoading,
+  handleProcessHints
 }) {
   const classes = useStyles();
   const footerButtonTextDictionary = {
@@ -73,7 +75,6 @@ export default function GameInProgress({
   const correctChoiceIndex =
     questionChoices.findIndex(({ isAnswer }) => isAnswer) + 1;
   const statePosition = Object.keys(GameSessionState).indexOf(currentState);
-
   // using useMemo due to the nested maps in the getAnswerByQuestion and the fact that this component rerenders every second from the timer
   const answers = useMemo(
     () =>
@@ -151,7 +152,10 @@ export default function GameInProgress({
     setTimeout(() => {
       if (graph === 'realtime')
         responsesRef.current.scrollIntoView({ behavior: 'smooth' });
-      else confidenceCardRef.current.scrollIntoView({ behavior: 'smooth' });
+      else if (graph=== 'confidence') 
+        confidenceCardRef.current.scrollIntoView({ behavior: 'smooth' });
+      else
+        hintCardRef.current.scrollIntoView({ behavior: 'smooth' });
     }, 0);
   };
 
@@ -181,12 +185,12 @@ export default function GameInProgress({
   const handleFooterOnClick = (numPlayers, totalAnswers) => {
     let nextState = nextStateFunc(currentState);
     if (nextState === GameSessionState.CHOOSE_CORRECT_ANSWER) {
-      assembleNavDictionary(isConfidenceEnabled, nextState);
+      assembleNavDictionary(isConfidenceEnabled, isHintEnabled, nextState);
       handleBeginQuestion();
       return;
     }
     if (nextState === GameSessionState.TEAMS_JOINING)
-      assembleNavDictionary(isConfidenceEnabled, nextState);
+      assembleNavDictionary(isConfidenceEnabled, isHintEnabled, nextState);
     if (
       nextState === GameSessionState.PHASE_1_DISCUSS ||
       nextState === GameSessionState.PHASE_2_DISCUSS
@@ -284,7 +288,9 @@ export default function GameInProgress({
             handleHintChange={handleHintChange}
             hints={hints}
             gptHints={gptHints}
-            handleProcessHintsClick={handleProcessHintsClick}
+            hintsError={hintsError}
+            isHintLoading={isHintLoading}
+            handleProcessHints={handleProcessHints}
           />
         </div>
         <GameModal

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -50,7 +50,10 @@ export default function GameInProgress({
   handleOnSelectMistake,
   hintCardRef,
   isHintEnabled,
-  handleHintChange
+  handleHintChange,
+  hints,
+  gptHints,
+  handleProcessHintsClick
 }) {
   const classes = useStyles();
   const footerButtonTextDictionary = {
@@ -279,6 +282,9 @@ export default function GameInProgress({
             hintCardRef={hintCardRef}
             isHintEnabled={isHintEnabled}
             handleHintChange={handleHintChange}
+            hints={hints}
+            gptHints={gptHints}
+            handleProcessHintsClick={handleProcessHintsClick}
           />
         </div>
         <GameModal

--- a/host/src/pages/StudentViews.jsx
+++ b/host/src/pages/StudentViews.jsx
@@ -20,6 +20,7 @@ export default function StudentViews({
   showFooterButtonOnly,
   setIsConfidenceEnabled,
   assembleNavDictionary,
+  isHintEnabled
 }) {
   let statePosition;
   let isLastQuestion =
@@ -81,7 +82,7 @@ export default function StudentViews({
     if (!isLastQuestion && currentState === GameSessionState.PHASE_2_RESULTS) {
       // if they are on the last page a\nd need to advance to the next question
       setIsConfidenceEnabled(false);
-      assembleNavDictionary(false, GameSessionState.TEAMS_JOINING);
+      assembleNavDictionary(false, isHintEnabled, GameSessionState.TEAMS_JOINING);
       handleUpdateGameSession({
         currentState: nextStateFunc(currentState),
         currentQuestionIndex: currentQuestionIndex + 1,
@@ -89,7 +90,7 @@ export default function StudentViews({
       return;
     }
     if (currentState === GameSessionState.PHASE_1_RESULTS)
-      assembleNavDictionary(false, currentState);
+      assembleNavDictionary(false, isHintEnabled, currentState);
     handleUpdateGameSession({ currentState: nextStateFunc(currentState) });
   };
 

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -81,9 +81,40 @@ interface SubscriptionValue<T> {
 
 export class ApiClient implements IApiClient {
     private endpoint: string
+    private hintEndpoint: string
 
     constructor(env: Environment) {
         this.endpoint = `https://1y2kkd6x3e.execute-api.us-east-1.amazonaws.com/${env}/createGameSession`
+        this.hintEndpoint = `https://yh5ionr9rg.execute-api.us-east-1.amazonaws.com/groupHints/groupHints`
+    }
+
+    async groupHints(
+        hints: string[]
+    ):Promise<string> {
+        try { 
+        const attempt = fetch(this.hintEndpoint, {
+            method: HTTPMethod.Post,
+            headers: {
+                "content-type": "application/json",
+                connection: "close",
+                "Access-Control-Allow-Origin": "*",
+            },
+            body: JSON.stringify({
+                hints: hints
+            }),
+        })
+        .then((response) => {
+            if (!response.ok) {
+                throw new Error(response.statusText)
+            }
+            return response.json()
+        })
+        
+        return attempt;
+        } catch (e) {
+            console.log(e)
+        }
+    return "";
     }
 
     createGameSession(

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -52,7 +52,7 @@ import {
     updateQuestion
 } from "./graphql/mutations"
 import { IApiClient, isNullOrUndefined } from "./IApiClient"
-import { IChoice, IResponse, IQuestion, IAnswerSettings, ITeamAnswer, ITeamAnswerHint, ITeamMember, IGameSession, ITeam, ITeamAnswerContent, NumberAnswer, AnswerType, StringAnswer, ExpressionAnswer } from "./Models"
+import { IChoice, IResponse, IQuestion, IHints, IAnswerSettings, ITeamAnswer, ITeamAnswerHint, ITeamMember, IGameSession, ITeam, ITeamAnswerContent, NumberAnswer, AnswerType, StringAnswer, ExpressionAnswer } from "./Models"
 
 Amplify.configure(awsconfig)
 
@@ -89,7 +89,9 @@ export class ApiClient implements IApiClient {
     }
 
     async groupHints(
-        hints: string[]
+        hints: string[],
+        questionText: string,
+        correctAnswer: string
     ):Promise<string> {
         try { 
         const attempt = fetch(this.hintEndpoint, {
@@ -100,12 +102,14 @@ export class ApiClient implements IApiClient {
                 "Access-Control-Allow-Origin": "*",
             },
             body: JSON.stringify({
-                hints: hints
+                hints: hints,
+                questionText: questionText,
+                correctAnswer: correctAnswer
             }),
         })
         .then((response) => {
             if (!response.ok) {
-                throw new Error(response.statusText)
+               console.error(response.statusText)
             }
             return response.json()
         })
@@ -581,6 +585,7 @@ type AWSQuestion = {
     choices?: string | null
     answerSettings?: string | null
     responses?: string | null
+    hints?: string | null
     imageUrl?: string | null
     instructions?: string | null
     standard?: string | null
@@ -774,6 +779,9 @@ export class GameSessionParser {
                     responses: isNullOrUndefined(awsQuestion.responses)
                          ? []
                          : this.parseServerArray<IResponse>(awsQuestion.responses),
+                    hints: isNullOrUndefined(awsQuestion.hints)
+                        ? []
+                        : this.parseServerArray<IHints>(awsQuestion.hints),
                     imageUrl: awsQuestion.imageUrl,
                     instructions: isNullOrUndefined(awsQuestion.instructions)
                         ? []

--- a/networking/src/IApiClient.ts
+++ b/networking/src/IApiClient.ts
@@ -1,5 +1,5 @@
 import { UpdateGameSessionInput } from './AWSMobileApi'
-import { ITeamAnswer, ITeamMember, ITeam, NumberAnswer, StringAnswer, ExpressionAnswer } from './Models'
+import { ITeamMember, ITeam, NumberAnswer, StringAnswer, ExpressionAnswer } from './Models'
 import { IGameSession } from './Models/IGameSession'
 
 export interface IApiClient {
@@ -10,7 +10,7 @@ export interface IApiClient {
     getGameSessionByCode(gameCode: number): Promise<IGameSession | null>
     addTeamToGameSessionId(gameSessionId: string, name: string, questionId: string | null): Promise<ITeam>
     addTeamMemberToTeam(teamId: string, isFacilitator: boolean, deviceId: string): Promise<ITeamMember>
-    addTeamAnswer(inputAnswer: NumberAnswer | StringAnswer | ExpressionAnswer): Promise<ITeamAnswer>
+    addTeamAnswer(inputAnswer: NumberAnswer | StringAnswer | ExpressionAnswer): Promise<NumberAnswer | StringAnswer | ExpressionAnswer>
 }
 
 export function isNullOrUndefined<T>(value: T | null | undefined): value is null | undefined {

--- a/networking/src/Models/IQuestion.ts
+++ b/networking/src/Models/IQuestion.ts
@@ -6,6 +6,7 @@ export interface IQuestion {
     choices?: Array<IChoice> | null
     answerSettings?: IAnswerSettings | null
     responses?: Array<IResponse> | null
+    hints?: IHints[] | null
     imageUrl?: string | null
     instructions?: Array<string> | null
     standard?: string | null
@@ -44,4 +45,10 @@ export interface IResponseTeam {
     team: string
     id: string
     confidence: ConfidenceLevel
+}
+
+export interface IHints {
+    themeText: string;
+    teams: string[];
+    teamCount: number;
 }

--- a/play/public/locales/en/translation.json
+++ b/play/public/locales/en/translation.json
@@ -113,6 +113,7 @@
     },
     "button": {
       "submit": "Submit Answer",
+      "hint": "Submit Hint",
       "submitted": "Submitted"
     }
   },

--- a/play/public/locales/es/translation.json
+++ b/play/public/locales/es/translation.json
@@ -104,7 +104,7 @@
     },
     "button": {
       "submit": "Enviar Respuesta",
-      "submitHint": "Enviar Explicación",
+      "hint": "Enviar Explicación",
       "submitted": "Enviada"
     }
   },

--- a/play/src/components/ButtonSubmitAnswer.tsx
+++ b/play/src/components/ButtonSubmitAnswer.tsx
@@ -40,9 +40,12 @@ export default function ButtonSubmitAnswer({
   const buttonText = isSubmitted
     ? t('gameinprogress.button.submitted')
     : t('gameinprogress.button.submit');
+  const hintButtonText = isSubmitted
+    ? t('gameinprogress.button.submitted')
+    : t('gameinprogress.button.hint');
   const buttonContents = (
     <Typography sx={{ textTransform: 'none' }} variant="button">
-      {buttonText}
+      {isHint ? hintButtonText : buttonText}
     </Typography>
   );
   return isSelected && !isSubmitted ? (

--- a/play/src/containers/GameInProgressContainer.tsx
+++ b/play/src/containers/GameInProgressContainer.tsx
@@ -14,6 +14,7 @@ import {
   LocalModel,
   StorageKey,
   StorageKeyAnswer,
+  StorageKeyHint,
   ErrorType,
 } from '../lib/PlayModels';
 
@@ -108,7 +109,10 @@ export function LocalModelLoader(): LocalModel {
   const localModelAnswer = JSON.parse(
     window.localStorage.getItem(StorageKeyAnswer) ?? '{}'
   );
-  const localModel = { ...localModelBase, answer: localModelAnswer };
+  const localModelHint = JSON.parse(
+    window.localStorage.getItem(StorageKeyHint) ?? '{}'
+  );
+  const localModel = { ...localModelBase, answer: localModelAnswer, hint: localModelHint };
   if (localModel && !localModel.hasRejoined) {
     const updatedModelForNextReload = { ...localModel, hasRejoined: true };
     window.localStorage.setItem(

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -142,6 +142,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
           hasRejoined: false,
           currentTimer: gameSession.phaseOneTime,
           answer: null,
+          hint: null
         };
         window.localStorage.setItem(StorageKey, JSON.stringify(storageObject));
         navigate(`/game`);

--- a/play/src/lib/HelperFunctions.tsx
+++ b/play/src/lib/HelperFunctions.tsx
@@ -4,6 +4,7 @@ import {
   StringAnswer,
   ExpressionAnswer,
   ITeam,
+  ITeamAnswerHint,
   GameSessionState,
   isNullOrUndefined,
   ConfidenceLevel,
@@ -83,6 +84,39 @@ export const checkForSubmittedAnswerOnRejoin = (
     }
   }
   return returnedAnswer as ITeamAnswerContent;
+};
+
+/**
+ * on rejoining game, this checks if the player has already submitted a hint
+ * @param localModel - the localModel retrieved from local storage
+ * @param hasRejoined - if a player is rejoining
+ * @param currentState - the current state of the game session
+ * @param currentQuestionIndex - the current question index of the game session
+ * @returns - the hint that the player was working on, null if they haven't submitted a hint 
+ */
+export const checkForSubmittedHintOnRejoin = (
+  localModel: LocalModel,
+  hasRejoined: boolean,
+  currentState: GameSessionState,
+  currentQuestionIndex: number
+): ITeamAnswerHint => {
+  let returnedHint: ITeamAnswerHint = {
+    rawHint: '',
+    teamName: '',
+    isHintSubmitted: false,
+  };
+  if (hasRejoined) {
+    if (
+      localModel.answer !== null &&
+      localModel.hint!== null &&
+      localModel.answer.currentState === currentState &&
+      localModel.answer.currentQuestionIndex === currentQuestionIndex
+    ) {
+      // set hint to localModel.hint
+      returnedHint = localModel.hint;
+    }
+  }
+  return returnedHint as ITeamAnswerHint;
 };
 
 /**

--- a/play/src/lib/PlayModels.tsx
+++ b/play/src/lib/PlayModels.tsx
@@ -1,4 +1,4 @@
-import { ITeamAnswerContent } from '@righton/networking';
+import { ITeamAnswerContent, ITeamAnswerHint } from '@righton/networking';
 import Icon0 from '../img/MonsterIcon0.svg';
 import Icon1 from '../img/MonsterIcon1.svg';
 import Icon2 from '../img/MonsterIcon2.svg';
@@ -130,6 +130,7 @@ export interface LocalModel {
   hasRejoined: boolean;
   currentTimer: number;
   answer: ITeamAnswerContent | null;
+  hint: ITeamAnswerHint | null;
 }
 
 interface MonsterMap {

--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -217,7 +217,7 @@ export default function GameInProgress({
     try {
       const response = await apiClient.addTeamAnswer(answer);
       window.localStorage.setItem(StorageKeyAnswer, JSON.stringify(answer.answerContent));
-      setTeamAnswerId(response.id);
+      setTeamAnswerId(response.id ?? '');
       setAnswerContent(answer?.answerContent as ITeamAnswerContent);
       setDisplaySubmitted(true);
     } catch (e) {

--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -32,6 +32,7 @@ import FooterStackContainerStyled from '../lib/styledcomponents/layout/FooterSta
 import {
   checkForSubmittedAnswerOnRejoin,
   checkForSelectedConfidenceOnRejoin,
+  checkForSubmittedHintOnRejoin
 } from '../lib/HelperFunctions';
 import ErrorModal from '../components/ErrorModal';
 import { ErrorType, LocalModel, StorageKeyAnswer, StorageKeyHint } from '../lib/PlayModels';
@@ -76,7 +77,15 @@ export default function GameInProgress({
   const theme = useTheme();
   const [isAnswerError, setIsAnswerError] = useState(false);
   const [isConfidenceError, setIsConfidenceError] = useState(false);
-  const [answerHint, setAnswerHint] = useState<ITeamAnswerHint | null>(null);
+  const [answerHint, setAnswerHint] = useState<ITeamAnswerHint>(() => {
+    const rejoinSubmittedHint = checkForSubmittedHintOnRejoin(
+      localModel,
+      hasRejoined,
+      currentState,
+      currentQuestionIndex ?? 0
+    ); 
+    return rejoinSubmittedHint;
+  });
   const isSmallDevice = useMediaQuery(theme.breakpoints.down('sm'));
   const currentTeam = teams?.find((team) => team.id === teamId);
   const currentQuestion = questions[currentQuestionIndex ?? 0];


### PR DESCRIPTION
This is the first of a few PRs for the Hint feature that will use GPT-4 to categorize hints. The PRs breakdown as follows:
[[Host] - Enable/disable Hint Feature on Host #896](https://github.com/rightoneducation/righton-app/pull/896)
-> [[Play/Networking] - Intakes hints on play, updates networking to send them to backend #897](https://github.com/rightoneducation/righton-app/pull/897)
->->[[Host/Play/Networking] - Updates across the apps to handle intaking/sending to lambda hints by host #898](https://github.com/rightoneducation/righton-app/pull/898)
->->->[[Host/Play] - Bug Fixes #899](https://github.com/rightoneducation/righton-app/pull/899)
->->->->[[Host/Networking] - Prompt Adjustment #900](https://github.com/rightoneducation/righton-app/pull/900)
->->->->->[[Host/Networking] - Moves the processing of hints to next phase #901](https://github.com/rightoneducation/righton-app/pull/901)

This PR contains a series of updates across the apps that allow `host` to receive the new hints via the subscription to `UpdateTeamAnswer`. Then, it allows the processing of those hints via `groupHints` on `apiClient` which sends them to the Lambda function that ultimately fires off the OpenAI API request. 