### PR TITLE
[Host/Networking] - Moves the processing of hints to next phase

### DIFF
--- a/host/src/components/FooterGame.jsx
+++ b/host/src/components/FooterGame.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles, BottomNavigation } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
-import PlayersAnsweredBar from './PlayersAnsweredBar';
+import LinearProgressBar from './LinearProgressBar';
 import ModuleNavigator from './ModuleNavigator';
 
 export default function FooterGame({
@@ -39,9 +39,9 @@ export default function FooterGame({
           <>
             <div style={{ opacity: gameTimer ? 1 : 0.4, width: '100%' }}>
               <div className={classes.playerNum}>Players who have answered</div>
-              <PlayersAnsweredBar
-                numPlayers={numPlayers}
-                totalAnswers={totalAnswers}
+              <LinearProgressBar
+                inputNum={totalAnswers}
+                totalNum={numPlayers}
               />
             </div>
             <ModuleNavigator

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -46,7 +46,8 @@ export default function GameInProgressContentSwitch ({
     hints,
     gptHints,
     hintsError,
-    isHintLoading
+    isHintLoading,
+    handleProcessHints
   }) {
   const classes = useStyles();
   const graphClickRenderSwitch = (graphClickInfo) => {
@@ -121,6 +122,7 @@ export default function GameInProgressContentSwitch ({
               hintsError={hintsError}
               currentState={currentState}
               isHintLoading={isHintLoading}
+              handleProcessHints={handleProcessHints}
             />
             <PlayerThinkingSelectedAnswer
               gptHints={gptHints}
@@ -204,6 +206,7 @@ export default function GameInProgressContentSwitch ({
                 hintsError={hintsError}
                 currentState={currentState}
                 isHintLoading={isHintLoading}
+                handleProcessHints={handleProcessHints}
               />
             </div>
           ) : null}

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -45,7 +45,6 @@ export default function GameInProgressContentSwitch ({
     handleHintChange,
     hints,
     gptHints,
-    handleProcessHintsClick,
     hintsError
   }) {
   const classes = useStyles();
@@ -118,9 +117,8 @@ export default function GameInProgressContentSwitch ({
               statePosition={statePosition}
               graphClickInfo={graphClickInfo}
               handleGraphClick={handleGraphClick}
-              handleProcessHintsClick={handleProcessHintsClick}
               hintsError={hintsError}
-              
+              currentState={currentState}
             />
             <PlayerThinkingSelectedAnswer
               gptHints={gptHints}
@@ -201,8 +199,8 @@ export default function GameInProgressContentSwitch ({
                 statePosition={statePosition}
                 graphClickInfo={graphClickInfo}
                 handleGraphClick={handleGraphClick}
-                handleProcessHintsClick={handleProcessHintsClick}
                 hintsError={hintsError}
+                currentState={currentState}
               />
             </div>
           ) : null}

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -45,7 +45,8 @@ export default function GameInProgressContentSwitch ({
     handleHintChange,
     hints,
     gptHints,
-    hintsError
+    hintsError,
+    isHintLoading
   }) {
   const classes = useStyles();
   const graphClickRenderSwitch = (graphClickInfo) => {
@@ -119,6 +120,7 @@ export default function GameInProgressContentSwitch ({
               handleGraphClick={handleGraphClick}
               hintsError={hintsError}
               currentState={currentState}
+              isHintLoading={isHintLoading}
             />
             <PlayerThinkingSelectedAnswer
               gptHints={gptHints}
@@ -201,6 +203,7 @@ export default function GameInProgressContentSwitch ({
                 handleGraphClick={handleGraphClick}
                 hintsError={hintsError}
                 currentState={currentState}
+                isHintLoading={isHintLoading}
               />
             </div>
           ) : null}

--- a/host/src/components/LinearProgressBar.jsx
+++ b/host/src/components/LinearProgressBar.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core';
 import LinearProgress from '@material-ui/core/LinearProgress';
 
-export default function PlayersAnsweredBar({ numPlayers, totalAnswers }) {
+export default function LinearProgressBar({ inputNum, totalNum }) {
   const classes = useStyles();
   const progressPercent =
-    numPlayers !== 0 ? (totalAnswers / numPlayers) * 100 : 0;
+    inputNum !== 0 ? (inputNum / totalNum) * 100 : 0;
 
   return (
     <div className={classes.bargroup}>
@@ -33,10 +33,10 @@ export default function PlayersAnsweredBar({ numPlayers, totalAnswers }) {
             lineHeight: '18px',
           }}
         >
-          {totalAnswers}
+          {inputNum}
         </div>
       </div>
-      <div className={classes.totalPlayers}>{numPlayers}</div>
+      <div className={classes.totalNum}>{totalNum}</div>
     </div>
   );
 }
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
     gap: '10px',
     width: '100%',
   },
-  totalPlayers: {
+  totalNum: {
     fontSize: '12px',
     lineHeight: '12px',
     color: 'white',

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import { Box, CircularProgress, Typography } from '@material-ui/core';
+import { Box, CircularProgress, Typography, Button } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core';
 import { GameSessionState, isNullOrUndefined } from '@righton/networking';
 import LinearProgressBar from '../LinearProgressBar';
@@ -17,9 +17,11 @@ export default function PlayerThinking({
   handleGraphClick,
   hintsError,
   currentState,
-  isHintLoading
+  isHintLoading,
+  handleProcessHints
 }) {
   const classes = useStyles();
+  hintsError = true;
   return (
     <Box className={classes.centerContent}>
       <Box style={{display: 'flex', aligntItems: 'center', justifyContent: 'space-between', width: '100%'}}>
@@ -66,7 +68,7 @@ export default function PlayerThinking({
             </>
           ) : (
               <>
-                {isHintLoading && (
+                {(isHintLoading && !hintsError) && (
                   <>
                     <CircularProgress style={{color:'#159EFA'}}/>
                     <Typography className={classes.subText}>
@@ -75,9 +77,18 @@ export default function PlayerThinking({
                     </>
                 )}
                 {hintsError && (
-                    <Typography className={classes.subText}>
-                        There was an error processing the hints. Please try again.
-                    </Typography>
+                    <>
+                      <Button
+                        className={classes.button}
+                        disabled={hints.length < 2}
+                        onClick={() => handleProcessHints(hints)}
+                      >
+                        Retry
+                      </Button>
+                      <Typography className={classes.subText}>
+                          There was an error processing the hints. Please try again.
+                      </Typography>
+                    </>
                 )}
               </>
             )}

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import { Box, Typography } from '@material-ui/core';
+import { Box, CircularProgress, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core';
 import { GameSessionState, isNullOrUndefined } from '@righton/networking';
 import LinearProgressBar from '../LinearProgressBar';
@@ -16,7 +16,8 @@ export default function PlayerThinking({
   isShortAnswerEnabled,
   handleGraphClick,
   hintsError,
-  currentState
+  currentState,
+  isHintLoading
 }) {
   const classes = useStyles();
   return (
@@ -29,45 +30,61 @@ export default function PlayerThinking({
       <Typography className={classes.infoText}>
         Players have optionally submitted hints to help other players.
       </Typography>
-      { !isNullOrUndefined(gptHints)? 
-        <>
-          <PlayerThinkingGraph
-            data={gptHints}
-            numPlayers={numPlayers}
-            totalAnswers={totalAnswers}
-            questionChoices={questionChoices}
-            statePosition={statePosition}
-            graphClickInfo={graphClickInfo}
-            isShortAnswerEnabled={isShortAnswerEnabled && statePosition < 6}
-            handleGraphClick={handleGraphClick}
-          />
-          {graphClickInfo.graph === null ? (
-            <Typography className={classes.subText}>
-              Tap on a response to see more details.
-            </Typography>
-          ) : null}
-        </>
-      : 
-      <Box style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: 16}}>
+      <Box style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: 16 }}>
+    { currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER ? (
+      <>
         <Typography className={classes.infoText}>
-        Players that have submitted a hint:
+            Players that have submitted a hint:
         </Typography>
         <LinearProgressBar
-          inputNum={hints.length}
-          totalNum={numPlayers}
+            inputNum={hints.length}
+            totalNum={numPlayers}
         />
-        { currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER &&
-          <Typography className={classes.subText}>
+        <Typography className={classes.subText}>
             Hints will be displayed in the next phase
-          </Typography>
-        }
-        { hintsError &&
-          <Typography className={classes.subText}>
-            There was an error processing the hints. Please try again.
-          </Typography>
-        } 
-       </Box>
-      }
+        </Typography>
+      </>
+    ) : (
+        <>
+          {!isNullOrUndefined(gptHints) && !isHintLoading ? (
+            <>      
+              <PlayerThinkingGraph
+                  data={gptHints}
+                  numPlayers={numPlayers}
+                  totalAnswers={totalAnswers}
+                  questionChoices={questionChoices}
+                  statePosition={statePosition}
+                  graphClickInfo={graphClickInfo}
+                  isShortAnswerEnabled={isShortAnswerEnabled && statePosition < 6}
+                  handleGraphClick={handleGraphClick}
+              />
+              {graphClickInfo.graph === null && (
+                  <Typography className={classes.subText}>
+                      Tap on a response to see more details.
+                  </Typography>
+              )}
+            </>
+          ) : (
+              <>
+                {isHintLoading && (
+                  <>
+                    <CircularProgress style={{color:'#159EFA'}}/>
+                    <Typography className={classes.subText}>
+                       The hints are loading ...
+                    </Typography>
+                    </>
+                )}
+                {hintsError && (
+                    <Typography className={classes.subText}>
+                        There was an error processing the hints. Please try again.
+                    </Typography>
+                )}
+              </>
+            )}
+        </>
+    )}
+</Box>
+
     </Box>
   );
 }

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -47,7 +47,7 @@ export default function PlayerThinking({
       </>
     ) : (
         <>
-          {!isNullOrUndefined(gptHints) && !isHintLoading ? (
+          {!isNullOrUndefined(gptHints) && !isHintLoading && !hintsError ? (
             <>      
               <PlayerThinkingGraph
                   data={gptHints}
@@ -79,7 +79,6 @@ export default function PlayerThinking({
                     <>
                       <Button
                         className={classes.button}
-                        disabled={hints.length < 2}
                         onClick={() => handleProcessHints(hints)}
                       >
                         Retry

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -21,7 +21,6 @@ export default function PlayerThinking({
   handleProcessHints
 }) {
   const classes = useStyles();
-  hintsError = true;
   return (
     <Box className={classes.centerContent}>
       <Box style={{display: 'flex', aligntItems: 'center', justifyContent: 'space-between', width: '100%'}}>

--- a/host/src/components/PlayerThinking/PlayerThinking.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinking.jsx
@@ -1,7 +1,8 @@
 import React, {useState} from 'react';
-import { Box, Typography, Button, RadioGroup, FormControlLabel, Radio } from '@material-ui/core';
+import { Box, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core';
-import { isNullOrUndefined } from '@righton/networking';
+import { GameSessionState, isNullOrUndefined } from '@righton/networking';
+import LinearProgressBar from '../LinearProgressBar';
 import PlayerThinkingGraph from './PlayerThinkingGraph';
 
 export default function PlayerThinking({
@@ -14,8 +15,8 @@ export default function PlayerThinking({
   graphClickInfo,
   isShortAnswerEnabled,
   handleGraphClick,
-  handleProcessHintsClick,
-  hintsError
+  hintsError,
+  currentState
 }) {
   const classes = useStyles();
   return (
@@ -49,20 +50,17 @@ export default function PlayerThinking({
       : 
       <Box style={{display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', gap: 16}}>
         <Typography className={classes.infoText}>
-        {hints.length} / {numPlayers} players have submitted a hint
+        Players that have submitted a hint:
         </Typography>
-          <Button
-          className={classes.button}
-          disabled={hints.length < 2}
-          onClick={() => handleProcessHintsClick(hints)}
-        >
-          Process Hints
-        </Button>
-        { hints.length < 2 &&
+        <LinearProgressBar
+          inputNum={hints.length}
+          totalNum={numPlayers}
+        />
+        { currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER &&
           <Typography className={classes.subText}>
-            At least 2 players must submit a hint to process them
+            Hints will be displayed in the next phase
           </Typography>
-        } 
+        }
         { hintsError &&
           <Typography className={classes.subText}>
             There was an error processing the hints. Please try again.
@@ -97,7 +95,7 @@ const useStyles = makeStyles({
   infoText: {
     color: '#FFF',
     alignSelf: 'stretch',
-    textAlign: 'center',
+    textAlign: 'left',
     fontFamily: 'Poppins',
     fontSize: '14px',
     fontStyle: 'normal',

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -524,7 +524,6 @@ const GameSessionContainer = () => {
           handleHintChange={handleHintChange}
           hints={hints}
           gptHints={gptHints}
-          handleProcessHintsClick={handleProcessHintsClick}
           hintsError={hintsError}
         />
       );
@@ -560,7 +559,6 @@ const GameSessionContainer = () => {
           handleHintChange={handleHintChange}
           hints={hints}
           gptHints={gptHints}
-          handleProcessHintsClick={handleProcessHintsClick}
           hintsError={hintsError}
         />
       );

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -465,6 +465,7 @@ const GameSessionContainer = () => {
       });
   };
   const handleProcessHints = async (hints) => {
+    setHintsError(false);
     try {
       const currentQuestion = gameSession?.questions[gameSession?.currentQuestionIndex];
       const questionText =  currentQuestion.text;
@@ -488,7 +489,12 @@ const GameSessionContainer = () => {
             });
           });
         }
-      });
+      })
+      .catch(e => {
+        console.log(e);
+        setHintsError(true);
+      })
+      ;
     } catch {
       setHintsError(true);
     }
@@ -539,6 +545,7 @@ const GameSessionContainer = () => {
           gptHints={gptHints}
           hintsError={hintsError}
           isHintLoading={isHintLoading}
+          handleProcessHints={handleProcessHints}
         />
       );
     }
@@ -575,6 +582,7 @@ const GameSessionContainer = () => {
           gptHints={gptHints}
           hintsError={hintsError}
           isHintLoading={isHintLoading}
+          handleProcessHints={handleProcessHints}
         />
       );
 

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -33,6 +33,7 @@ const GameSessionContainer = () => {
   const [hints, setHints] = useState([]);
   const [gptHints, setGptHints] = React.useState(null);
   const [hintsError, setHintsError] = React.useState(false);
+  const [isHintLoading, setisHintLoading] = React.useState(false);
   const [selectedMistakes, setSelectedMistakes] = useState([]);
   const [isTimerActive, setIsTimerActive] = useState(false);
   const [isLoadModalOpen, setIsLoadModalOpen] = useState(false);
@@ -148,7 +149,6 @@ const GameSessionContainer = () => {
         })
         .catch((reason) => console.log(reason));
     });
-
     let gameSessionSubscription: any | null = null;
     gameSessionSubscription = apiClient.subscribeUpdateGameSession(
       gameSessionId,
@@ -377,6 +377,17 @@ const GameSessionContainer = () => {
         });
     }
     
+    // if game is moving to PHASE_2_DISCUSS, hints are enabled, there are hints to process that have yet to be processed
+    if (
+      gameSession.currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER 
+      && isHintEnabled 
+      && gptHints === null 
+      && hints.length > 0
+    ) {
+      setisHintLoading(true);
+      handleProcessHints(hints);
+    }
+
     const response = await apiClient.updateGameSession({ id: gameSessionId, ...newUpdates })
     if (response.currentState === GameSessionState.CHOOSE_CORRECT_ANSWER) {
       setHeaderGameCurrentTime(response.phaseOneTime);
@@ -453,7 +464,7 @@ const GameSessionContainer = () => {
         setIsLoadModalOpen(true);
       });
   };
-  const handleProcessHintsClick = async (hints) => {
+  const handleProcessHints = async (hints) => {
     try {
       const currentQuestion = gameSession?.questions[gameSession?.currentQuestionIndex];
       const questionText =  currentQuestion.text;
@@ -464,7 +475,9 @@ const GameSessionContainer = () => {
       apiClient.groupHints(hints, questionText, correctAnswer).then((response) => {
         const parsedHints = JSON.parse(response.gptHints.content);  
         setGptHints(parsedHints);
+        setisHintLoading(false);
         if (parsedHints){
+          setHints(null);
           apiClient.getGameSession(gameSessionId).then((gameSession) => {
             apiClient
               .updateQuestion({
@@ -525,6 +538,7 @@ const GameSessionContainer = () => {
           hints={hints}
           gptHints={gptHints}
           hintsError={hintsError}
+          isHintLoading={isHintLoading}
         />
       );
     }
@@ -560,6 +574,7 @@ const GameSessionContainer = () => {
           hints={hints}
           gptHints={gptHints}
           hintsError={hintsError}
+          isHintLoading={isHintLoading}
         />
       );
 

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -54,7 +54,8 @@ export default function GameInProgress({
   hints,
   gptHints,
   hintsError,
-  isHintLoading
+  isHintLoading,
+  handleProcessHints
 }) {
   const classes = useStyles();
   const footerButtonTextDictionary = {
@@ -289,6 +290,7 @@ export default function GameInProgress({
             gptHints={gptHints}
             hintsError={hintsError}
             isHintLoading={isHintLoading}
+            handleProcessHints={handleProcessHints}
           />
         </div>
         <GameModal

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -53,7 +53,6 @@ export default function GameInProgress({
   handleHintChange,
   hints,
   gptHints,
-  handleProcessHintsClick,
   hintsError,
 }) {
   const classes = useStyles();
@@ -287,7 +286,6 @@ export default function GameInProgress({
             handleHintChange={handleHintChange}
             hints={hints}
             gptHints={gptHints}
-            handleProcessHintsClick={handleProcessHintsClick}
             hintsError={hintsError}
           />
         </div>

--- a/host/src/pages/GameInProgress.jsx
+++ b/host/src/pages/GameInProgress.jsx
@@ -54,6 +54,7 @@ export default function GameInProgress({
   hints,
   gptHints,
   hintsError,
+  isHintLoading
 }) {
   const classes = useStyles();
   const footerButtonTextDictionary = {
@@ -287,6 +288,7 @@ export default function GameInProgress({
             hints={hints}
             gptHints={gptHints}
             hintsError={hintsError}
+            isHintLoading={isHintLoading}
           />
         </div>
         <GameModal


### PR DESCRIPTION
This is the first of a few PRs for the Hint feature that will use GPT-4 to categorize hints. The PRs breakdown as follows:
[[Host] - Enable/disable Hint Feature on Host #896](https://github.com/rightoneducation/righton-app/pull/896)
-> [[Play/Networking] - Intakes hints on play, updates networking to send them to backend #897](https://github.com/rightoneducation/righton-app/pull/897)
->->[[Host/Play/Networking] - Updates across the apps to handle intaking/sending to lambda hints by host #898](https://github.com/rightoneducation/righton-app/pull/898)
->->->[[Host/Play] - Bug Fixes #899](https://github.com/rightoneducation/righton-app/pull/899)
->->->->[[Host/Networking] - Prompt Adjustment #900](https://github.com/rightoneducation/righton-app/pull/900)
->->->->->[[Host/Networking] - Moves the processing of hints to next phase #901](https://github.com/rightoneducation/righton-app/pull/901)

This PR removes the placeholder "Processing Hints' button and instead moves that processing action to start automatically when `GameSessionState === PHASE_2_DISCUSS`. This is based on discussion in a team meeting with Yong Lin. 