### PR TITLE
Alex  host v2 responsive layout

### DIFF
--- a/host_v2/package.json
+++ b/host_v2/package.json
@@ -23,8 +23,10 @@
     "react-i18next": "^13.5.0",
     "react-router-dom": "^6.21.0",
     "react-scripts": "5.0.1",
+    "react-spring": "^9.7.3",
     "storybook": "^7.6.5",
     "styled-components": "^6.1.1",
+    "swiper": "^11.0.5",
     "typescript": "^4.9.5",
     "uuid": "^9.0.1",
     "web-vitals": "^2.1.4"

--- a/host_v2/src/components/PlaceholderContentArea.tsx
+++ b/host_v2/src/components/PlaceholderContentArea.tsx
@@ -34,17 +34,19 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
   const mediaQueryLarge = window.matchMedia(`(min-width: ${theme.breakpoints.values.lg}px)`);
   const isLargeScreen = mediaQueryLarge.matches;
 
-  // TODO: 
-  //      -update scroll behavior if necessary (after getting feedback from design)
   const largeScreen =
     <BodyContentAreaTripleColumnStyled container>
       <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
-        <Card />
-        <Card />
+        <ScrollBoxStyled>
+          <Card />
+          <Card />
+        </ScrollBoxStyled>
       </Grid>
       <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
-        <Card />
-        <Card />
+        <ScrollBoxStyled>
+          <Card />
+          <Card />
+        </ScrollBoxStyled>
       </Grid>
       <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
         <ScrollBoxStyled>
@@ -56,7 +58,6 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
 
   // TODO: 
   //      -resolve new keyword issue, preventing addition of bullets, pagination
-  //      -update scroll behavior if necessary (after getting feedback from design)
   const mediumScreen =
     <BodyContentAreaDoubleColumnStyled>
       <Swiper slidesPerView={2.1}>

--- a/host_v2/src/components/PlaceholderContentArea.tsx
+++ b/host_v2/src/components/PlaceholderContentArea.tsx
@@ -1,22 +1,121 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Grid } from '@mui/material';
-import { BodyContentAreaDoubleColumnStyled } from '../lib/styledcomponents/layout/BodyContentAreasStyled';
+import { useTheme } from '@mui/material/styles';
+import Pagination from 'swiper';
+import { useSpring, animated } from 'react-spring';
+import { Swiper, SwiperSlide } from "swiper/react";
+import {
+  BodyContentAreaDoubleColumnStyled,
+  BodyContentAreaTripleColumnStyled,
+  BodyContentAreaSingleColumnStyled
+} from '../lib/styledcomponents/layout/BodyContentAreasStyled';
 import Card from './Card';
+import 'swiper/css';
+import 'swiper/css/pagination';
+import ScrollBoxStyled from '../lib/styledcomponents/layout/ScrollBoxStyled';
+
 
 interface PlaceholderContentAreaProps { } // eslint-disable-line
 
 export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps) {
   // eslint-disable-line
-  return (
-    <BodyContentAreaDoubleColumnStyled container style={{ paddingTop: '16px' }}>
-      <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+  // TODO: pass screen size in from parent components later but for now do it this way
+  // this is only an initial check, wondering if we should use a listener in case the 
+  // screen size changes on desktop or if this suffices (with no listener and only an initial check)
+  const theme = useTheme();
+
+  const mediaQuerySmall = window.matchMedia(`(max-width: ${theme.breakpoints.values.sm}px)`);
+  const isSmallScreen = mediaQuerySmall.matches;
+
+  const mediaQueryMedium = window.matchMedia(`(min-width:${theme.breakpoints.values.sm}px), max-width: ${theme.breakpoints.values.lg}px)`);
+  const isMediumScreen = mediaQueryMedium.matches;
+
+  const mediaQueryLarge = window.matchMedia(`(min-width: ${theme.breakpoints.values.lg}px)`);
+  const isLargeScreen = mediaQueryLarge.matches;
+
+  // TODO: 
+  //      -enable scroll 
+  const largeScreen =
+    <BodyContentAreaTripleColumnStyled container style={{ paddingTop: '16px' }}>
+      <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
         <Card />
         <Card />
       </Grid>
-      <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+      <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
         <Card />
         <Card />
       </Grid>
+      <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
+        <Card />
+        <Card />
+      </Grid>
+    </BodyContentAreaTripleColumnStyled>
+
+  // TODO: 
+  //      -add edge of next slide to the right
+  //      -resolve new keyword issue, preventing addition of bullets, pagination
+  //      -enable scroll 
+  const mediumScreen =
+    <BodyContentAreaDoubleColumnStyled>
+      <Swiper slidesPerView={2}>
+        <SwiperSlide>
+          <Grid item xs={12} sm={6} direction="column">
+            <Card />
+            <Card />
+          </Grid>
+        </SwiperSlide>
+        <SwiperSlide>
+          <Grid item xs={12} sm={6} direction="column">
+            <Card />
+            <Card />
+          </Grid>
+        </SwiperSlide>
+        <SwiperSlide>
+          <Grid item xs={12} sm={6} direction="column">
+            <Card />
+            <Card />
+          </Grid>
+        </SwiperSlide>
+      </Swiper>
     </BodyContentAreaDoubleColumnStyled>
-  );
+
+  // TODO: 
+  //      -add edge of next slide to the right
+  //      -resolve new keyword issue, preventing addition of bullets, pagination
+  //      -enable scroll 
+  const smallScreen = <BodyContentAreaSingleColumnStyled>
+    <Swiper>
+      <SwiperSlide>
+        <ScrollBoxStyled>
+          <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+            <Card />
+            <Card />
+          </Grid>
+        </ScrollBoxStyled>
+      </SwiperSlide>
+      <SwiperSlide>
+        <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+          <Card />
+          <Card />
+        </Grid>
+      </SwiperSlide>
+      <SwiperSlide>
+        <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+          <Card />
+          <Card />
+        </Grid>
+      </SwiperSlide></Swiper>
+  </BodyContentAreaSingleColumnStyled>
+
+  if (isLargeScreen) {
+    return (
+      largeScreen
+    );
+  } if (isMediumScreen) {
+    return (
+      mediumScreen
+    );
+  }
+  return smallScreen;
+
 }

--- a/host_v2/src/components/PlaceholderContentArea.tsx
+++ b/host_v2/src/components/PlaceholderContentArea.tsx
@@ -54,26 +54,32 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
   // TODO: 
   //      -add edge of next slide to the right
   //      -resolve new keyword issue, preventing addition of bullets, pagination
-  //      -enable scroll 
+  //      -enable scroll
   const mediumScreen =
     <BodyContentAreaDoubleColumnStyled>
       <Swiper slidesPerView={2}>
         <SwiperSlide>
           <Grid item xs={12} sm={6} direction="column">
-            <Card />
-            <Card />
+            <ScrollBoxStyled>
+              <Card />
+              <Card />
+            </ScrollBoxStyled>
           </Grid>
         </SwiperSlide>
         <SwiperSlide>
           <Grid item xs={12} sm={6} direction="column">
-            <Card />
-            <Card />
+            <ScrollBoxStyled>
+              <Card />
+              <Card />
+            </ScrollBoxStyled>
           </Grid>
         </SwiperSlide>
         <SwiperSlide>
           <Grid item xs={12} sm={6} direction="column">
-            <Card />
-            <Card />
+            <ScrollBoxStyled>
+              <Card />
+              <Card />
+            </ScrollBoxStyled>
           </Grid>
         </SwiperSlide>
       </Swiper>
@@ -82,27 +88,30 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
   // TODO: 
   //      -add edge of next slide to the right
   //      -resolve new keyword issue, preventing addition of bullets, pagination
-  //      -enable scroll 
   const smallScreen = <BodyContentAreaSingleColumnStyled>
-    <Swiper>
-      <SwiperSlide>
-        <ScrollBoxStyled>
-          <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-            <Card />
-            <Card />
-          </Grid>
-        </ScrollBoxStyled>
-      </SwiperSlide>
+    <Swiper spaceBetween={10}>
       <SwiperSlide>
         <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-          <Card />
-          <Card />
+          <ScrollBoxStyled>
+            <Card />
+            <Card />
+          </ScrollBoxStyled>
         </Grid>
       </SwiperSlide>
       <SwiperSlide>
         <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-          <Card />
-          <Card />
+          <ScrollBoxStyled>
+            <Card />
+            <Card />
+          </ScrollBoxStyled>
+        </Grid>
+      </SwiperSlide>
+      <SwiperSlide>
+        <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+          <ScrollBoxStyled>
+            <Card />
+            <Card />
+          </ScrollBoxStyled>
         </Grid>
       </SwiperSlide></Swiper>
   </BodyContentAreaSingleColumnStyled>

--- a/host_v2/src/components/PlaceholderContentArea.tsx
+++ b/host_v2/src/components/PlaceholderContentArea.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode } from 'react';
 import { Grid } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { Pagination }  from "swiper/modules";
+import { Pagination } from "swiper/modules";
 import {
   BodyContentAreaDoubleColumnStyled,
   BodyContentAreaTripleColumnStyled,
@@ -19,19 +20,10 @@ interface PlaceholderContentAreaProps { } // eslint-disable-line
 
 export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps) {
   // eslint-disable-line
-  // TODO: pass screen size in from parent components later but for now do it this way
-  // this is only an initial check, wondering if we should use a listener in case the 
-  // screen size changes on desktop or if this suffices (with no listener and only an initial check)
+
   const theme = useTheme();
-
-  const mediaQuerySmall = window.matchMedia(`(max-width: ${theme.breakpoints.values.sm}px)`);
-  const isSmallScreen = mediaQuerySmall.matches;
-
-  const mediaQueryMedium = window.matchMedia(`(min-width:${theme.breakpoints.values.sm}px), max-width: ${theme.breakpoints.values.lg}px)`);
-  const isMediumScreen = mediaQueryMedium.matches;
-
-  const mediaQueryLarge = window.matchMedia(`(min-width: ${theme.breakpoints.values.lg}px)`);
-  const isLargeScreen = mediaQueryLarge.matches;
+  const isMediumScreen = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
+  const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
 
   const largeScreen =
     <BodyContentAreaTripleColumnStyled container>
@@ -55,12 +47,10 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
       </Grid>
     </BodyContentAreaTripleColumnStyled>
 
-  // TODO: 
-  //      -resolve new keyword issue, preventing addition of bullets, pagination
   const mediumScreen =
     <BodyContentAreaDoubleColumnStyled>
-      <Swiper      
-        modules={[Pagination]} 
+      <Swiper
+        modules={[Pagination]}
         pagination={{
           el: '.swiper-pagination-container',
           bulletClass: 'swiper-pagination-bullet',
@@ -99,48 +89,46 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
       </Swiper>
     </BodyContentAreaDoubleColumnStyled>
 
-  // TODO: 
-  //      -resolve new keyword issue, preventing addition of bullets, pagination
-  const smallScreen = 
+  const smallScreen =
     <BodyContentAreaSingleColumnStyled>
-      <Swiper 
-        modules={[Pagination]} 
+      <Swiper
+        modules={[Pagination]}
         pagination={{
           el: '.swiper-pagination-container',
           bulletClass: 'swiper-pagination-bullet',
           bulletActiveClass: 'swiper-pagination-bullet-active',
           clickable: true,
           renderBullet(index: number, className: string) {
-            return `<span class="${className}" style="width:20px; height:6px; border-radius:0"></span>`;
+            return `<span class="${className}" style="width:20px; height:6px; border-radius:0;"></span>`;
           },
         }}
         slidesPerView={1.1}
-        >
-          <SwiperSlide>
-            <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-              <ScrollBoxStyled>
-                <Card />
-                <Card />
-              </ScrollBoxStyled>
-            </Grid>
-          </SwiperSlide>
-          <SwiperSlide>
-            <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-              <ScrollBoxStyled>
-                <Card />
-                <Card />
-              </ScrollBoxStyled>
-            </Grid>
-          </SwiperSlide>
-          <SwiperSlide>
-            <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-              <ScrollBoxStyled>
-                <Card />
-                <Card />
-              </ScrollBoxStyled>
-            </Grid>
-          </SwiperSlide>
-        </Swiper>
+      >
+        <SwiperSlide>
+          <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+            <ScrollBoxStyled>
+              <Card />
+              <Card />
+            </ScrollBoxStyled>
+          </Grid>
+        </SwiperSlide>
+        <SwiperSlide>
+          <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+            <ScrollBoxStyled>
+              <Card />
+              <Card />
+            </ScrollBoxStyled>
+          </Grid>
+        </SwiperSlide>
+        <SwiperSlide>
+          <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+            <ScrollBoxStyled>
+              <Card />
+              <Card />
+            </ScrollBoxStyled>
+          </Grid>
+        </SwiperSlide>
+      </Swiper>
     </BodyContentAreaSingleColumnStyled>
 
   if (isLargeScreen) {
@@ -152,20 +140,20 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
       <>
         {mediumScreen}
         <PaginationContainerStyled
-        className="swiper-pagination-container"
-        style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
+          className="swiper-pagination-container"
+          style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
         />
       </>
     );
   }
   return (
     <>
-    {smallScreen}
-    <PaginationContainerStyled
-      className="swiper-pagination-container"
-      style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
-    />
-  </>
+      {smallScreen}
+      <PaginationContainerStyled
+        className="swiper-pagination-container"
+        style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
+      />
+    </>
   );
 
 }

--- a/host_v2/src/components/PlaceholderContentArea.tsx
+++ b/host_v2/src/components/PlaceholderContentArea.tsx
@@ -1,19 +1,18 @@
 import React, { ReactNode } from 'react';
 import { Grid } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import Pagination from 'swiper';
-import { useSpring, animated } from 'react-spring';
-import { Swiper, SwiperSlide } from "swiper/react";
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Pagination }  from "swiper/modules";
 import {
   BodyContentAreaDoubleColumnStyled,
   BodyContentAreaTripleColumnStyled,
   BodyContentAreaSingleColumnStyled
 } from '../lib/styledcomponents/layout/BodyContentAreasStyled';
 import Card from './Card';
-import HostDefaultCardStyled from '../lib/styledcomponents/HostDefaultCardStyled';
 import 'swiper/css';
 import 'swiper/css/pagination';
 import ScrollBoxStyled from '../lib/styledcomponents/layout/ScrollBoxStyled';
+import PaginationContainerStyled from '../lib/styledcomponents/PaginationContainerStyled';
 
 
 interface PlaceholderContentAreaProps { } // eslint-disable-line
@@ -60,7 +59,19 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
   //      -resolve new keyword issue, preventing addition of bullets, pagination
   const mediumScreen =
     <BodyContentAreaDoubleColumnStyled>
-      <Swiper slidesPerView={2.1}>
+      <Swiper      
+        modules={[Pagination]} 
+        pagination={{
+          el: '.swiper-pagination-container',
+          bulletClass: 'swiper-pagination-bullet',
+          bulletActiveClass: 'swiper-pagination-bullet-active',
+          clickable: true,
+          renderBullet(index: number, className: string) {
+            return `<span class="${className}" style="width:20px; height:6px; border-radius:0"></span>`;
+          },
+        }}
+        slidesPerView={2.1}
+      >
         <SwiperSlide>
           <Grid item xs={12} sm={6} direction="column">
             <ScrollBoxStyled>
@@ -90,33 +101,47 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
 
   // TODO: 
   //      -resolve new keyword issue, preventing addition of bullets, pagination
-  const smallScreen = <BodyContentAreaSingleColumnStyled>
-    <Swiper slidesPerView={1.1}>
-      <SwiperSlide>
-        <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-          <ScrollBoxStyled>
-            <Card />
-            <Card />
-          </ScrollBoxStyled>
-        </Grid>
-      </SwiperSlide>
-      <SwiperSlide>
-        <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-          <ScrollBoxStyled>
-            <Card />
-            <Card />
-          </ScrollBoxStyled>
-        </Grid>
-      </SwiperSlide>
-      <SwiperSlide>
-        <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
-          <ScrollBoxStyled>
-            <Card />
-            <Card />
-          </ScrollBoxStyled>
-        </Grid>
-      </SwiperSlide></Swiper>
-  </BodyContentAreaSingleColumnStyled>
+  const smallScreen = 
+    <BodyContentAreaSingleColumnStyled>
+      <Swiper 
+        modules={[Pagination]} 
+        pagination={{
+          el: '.swiper-pagination-container',
+          bulletClass: 'swiper-pagination-bullet',
+          bulletActiveClass: 'swiper-pagination-bullet-active',
+          clickable: true,
+          renderBullet(index: number, className: string) {
+            return `<span class="${className}" style="width:20px; height:6px; border-radius:0"></span>`;
+          },
+        }}
+        slidesPerView={1.1}
+        >
+          <SwiperSlide>
+            <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+              <ScrollBoxStyled>
+                <Card />
+                <Card />
+              </ScrollBoxStyled>
+            </Grid>
+          </SwiperSlide>
+          <SwiperSlide>
+            <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+              <ScrollBoxStyled>
+                <Card />
+                <Card />
+              </ScrollBoxStyled>
+            </Grid>
+          </SwiperSlide>
+          <SwiperSlide>
+            <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
+              <ScrollBoxStyled>
+                <Card />
+                <Card />
+              </ScrollBoxStyled>
+            </Grid>
+          </SwiperSlide>
+        </Swiper>
+    </BodyContentAreaSingleColumnStyled>
 
   if (isLargeScreen) {
     return (
@@ -124,9 +149,23 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
     );
   } if (isMediumScreen) {
     return (
-      mediumScreen
+      <>
+        {mediumScreen}
+        <PaginationContainerStyled
+        className="swiper-pagination-container"
+        style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
+        />
+      </>
     );
   }
-  return smallScreen;
+  return (
+    <>
+    {smallScreen}
+    <PaginationContainerStyled
+      className="swiper-pagination-container"
+      style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
+    />
+  </>
+  );
 
 }

--- a/host_v2/src/components/PlaceholderContentArea.tsx
+++ b/host_v2/src/components/PlaceholderContentArea.tsx
@@ -10,6 +10,7 @@ import {
   BodyContentAreaSingleColumnStyled
 } from '../lib/styledcomponents/layout/BodyContentAreasStyled';
 import Card from './Card';
+import HostDefaultCardStyled from '../lib/styledcomponents/HostDefaultCardStyled';
 import 'swiper/css';
 import 'swiper/css/pagination';
 import ScrollBoxStyled from '../lib/styledcomponents/layout/ScrollBoxStyled';
@@ -34,9 +35,9 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
   const isLargeScreen = mediaQueryLarge.matches;
 
   // TODO: 
-  //      -enable scroll 
+  //      -update scroll behavior if necessary (after getting feedback from design)
   const largeScreen =
-    <BodyContentAreaTripleColumnStyled container style={{ paddingTop: '16px' }}>
+    <BodyContentAreaTripleColumnStyled container>
       <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
         <Card />
         <Card />
@@ -46,18 +47,19 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
         <Card />
       </Grid>
       <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
-        <Card />
-        <Card />
+        <ScrollBoxStyled>
+          <Card />
+          <Card />
+        </ScrollBoxStyled>
       </Grid>
     </BodyContentAreaTripleColumnStyled>
 
   // TODO: 
-  //      -add edge of next slide to the right
   //      -resolve new keyword issue, preventing addition of bullets, pagination
-  //      -enable scroll
+  //      -update scroll behavior if necessary (after getting feedback from design)
   const mediumScreen =
     <BodyContentAreaDoubleColumnStyled>
-      <Swiper slidesPerView={2}>
+      <Swiper slidesPerView={2.1}>
         <SwiperSlide>
           <Grid item xs={12} sm={6} direction="column">
             <ScrollBoxStyled>
@@ -86,10 +88,9 @@ export default function PlaceholderContentArea({ }: PlaceholderContentAreaProps)
     </BodyContentAreaDoubleColumnStyled>
 
   // TODO: 
-  //      -add edge of next slide to the right
   //      -resolve new keyword issue, preventing addition of bullets, pagination
   const smallScreen = <BodyContentAreaSingleColumnStyled>
-    <Swiper spaceBetween={10}>
+    <Swiper slidesPerView={1.1}>
       <SwiperSlide>
         <Grid item xs={12} sm={6} sx={{ width: '100%', height: '100%' }}>
           <ScrollBoxStyled>

--- a/host_v2/src/containers/GameSessionContainer.tsx
+++ b/host_v2/src/containers/GameSessionContainer.tsx
@@ -33,6 +33,7 @@ export default function GameSessionContainer({
         <BodyBoxUpperStyled />
         <BodyBoxLowerStyled />
         <PlaceholderContentArea />
+        
       </BodyStackContainerStyled>
     </StackContainerStyled>
   );

--- a/host_v2/src/lib/styledcomponents/PaginationContainerStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/PaginationContainerStyled.tsx
@@ -1,0 +1,17 @@
+import { styled } from '@mui/material/styles';
+import { Container } from '@mui/material';
+
+// container for the Swiperjs pagination bullets
+export default styled(Container)(({ theme }) => ({
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  padding: '8px',
+  '--swiper-pagination-color': `${theme.palette.primary.highlightGradient}`,
+  '--swiper-pagination-bullet-inactive-color': `${theme.palette.primary.darkGrey}`,
+  '--swiper-pagination-bullet-inactive-opacity': '1',
+  '--swiper-pagination-bullet-size': '10px',
+  '--swiper-pagination-bullet-horizontal-gap': '4px',
+  /* size and shape of bullets handled in <swiper pagination: { renderBullets } /> */
+}));

--- a/host_v2/src/lib/styledcomponents/layout/BodyContentAreasStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/BodyContentAreasStyled.tsx
@@ -37,9 +37,7 @@ export const BodyContentAreaSingleColumnStyled = styled(
   BodyContentAreaDoubleColumnStyled,
 )(({ theme }) => ({
   justifyContent: 'center',
-  maxWidth: `calc(400px + ${theme.sizing.mediumPadding * 2}px)`,
-  paddingLeft: `${theme.sizing.mediumPadding}px`,
-  paddingRight: `${theme.sizing.mediumPadding}px`,
+  maxWidth: `calc(400px + ${theme.sizing.mediumPadding * 2}px)`
 }));
 
 // content area of body that floats above background layers above - Phase Results Page

--- a/host_v2/src/lib/styledcomponents/layout/BodyContentAreasStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/BodyContentAreasStyled.tsx
@@ -1,6 +1,19 @@
 import { styled } from '@mui/material/styles';
 import { Grid } from '@mui/material';
 
+export const BodyContentAreaTripleColumnStyled = styled(Grid)({
+  position: 'absolute',
+  top: '0',
+  display: 'flex',
+  justifyContent: 'flex-start',
+  alignItems: 'flex-start',
+  maxWidth: '1236px',
+  width: '100%',
+  height: '100%',
+  overflow: 'hidden',
+  zIndex: 2,
+});
+
 /* lower-level container for background content in body. floats above body boxes
 (body stack container -> body box upper, body box lower, body content area) */
 export const BodyContentAreaDoubleColumnStyled = styled(Grid)({
@@ -8,7 +21,7 @@ export const BodyContentAreaDoubleColumnStyled = styled(Grid)({
   top: '0',
   display: 'flex',
   justifyContent: 'flex-start',
-  alignItems: 'center',
+  alignItems: 'flex-start',
   maxWidth: '824px',
   width: '100%',
   height: '100%',

--- a/host_v2/src/lib/styledcomponents/layout/BodyContentAreasStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/BodyContentAreasStyled.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@mui/material/styles';
 import { Grid } from '@mui/material';
 
-export const BodyContentAreaTripleColumnStyled = styled(Grid)({
+export const BodyContentAreaTripleColumnStyled = styled(Grid)(({ theme }) => ({
   position: 'absolute',
   top: '0',
   display: 'flex',
@@ -11,8 +11,11 @@ export const BodyContentAreaTripleColumnStyled = styled(Grid)({
   width: '100%',
   height: '100%',
   overflow: 'hidden',
+  paddingTop: `${theme.sizing.smallPadding}px`,
+  paddingLeft: `${theme.sizing.mediumPadding}px`,
+  paddingRight: `${theme.sizing.mediumPadding}px`,
   zIndex: 2,
-});
+}));
 
 /* lower-level container for background content in body. floats above body boxes
 (body stack container -> body box upper, body box lower, body content area) */

--- a/host_v2/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
@@ -6,7 +6,10 @@ import { Box } from '@mui/material';
  * creates a box that constrains touch scrolling to vertical only so that it doesn't conflict with swiper horizontal scrolling
  */
 export default styled(Box)(({ theme }) => ({
-  height: `calc(100% - ${theme.sizing.footerHeight}px - ${theme.sizing.extraSmallPadding}px - 30px)`, // footer height & 8px grid spacing
+  // TODO: right now the dynamic height calculation doesn't work: 
+  // `calc(100% - ${theme.sizing.headerHeight}px - ${theme.sizing.footerHeight}px)`
+  // so it is hardcoded
+  height: '457px',
   paddingBottom: `${theme.sizing.mediumPadding}px`, // added so box shadow shows around edge of card
   paddingLeft: `${theme.sizing.smallPadding}px`,
   paddingRight: `${theme.sizing.smallPadding}px`,

--- a/host_v2/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
@@ -1,0 +1,21 @@
+import { styled } from '@mui/material/styles';
+import { Box } from '@mui/material';
+
+/**
+ * lower-level container for background section in body
+ * creates a box that constrains touch scrolling to vertical only so that it doesn't conflict with swiper horizontal scrolling
+ */
+export default styled(Box)(({ theme }) => ({
+  height: `calc(100% - ${theme.sizing.footerHeight}px - ${theme.sizing.extraSmallPadding}px - 30px)`, // footer height & 8px grid spacing
+  paddingBottom: `${theme.sizing.mediumPadding}px`, // added so box shadow shows around edge of card
+  paddingLeft: `${theme.sizing.smallPadding}px`,
+  paddingRight: `${theme.sizing.smallPadding}px`,
+  overflow: 'auto',
+  touchAction: 'pan-y', // this constrains the touch controls to only vertical scrolling so it doesn't mess with the swiper X direction swipe
+  '&::-webkit-scrollbar': {
+    // Chrome and Safari
+    display: 'none',
+  },
+  scrollbarWidth: 'none', // Firefox
+  '-ms-overflow-style': 'none', // IE and Edge
+}));

--- a/host_v2/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
@@ -6,13 +6,10 @@ import { Box } from '@mui/material';
  * creates a box that constrains touch scrolling to vertical only so that it doesn't conflict with swiper horizontal scrolling
  */
 export default styled(Box)(({ theme }) => ({
-  // TODO: right now the dynamic height calculation doesn't work: 
-  // `calc(100% - ${theme.sizing.headerHeight}px - ${theme.sizing.footerHeight}px)`
-  // so it is hardcoded
-  height: '457px',
+  height: `calc(100vh - ${theme.sizing.headerHeight}px - ${theme.sizing.footerHeight}px)`,
   paddingBottom: `${theme.sizing.mediumPadding}px`, // added so box shadow shows around edge of card
-  paddingLeft: `${theme.sizing.smallPadding}px`,
-  paddingRight: `${theme.sizing.smallPadding}px`,
+  marginLeft: `${theme.sizing.extraSmallPadding}px`,
+  marginRight: `${theme.sizing.extraSmallPadding}px`,
   overflow: 'auto',
   touchAction: 'pan-y', // this constrains the touch controls to only vertical scrolling so it doesn't mess with the swiper X direction swipe
   '&::-webkit-scrollbar': {

--- a/host_v2/tsconfig.json
+++ b/host_v2/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -16,9 +20,16 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "paths": {
-      "@mui/styled-engine": ["./node_modules/@mui/styled-engine-sc"]
+      "@mui/styled-engine": [
+        "./node_modules/@mui/styled-engine-sc"
+      ]
     }
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "tests"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "tests"
+  ]
 }

--- a/host_v2/yarn.lock
+++ b/host_v2/yarn.lock
@@ -2405,6 +2405,85 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@react-spring/animated@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.7.3.tgz#4211b1a6d48da0ff474a125e93c0f460ff816e0f"
+  integrity sha512-5CWeNJt9pNgyvuSzQH+uy2pvTg8Y4/OisoscZIR8/ZNLIOI+CatFBhGZpDGTF/OzdNFsAoGk3wiUYTwoJ0YIvw==
+  dependencies:
+    "@react-spring/shared" "~9.7.3"
+    "@react-spring/types" "~9.7.3"
+
+"@react-spring/core@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.7.3.tgz#60056bcb397f2c4f371c6c9a5f882db77ae90095"
+  integrity sha512-IqFdPVf3ZOC1Cx7+M0cXf4odNLxDC+n7IN3MDcVCTIOSBfqEcBebSv+vlY5AhM0zw05PDbjKrNmBpzv/AqpjnQ==
+  dependencies:
+    "@react-spring/animated" "~9.7.3"
+    "@react-spring/shared" "~9.7.3"
+    "@react-spring/types" "~9.7.3"
+
+"@react-spring/konva@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/konva/-/konva-9.7.3.tgz#16bd29dd4860a99e960a72987c8bcfc828b22119"
+  integrity sha512-R9sY6SiPGYqz1383P5qppg5z57YfChVknOC1UxxaGxpw+WiZa8fZ4zmZobslrw+os3/+HAXZv8O+EvU/nQpf7g==
+  dependencies:
+    "@react-spring/animated" "~9.7.3"
+    "@react-spring/core" "~9.7.3"
+    "@react-spring/shared" "~9.7.3"
+    "@react-spring/types" "~9.7.3"
+
+"@react-spring/native@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/native/-/native-9.7.3.tgz#ee38d7c23482cfb4916c9b3c021de2995a4f553a"
+  integrity sha512-4mpxX3FuEBCUT6ae2fjhxcJW6bhr2FBwFf274eXB7n+U30Gdg8Wo2qYwcUnmiAA0S3dvP8vLTazx3+CYWFShnA==
+  dependencies:
+    "@react-spring/animated" "~9.7.3"
+    "@react-spring/core" "~9.7.3"
+    "@react-spring/shared" "~9.7.3"
+    "@react-spring/types" "~9.7.3"
+
+"@react-spring/shared@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.7.3.tgz#4cf29797847c689912aec4e62e34c99a4d5d9e53"
+  integrity sha512-NEopD+9S5xYyQ0pGtioacLhL2luflh6HACSSDUZOwLHoxA5eku1UPuqcJqjwSD6luKjjLfiLOspxo43FUHKKSA==
+  dependencies:
+    "@react-spring/types" "~9.7.3"
+
+"@react-spring/three@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/three/-/three-9.7.3.tgz#4358a0c4640efe2972c4f7d0f7cd4efe927471c1"
+  integrity sha512-Q1p512CqUlmMK8UMBF/Rj79qndhOWq4XUTayxMP9S892jiXzWQuj+xC3Xvm59DP/D4JXusXpxxqfgoH+hmOktA==
+  dependencies:
+    "@react-spring/animated" "~9.7.3"
+    "@react-spring/core" "~9.7.3"
+    "@react-spring/shared" "~9.7.3"
+    "@react-spring/types" "~9.7.3"
+
+"@react-spring/types@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/types/-/types-9.7.3.tgz#ea78fd447cbc2612c1f5d55852e3c331e8172a0b"
+  integrity sha512-Kpx/fQ/ZFX31OtlqVEFfgaD1ACzul4NksrvIgYfIFq9JpDHFwQkMVZ10tbo0FU/grje4rcL4EIrjekl3kYwgWw==
+
+"@react-spring/web@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.7.3.tgz#d9f4e17fec259f1d65495a19502ada4f5b57fa3d"
+  integrity sha512-BXt6BpS9aJL/QdVqEIX9YoUy8CE6TJrU0mNCqSoxdXlIeNcEBWOfIyE6B14ENNsyQKS3wOWkiJfco0tCr/9tUg==
+  dependencies:
+    "@react-spring/animated" "~9.7.3"
+    "@react-spring/core" "~9.7.3"
+    "@react-spring/shared" "~9.7.3"
+    "@react-spring/types" "~9.7.3"
+
+"@react-spring/zdog@~9.7.3":
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/zdog/-/zdog-9.7.3.tgz#8ccc7316f6d3460ed244d9e3f60de9b4c4a848ac"
+  integrity sha512-L+yK/1PvNi9n8cldiJ309k4LdxcPkeWE0W18l1zrP1IBIyd5NB5EPA8DMsGr9gtNnnIujtEzZk+4JIOjT8u/tw==
+  dependencies:
+    "@react-spring/animated" "~9.7.3"
+    "@react-spring/core" "~9.7.3"
+    "@react-spring/shared" "~9.7.3"
+    "@react-spring/types" "~9.7.3"
+
 "@remix-run/router@1.14.0":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.14.0.tgz#9bc39a5a3a71b81bdb310eba6def5bc3966695b7"
@@ -11063,6 +11142,18 @@ react-scripts@5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
+react-spring@^9.7.3:
+  version "9.7.3"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.7.3.tgz#3211dea4c4d7c5b541260af5100261b87becb5d5"
+  integrity sha512-oTxDpFV5gzq7jQX6+bU0SVq+vX8VnuuT5c8Zwn6CpDErOPvCmV+DRkPiEBtaL3Ozgzwiy5yFx83N0h303j/r3A==
+  dependencies:
+    "@react-spring/core" "~9.7.3"
+    "@react-spring/konva" "~9.7.3"
+    "@react-spring/native" "~9.7.3"
+    "@react-spring/three" "~9.7.3"
+    "@react-spring/web" "~9.7.3"
+    "@react-spring/zdog" "~9.7.3"
+
 react-style-singleton@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
@@ -12186,6 +12277,11 @@ swc-loader@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/swc-loader/-/swc-loader-0.2.3.tgz#6792f1c2e4c9ae9bf9b933b3e010210e270c186d"
   integrity sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==
+
+swiper@^11.0.5:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-11.0.5.tgz#6ed1ad06e6906ba42fd4b93d4988f0626a49046e"
+  integrity sha512-rhCwupqSyRnWrtNzWzemnBLMoyYuoDgGgspAm/8iBD3jCvAWycPLH4Z3TB0O5520DHLzMx94yUMH/B9Efpa48w==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
**Issue:**
Addresses items for git issue #914: create responsive layout for host_v2 cards

**Resolution:**

- Created three separate components to be rendered conditional on screen size using a media query (smallDevice, mediumDevice, and largeDevice)
- Adapted Swiper, ScrollBoxStyled from play to enable swiping across carousel columns for small and medium devices
- This can be found in `host_v2>src>components>PlaceHolderContentArea.tsx`

Relevant code:
- `host_v2>src>components>PlaceHolderContentArea.tsx` - Bulk of the code pertaining to this PR is in this file. It contains the media queries, the Swiper carousel components for each respective screen, and lastly a conditional rendering of the appropriate UI component based on the media query
- `host_v2>src>lib>styledComponents>layout>ScrollBoxStyled.tsx` - added this file (which is essentially the same in play outside of the height calculation since the themes vary between host_v2 and play) to allow for vertical scroll on Swiper slides without moving the page horizontally
- `host_v2>src>lib>styledComponents>layout>BodyContentAreasStyled.tsx` - added new `const BodyContentAreaTripleColumnStyled` on `lines 4-18` with a larger max width to account for styling on large devices that calls for 3 columns without a swiper
- host_v2>src>lib>styledComponents>PaginationContainerStyled.tsx` - Added by Drew to enable pagination for Swiper

**Preview:**

Here is how the responsive layout UI looks on different devices: 

https://github.com/rightoneducation/righton-app/assets/106450593/44e980d4-f17f-45a6-b1d3-60c21e50075b



@amarax , @drewjhart  
