### PR TITLE
[Host/Play] - Bug Fixes

### DIFF
--- a/host/src/components/FooterGame.jsx
+++ b/host/src/components/FooterGame.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles, BottomNavigation } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
-import PlayersAnsweredBar from './PlayersAnsweredBar';
+import LinearProgressBar from './LinearProgressBar';
 import ModuleNavigator from './ModuleNavigator';
 
 export default function FooterGame({
@@ -39,9 +39,9 @@ export default function FooterGame({
           <>
             <div style={{ opacity: gameTimer ? 1 : 0.4, width: '100%' }}>
               <div className={classes.playerNum}>Players who have answered</div>
-              <PlayersAnsweredBar
-                numPlayers={numPlayers}
-                totalAnswers={totalAnswers}
+              <LinearProgressBar
+                inputNum={totalAnswers}
+                totalNum={numPlayers}
               />
             </div>
             <ModuleNavigator

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -45,8 +45,9 @@ export default function GameInProgressContentSwitch ({
     handleHintChange,
     hints,
     gptHints,
-    handleProcessHintsClick,
-    hintsError
+    hintsError,
+    isHintLoading,
+    handleProcessHints
   }) {
   const classes = useStyles();
   const graphClickRenderSwitch = (graphClickInfo) => {
@@ -118,9 +119,10 @@ export default function GameInProgressContentSwitch ({
               statePosition={statePosition}
               graphClickInfo={graphClickInfo}
               handleGraphClick={handleGraphClick}
-              handleProcessHintsClick={handleProcessHintsClick}
               hintsError={hintsError}
-              
+              currentState={currentState}
+              isHintLoading={isHintLoading}
+              handleProcessHints={handleProcessHints}
             />
             <PlayerThinkingSelectedAnswer
               gptHints={gptHints}
@@ -201,8 +203,10 @@ export default function GameInProgressContentSwitch ({
                 statePosition={statePosition}
                 graphClickInfo={graphClickInfo}
                 handleGraphClick={handleGraphClick}
-                handleProcessHintsClick={handleProcessHintsClick}
                 hintsError={hintsError}
+                currentState={currentState}
+                isHintLoading={isHintLoading}
+                handleProcessHints={handleProcessHints}
               />
             </div>
           ) : null}

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -46,6 +46,7 @@ export default function GameInProgressContentSwitch ({
     hints,
     gptHints,
     handleProcessHintsClick,
+    hintsError
   }) {
   const classes = useStyles();
   const graphClickRenderSwitch = (graphClickInfo) => {
@@ -118,6 +119,8 @@ export default function GameInProgressContentSwitch ({
               graphClickInfo={graphClickInfo}
               handleGraphClick={handleGraphClick}
               handleProcessHintsClick={handleProcessHintsClick}
+              hintsError={hintsError}
+              
             />
             <PlayerThinkingSelectedAnswer
               gptHints={gptHints}
@@ -199,6 +202,7 @@ export default function GameInProgressContentSwitch ({
                 graphClickInfo={graphClickInfo}
                 handleGraphClick={handleGraphClick}
                 handleProcessHintsClick={handleProcessHintsClick}
+                hintsError={hintsError}
               />
             </div>
           ) : null}

--- a/host/src/components/LinearProgressBar.jsx
+++ b/host/src/components/LinearProgressBar.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core';
 import LinearProgress from '@material-ui/core/LinearProgress';
 
-export default function PlayersAnsweredBar({ numPlayers, totalAnswers }) {
+export default function LinearProgressBar({ inputNum, totalNum }) {
   const classes = useStyles();
   const progressPercent =
-    numPlayers !== 0 ? (totalAnswers / numPlayers) * 100 : 0;
+    inputNum !== 0 ? (inputNum / totalNum) * 100 : 0;
 
   return (
     <div className={classes.bargroup}>
@@ -33,10 +33,10 @@ export default function PlayersAnsweredBar({ numPlayers, totalAnswers }) {
             lineHeight: '18px',
           }}
         >
-          {totalAnswers}
+          {inputNum}
         </div>
       </div>
-      <div className={classes.totalPlayers}>{numPlayers}</div>
+      <div className={classes.totalNum}>{totalNum}</div>
     </div>
   );
 }
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
     gap: '10px',
     width: '100%',
   },
-  totalPlayers: {
+  totalNum: {
     fontSize: '12px',
     lineHeight: '12px',
     color: 'white',

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -14,7 +14,8 @@ export default function PlayerThinking({
   graphClickInfo,
   isShortAnswerEnabled,
   handleGraphClick,
-  handleProcessHintsClick
+  handleProcessHintsClick,
+  hintsError
 }) {
   const classes = useStyles();
   return (
@@ -60,6 +61,11 @@ export default function PlayerThinking({
         { hints.length <= 2 &&
           <Typography className={classes.subText}>
             At least 2 players must submit a hint to process them
+          </Typography>
+        } 
+        { hintsError &&
+          <Typography className={classes.subText}>
+            There was an error processing the hints. Please try again.
           </Typography>
         } 
        </Box>

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -58,7 +58,7 @@ export default function PlayerThinking({
         >
           Process Hints
         </Button>
-        { hints.length <= 2 &&
+        { hints.length < 2 &&
           <Typography className={classes.subText}>
             At least 2 players must submit a hint to process them
           </Typography>

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -52,10 +52,16 @@ export default function PlayerThinking({
         </Typography>
           <Button
           className={classes.button}
+          disabled={hints.length < 2}
           onClick={() => handleProcessHintsClick(hints)}
         >
           Process Hints
         </Button>
+        { hints.length <= 2 &&
+          <Typography className={classes.subText}>
+            At least 2 players must submit a hint to process them
+          </Typography>
+        } 
        </Box>
       }
     </Box>
@@ -111,5 +117,14 @@ const useStyles = makeStyles({
     fontWeight: '700',
     lineHeight: '30px',
     textTransform: 'none',
+    '&:disabled': {
+      background: `#909090`,
+      color: '#FFF',
+      boxShadow: 'none',
+      border: '4px solid #909090',
+      '&:hover': {
+        background: `#909090`,
+      },
+    }
   },
 });

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -113,6 +113,7 @@ const GameSessionContainer = () => {
           response.questions[response.currentQuestionIndex].isHintEnabled,
         );
         setGptHints(response.questions[response.currentQuestionIndex].hints);
+        setHintsError(false);
         assembleNavDictionary(
           response.questions[response.currentQuestionIndex].isConfidenceEnabled,
           response.questions[response.currentQuestionIndex].isHintEnabled,
@@ -156,6 +157,7 @@ const GameSessionContainer = () => {
         if (gameSession && gameSession.currentState !== response.currentState) {
           checkGameTimer(response);
         }
+        setHintsError(false);
         setGameSession({ ...gameSession, ...response });
         setIsConfidenceEnabled(
           response.questions[response.currentQuestionIndex].isConfidenceEnabled,
@@ -453,6 +455,10 @@ const GameSessionContainer = () => {
   };
   const handleProcessHintsClick = async (hints) => {
     try {
+      const questionChoices = getQuestionChoices(gameSession?.questions, gameSession?.currentQuestionIndex);
+      const correctChoiceIndex =
+        questionChoices.findIndex(({ isAnswer }) => isAnswer) + 1;
+      const correctAnswer = questionChoices[correctChoiceIndex].text;
       apiClient.groupHints(hints).then((response) => {
         const parsedHints = JSON.parse(response.gptHints);
         setGptHints(parsedHints);
@@ -553,6 +559,7 @@ const GameSessionContainer = () => {
           hints={hints}
           gptHints={gptHints}
           handleProcessHintsClick={handleProcessHintsClick}
+          hintsError={hintsError}
         />
       );
 

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -473,7 +473,7 @@ const GameSessionContainer = () => {
           });
         }
       });
-    } catch (err) {
+    } catch {
       setHintsError(true);
     }
   };

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -33,6 +33,7 @@ const GameSessionContainer = () => {
   const [hints, setHints] = useState([]);
   const [gptHints, setGptHints] = React.useState(null);
   const [hintsError, setHintsError] = React.useState(false);
+  const [isHintLoading, setisHintLoading] = React.useState(false);
   const [selectedMistakes, setSelectedMistakes] = useState([]);
   const [isTimerActive, setIsTimerActive] = useState(false);
   const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
@@ -148,7 +149,6 @@ const GameSessionContainer = () => {
         })
         .catch((reason) => console.log(reason));
     });
-
     let gameSessionSubscription: any | null = null;
     gameSessionSubscription = apiClient.subscribeUpdateGameSession(
       gameSessionId,
@@ -377,6 +377,17 @@ const GameSessionContainer = () => {
         });
     }
     
+    // if game is moving to PHASE_2_DISCUSS, hints are enabled, there are hints to process that have yet to be processed
+    if (
+      gameSession.currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER 
+      && isHintEnabled 
+      && gptHints === null 
+      && hints.length > 0
+    ) {
+      setisHintLoading(true);
+      handleProcessHints(hints);
+    }
+
     const response = await apiClient.updateGameSession({ id: gameSessionId, ...newUpdates })
     if (response.currentState === GameSessionState.CHOOSE_CORRECT_ANSWER) {
       setHeaderGameCurrentTime(response.phaseOneTime);
@@ -453,16 +464,21 @@ const GameSessionContainer = () => {
         setIsLoadModalOpen(true);
       });
   };
-  const handleProcessHintsClick = async (hints) => {
+  const handleProcessHints = async (hints) => {
+    setHintsError(false);
     try {
-      const questionChoices = getQuestionChoices(gameSession?.questions, gameSession?.currentQuestionIndex);
+      const currentQuestion = gameSession?.questions[gameSession?.currentQuestionIndex];
+      const questionText =  currentQuestion.text;
       const correctChoiceIndex =
-        questionChoices.findIndex(({ isAnswer }) => isAnswer) + 1;
-      const correctAnswer = questionChoices[correctChoiceIndex].text;
-      apiClient.groupHints(hints).then((response) => {
-        const parsedHints = JSON.parse(response.gptHints);
+        currentQuestion.choices.findIndex(({ isAnswer }) => isAnswer);
+      const correctAnswer = currentQuestion.choices[correctChoiceIndex].text;
+
+      apiClient.groupHints(hints, questionText, correctAnswer).then((response) => {
+        const parsedHints = JSON.parse(response.gptHints.content);  
         setGptHints(parsedHints);
+        setisHintLoading(false);
         if (parsedHints){
+          setHints(null);
           apiClient.getGameSession(gameSessionId).then((gameSession) => {
             apiClient
               .updateQuestion({
@@ -473,14 +489,19 @@ const GameSessionContainer = () => {
             });
           });
         }
-      });
+      })
+      .catch(e => {
+        console.log(e);
+        setHintsError(true);
+      })
+      ;
     } catch {
       setHintsError(true);
     }
   };
 
   if (!gameSession) {
-    return null;
+    return null;        
   }
   switch (gameSession.currentState) {
     case GameSessionState.NOT_STARTED:
@@ -522,8 +543,9 @@ const GameSessionContainer = () => {
           handleHintChange={handleHintChange}
           hints={hints}
           gptHints={gptHints}
-          handleProcessHintsClick={handleProcessHintsClick}
           hintsError={hintsError}
+          isHintLoading={isHintLoading}
+          handleProcessHints={handleProcessHints}
         />
       );
     }
@@ -558,8 +580,9 @@ const GameSessionContainer = () => {
           handleHintChange={handleHintChange}
           hints={hints}
           gptHints={gptHints}
-          handleProcessHintsClick={handleProcessHintsClick}
           hintsError={hintsError}
+          isHintLoading={isHintLoading}
+          handleProcessHints={handleProcessHints}
         />
       );
 

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -53,7 +53,7 @@ const GameSessionContainer = () => {
     { ref: questionCardRef, text: 'Question Card' },
     { ref: responsesRef, text: 'Responses Settings' },
     { ref: confidenceCardRef, text: 'Confidence Settings' },
-    { ref: hintCardRef, text: 'Surfacing Thinking Settings' },
+    { ref: hintCardRef, text: 'Player Thinking Settings' },
   ];
   const gameplayNavDictionary = [
     { ref: questionCardRef, text: 'Question Card' },
@@ -64,24 +64,17 @@ const GameSessionContainer = () => {
     questionConfigNavDictionary,
   );
   // assembles fields for module navigator in footer
-  const assembleNavDictionary = (isConfidenceEnabled, state) => {
+  const assembleNavDictionary = (isConfidenceEnabled, isHintEnabled, state) => {
     if (state === GameSessionState.TEAMS_JOINING) {
       setNavDictionary(questionConfigNavDictionary);
       return;
     }
     let newDictionary = [...gameplayNavDictionary];
     let insertIndex = 2;
-    if (isConfidenceEnabled){
+    if (isConfidenceEnabled && (state === GameSessionState.CHOOSE_CORRECT_ANSWER || state === GameSessionState.PHASE_1_DISCUSS)){
       newDictionary.splice(insertIndex, 0, {
         ref: confidenceCardRef,
         text: 'Player Confidence',
-      });
-      insertIndex++;
-    }
-    if (isShortAnswerEnabled){
-      newDictionary.splice(insertIndex, 0, {
-        ref: featuredMistakesRef,
-        text: 'Featured Mistakes',
       });
       insertIndex++;
     }
@@ -89,6 +82,13 @@ const GameSessionContainer = () => {
       newDictionary.splice(insertIndex, 0, {
         ref: hintCardRef,
         text: 'Player Thinking',
+      });
+      insertIndex++;
+    }
+    if (isShortAnswerEnabled){
+      newDictionary.splice(insertIndex, 0, {
+        ref: featuredMistakesRef,
+        text: 'Featured Mistakes',
       });
       insertIndex++;
     }
@@ -120,6 +120,7 @@ const GameSessionContainer = () => {
         };
         assembleNavDictionary(
           response.questions[response.currentQuestionIndex].isConfidenceEnabled,
+          response.questions[response.currentQuestionIndex].isHintEnabled,
           response.currentState,
         );
       }
@@ -572,6 +573,7 @@ const GameSessionContainer = () => {
           showFooterButtonOnly={true}
           setIsConfidenceEnabled={setIsConfidenceEnabled}
           assembleNavDictionary={assembleNavDictionary}
+          isHintEnabled={isHintEnabled}
         />
       );
 

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -8,11 +8,8 @@ import {
   Environment,
   GameSessionState,
   IGameSession,
+  IHints,
   isNullOrUndefined,
-  NumberAnswer,
-  StringAnswer,
-  ExpressionAnswer,
-  AnswerType
 } from '@righton/networking';
 import GameInProgress from '../pages/GameInProgress';
 import Ranking from '../pages/Ranking';
@@ -115,9 +112,7 @@ const GameSessionContainer = () => {
         setIsHintEnabled(
           response.questions[response.currentQuestionIndex].isHintEnabled,
         );
-        if (!isNullOrUndefined(response.questions[response.currentQuestionIndex].hints)) {
-          setHints(response.questions[response.currentQuestionIndex].hints);
-        };
+        setGptHints(response.questions[response.currentQuestionIndex].hints);
         assembleNavDictionary(
           response.questions[response.currentQuestionIndex].isConfidenceEnabled,
           response.questions[response.currentQuestionIndex].isHintEnabled,
@@ -270,7 +265,6 @@ const GameSessionContainer = () => {
           });
           return newState;
         });
-        console.log(teamAnswerResponse);
         if (!isNullOrUndefined(teamAnswerResponse.hint)) {
           setHints((prevHints) => {return [...prevHints, teamAnswerResponse.hint]});
         }
@@ -469,7 +463,7 @@ const GameSessionContainer = () => {
                 gameSessionId: gameSession.id, 
                 id: gameSession.questions[gameSession.currentQuestionIndex].id,
                 order: gameSession.questions[gameSession.currentQuestionIndex].order,
-                hints: JSON.stringify(parsedHints),
+                hints: JSON.stringify(parsedHints as IHints[]),
             });
           });
         }

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -185,12 +185,12 @@ export default function GameInProgress({
   const handleFooterOnClick = (numPlayers, totalAnswers) => {
     let nextState = nextStateFunc(currentState);
     if (nextState === GameSessionState.CHOOSE_CORRECT_ANSWER) {
-      assembleNavDictionary(isConfidenceEnabled, nextState);
+      assembleNavDictionary(isConfidenceEnabled, isHintEnabled, nextState);
       handleBeginQuestion();
       return;
     }
     if (nextState === GameSessionState.TEAMS_JOINING)
-      assembleNavDictionary(isConfidenceEnabled, nextState);
+      assembleNavDictionary(isConfidenceEnabled, isHintEnabled, nextState);
     if (
       nextState === GameSessionState.PHASE_1_DISCUSS ||
       nextState === GameSessionState.PHASE_2_DISCUSS

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -53,7 +53,8 @@ export default function GameInProgress({
   handleHintChange,
   hints,
   gptHints,
-  handleProcessHintsClick
+  handleProcessHintsClick,
+  hintsError,
 }) {
   const classes = useStyles();
   const footerButtonTextDictionary = {
@@ -285,6 +286,7 @@ export default function GameInProgress({
             hints={hints}
             gptHints={gptHints}
             handleProcessHintsClick={handleProcessHintsClick}
+            hintsError={hintsError}
           />
         </div>
         <GameModal

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -74,7 +74,6 @@ export default function GameInProgress({
   const correctChoiceIndex =
     questionChoices.findIndex(({ isAnswer }) => isAnswer) + 1;
   const statePosition = Object.keys(GameSessionState).indexOf(currentState);
-
   // using useMemo due to the nested maps in the getAnswerByQuestion and the fact that this component rerenders every second from the timer
   const answers = useMemo(
     () =>

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -53,8 +53,9 @@ export default function GameInProgress({
   handleHintChange,
   hints,
   gptHints,
-  handleProcessHintsClick,
   hintsError,
+  isHintLoading,
+  handleProcessHints
 }) {
   const classes = useStyles();
   const footerButtonTextDictionary = {
@@ -287,8 +288,9 @@ export default function GameInProgress({
             handleHintChange={handleHintChange}
             hints={hints}
             gptHints={gptHints}
-            handleProcessHintsClick={handleProcessHintsClick}
             hintsError={hintsError}
+            isHintLoading={isHintLoading}
+            handleProcessHints={handleProcessHints}
           />
         </div>
         <GameModal

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -152,7 +152,10 @@ export default function GameInProgress({
     setTimeout(() => {
       if (graph === 'realtime')
         responsesRef.current.scrollIntoView({ behavior: 'smooth' });
-      else confidenceCardRef.current.scrollIntoView({ behavior: 'smooth' });
+      else if (graph=== 'confidence') 
+        confidenceCardRef.current.scrollIntoView({ behavior: 'smooth' });
+      else
+        hintCardRef.current.scrollIntoView({ behavior: 'smooth' });
     }, 0);
   };
 

--- a/host/src/pages/StudentViews.jsx
+++ b/host/src/pages/StudentViews.jsx
@@ -20,6 +20,7 @@ export default function StudentViews({
   showFooterButtonOnly,
   setIsConfidenceEnabled,
   assembleNavDictionary,
+  isHintEnabled
 }) {
   let statePosition;
   let isLastQuestion =
@@ -81,7 +82,7 @@ export default function StudentViews({
     if (!isLastQuestion && currentState === GameSessionState.PHASE_2_RESULTS) {
       // if they are on the last page a\nd need to advance to the next question
       setIsConfidenceEnabled(false);
-      assembleNavDictionary(false, GameSessionState.TEAMS_JOINING);
+      assembleNavDictionary(false, isHintEnabled, GameSessionState.TEAMS_JOINING);
       handleUpdateGameSession({
         currentState: nextStateFunc(currentState),
         currentQuestionIndex: currentQuestionIndex + 1,
@@ -89,7 +90,7 @@ export default function StudentViews({
       return;
     }
     if (currentState === GameSessionState.PHASE_1_RESULTS)
-      assembleNavDictionary(false, currentState);
+      assembleNavDictionary(false, isHintEnabled, currentState);
     handleUpdateGameSession({ currentState: nextStateFunc(currentState) });
   };
 

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -89,7 +89,9 @@ export class ApiClient implements IApiClient {
     }
 
     async groupHints(
-        hints: string[]
+        hints: string[],
+        questionText: string,
+        correctAnswer: string
     ):Promise<string> {
         try { 
         const attempt = fetch(this.hintEndpoint, {
@@ -100,12 +102,14 @@ export class ApiClient implements IApiClient {
                 "Access-Control-Allow-Origin": "*",
             },
             body: JSON.stringify({
-                hints: hints
+                hints: hints,
+                questionText: questionText,
+                correctAnswer: correctAnswer
             }),
         })
         .then((response) => {
             if (!response.ok) {
-                throw new Error(response.statusText)
+               console.error(response.statusText)
             }
             return response.json()
         })

--- a/networking/src/ApiClient.ts
+++ b/networking/src/ApiClient.ts
@@ -52,7 +52,7 @@ import {
     updateQuestion
 } from "./graphql/mutations"
 import { IApiClient, isNullOrUndefined } from "./IApiClient"
-import { IChoice, IResponse, IQuestion, IAnswerSettings, ITeamAnswer, ITeamAnswerHint, ITeamMember, IGameSession, ITeam, ITeamAnswerContent, NumberAnswer, AnswerType, StringAnswer, ExpressionAnswer } from "./Models"
+import { IChoice, IResponse, IQuestion, IHints, IAnswerSettings, ITeamAnswer, ITeamAnswerHint, ITeamMember, IGameSession, ITeam, ITeamAnswerContent, NumberAnswer, AnswerType, StringAnswer, ExpressionAnswer } from "./Models"
 
 Amplify.configure(awsconfig)
 
@@ -581,6 +581,7 @@ type AWSQuestion = {
     choices?: string | null
     answerSettings?: string | null
     responses?: string | null
+    hints?: string | null
     imageUrl?: string | null
     instructions?: string | null
     standard?: string | null
@@ -774,6 +775,9 @@ export class GameSessionParser {
                     responses: isNullOrUndefined(awsQuestion.responses)
                          ? []
                          : this.parseServerArray<IResponse>(awsQuestion.responses),
+                    hints: isNullOrUndefined(awsQuestion.hints)
+                        ? []
+                        : this.parseServerArray<IHints>(awsQuestion.hints),
                     imageUrl: awsQuestion.imageUrl,
                     instructions: isNullOrUndefined(awsQuestion.instructions)
                         ? []

--- a/networking/src/Models/IQuestion.ts
+++ b/networking/src/Models/IQuestion.ts
@@ -6,6 +6,7 @@ export interface IQuestion {
     choices?: Array<IChoice> | null
     answerSettings?: IAnswerSettings | null
     responses?: Array<IResponse> | null
+    hints?: IHints[] | null
     imageUrl?: string | null
     instructions?: Array<string> | null
     standard?: string | null
@@ -44,4 +45,10 @@ export interface IResponseTeam {
     team: string
     id: string
     confidence: ConfidenceLevel
+}
+
+export interface IHints {
+    themeText: string;
+    teams: string[];
+    teamCount: number;
 }

--- a/play/public/locales/en/translation.json
+++ b/play/public/locales/en/translation.json
@@ -113,6 +113,7 @@
     },
     "button": {
       "submit": "Submit Answer",
+      "hint": "Submit Hint",
       "submitted": "Submitted"
     }
   },

--- a/play/public/locales/es/translation.json
+++ b/play/public/locales/es/translation.json
@@ -104,7 +104,7 @@
     },
     "button": {
       "submit": "Enviar Respuesta",
-      "submitHint": "Enviar Explicación",
+      "hint": "Enviar Explicación",
       "submitted": "Enviada"
     }
   },

--- a/play/src/components/ButtonSubmitAnswer.tsx
+++ b/play/src/components/ButtonSubmitAnswer.tsx
@@ -40,9 +40,12 @@ export default function ButtonSubmitAnswer({
   const buttonText = isSubmitted
     ? t('gameinprogress.button.submitted')
     : t('gameinprogress.button.submit');
+  const hintButtonText = isSubmitted
+    ? t('gameinprogress.button.submitted')
+    : t('gameinprogress.button.hint');
   const buttonContents = (
     <Typography sx={{ textTransform: 'none' }} variant="button">
-      {buttonText}
+      {isHint ? hintButtonText : buttonText}
     </Typography>
   );
   return isSelected && !isSubmitted ? (

--- a/play/src/containers/GameInProgressContainer.tsx
+++ b/play/src/containers/GameInProgressContainer.tsx
@@ -14,6 +14,7 @@ import {
   LocalModel,
   StorageKey,
   StorageKeyAnswer,
+  StorageKeyHint,
   ErrorType,
 } from '../lib/PlayModels';
 
@@ -108,7 +109,10 @@ export function LocalModelLoader(): LocalModel {
   const localModelAnswer = JSON.parse(
     window.localStorage.getItem(StorageKeyAnswer) ?? '{}'
   );
-  const localModel = { ...localModelBase, answer: localModelAnswer };
+  const localModelHint = JSON.parse(
+    window.localStorage.getItem(StorageKeyHint) ?? '{}'
+  );
+  const localModel = { ...localModelBase, answer: localModelAnswer, hint: localModelHint };
   if (localModel && !localModel.hasRejoined) {
     const updatedModelForNextReload = { ...localModel, hasRejoined: true };
     window.localStorage.setItem(

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -142,6 +142,7 @@ export function PregameContainer({ apiClient }: PregameFinished) {
           hasRejoined: false,
           currentTimer: gameSession.phaseOneTime,
           answer: null,
+          hint: null
         };
         window.localStorage.setItem(StorageKey, JSON.stringify(storageObject));
         navigate(`/game`);

--- a/play/src/lib/HelperFunctions.tsx
+++ b/play/src/lib/HelperFunctions.tsx
@@ -4,6 +4,7 @@ import {
   StringAnswer,
   ExpressionAnswer,
   ITeam,
+  ITeamAnswerHint,
   GameSessionState,
   isNullOrUndefined,
   ConfidenceLevel,
@@ -83,6 +84,39 @@ export const checkForSubmittedAnswerOnRejoin = (
     }
   }
   return returnedAnswer as ITeamAnswerContent;
+};
+
+/**
+ * on rejoining game, this checks if the player has already submitted a hint
+ * @param localModel - the localModel retrieved from local storage
+ * @param hasRejoined - if a player is rejoining
+ * @param currentState - the current state of the game session
+ * @param currentQuestionIndex - the current question index of the game session
+ * @returns - the hint that the player was working on, null if they haven't submitted a hint 
+ */
+export const checkForSubmittedHintOnRejoin = (
+  localModel: LocalModel,
+  hasRejoined: boolean,
+  currentState: GameSessionState,
+  currentQuestionIndex: number
+): ITeamAnswerHint => {
+  let returnedHint: ITeamAnswerHint = {
+    rawHint: '',
+    teamName: '',
+    isHintSubmitted: false,
+  };
+  if (hasRejoined) {
+    if (
+      localModel.answer !== null &&
+      localModel.hint!== null &&
+      localModel.answer.currentState === currentState &&
+      localModel.answer.currentQuestionIndex === currentQuestionIndex
+    ) {
+      // set hint to localModel.hint
+      returnedHint = localModel.hint;
+    }
+  }
+  return returnedHint as ITeamAnswerHint;
 };
 
 /**

--- a/play/src/lib/PlayModels.tsx
+++ b/play/src/lib/PlayModels.tsx
@@ -1,4 +1,4 @@
-import { ITeamAnswerContent } from '@righton/networking';
+import { ITeamAnswerContent, ITeamAnswerHint } from '@righton/networking';
 import Icon0 from '../img/MonsterIcon0.svg';
 import Icon1 from '../img/MonsterIcon1.svg';
 import Icon2 from '../img/MonsterIcon2.svg';
@@ -130,6 +130,7 @@ export interface LocalModel {
   hasRejoined: boolean;
   currentTimer: number;
   answer: ITeamAnswerContent | null;
+  hint: ITeamAnswerHint | null;
 }
 
 interface MonsterMap {

--- a/play/src/pages/GameInProgress.tsx
+++ b/play/src/pages/GameInProgress.tsx
@@ -32,6 +32,7 @@ import FooterStackContainerStyled from '../lib/styledcomponents/layout/FooterSta
 import {
   checkForSubmittedAnswerOnRejoin,
   checkForSelectedConfidenceOnRejoin,
+  checkForSubmittedHintOnRejoin
 } from '../lib/HelperFunctions';
 import ErrorModal from '../components/ErrorModal';
 import { ErrorType, LocalModel, StorageKeyAnswer, StorageKeyHint } from '../lib/PlayModels';
@@ -76,7 +77,15 @@ export default function GameInProgress({
   const theme = useTheme();
   const [isAnswerError, setIsAnswerError] = useState(false);
   const [isConfidenceError, setIsConfidenceError] = useState(false);
-  const [answerHint, setAnswerHint] = useState<ITeamAnswerHint | null>(null);
+  const [answerHint, setAnswerHint] = useState<ITeamAnswerHint>(() => {
+    const rejoinSubmittedHint = checkForSubmittedHintOnRejoin(
+      localModel,
+      hasRejoined,
+      currentState,
+      currentQuestionIndex ?? 0
+    ); 
+    return rejoinSubmittedHint;
+  });
   const isSmallDevice = useMediaQuery(theme.breakpoints.down('sm'));
   const currentTeam = teams?.find((team) => team.id === teamId);
   const currentQuestion = questions[currentQuestionIndex ?? 0];


### PR DESCRIPTION
This is the first of a few PRs for the Hint feature that will use GPT-4 to categorize hints. The PRs breakdown as follows:
[[Host] - Enable/disable Hint Feature on Host #896](https://github.com/rightoneducation/righton-app/pull/896)
-> [[Play/Networking] - Intakes hints on play, updates networking to send them to backend #897](https://github.com/rightoneducation/righton-app/pull/897)
->->[[Host/Play/Networking] - Updates across the apps to handle intaking/sending to lambda hints by host #898](https://github.com/rightoneducation/righton-app/pull/898)
->->->[[Host/Play] - Bug Fixes #899](https://github.com/rightoneducation/righton-app/pull/899)
->->->->[[Host/Networking] - Prompt Adjustment #900](https://github.com/rightoneducation/righton-app/pull/900)
->->->->->[[Host/Networking] - Moves the processing of hints to next phase #901](https://github.com/rightoneducation/righton-app/pull/901)

This PR addresses the following bugs:

1. `host` - Adds error check to processing hints api call
2. `host` - Fixes scroll bug with handleGraphClick
3. `host` - Disables the processing hints button if less than two players have submitted hints
4. `play` - Adds in localstorage variable for hints similar to answers, so that students can't refresh and resubmit hints
5. `networking`- Parses questions.hints so that hint info is reloaded on page refresh