### PR TITLE
[Play] - Disable text field on short answer or hint submit

### DIFF
--- a/play/src/components/HintCard.tsx
+++ b/play/src/components/HintCard.tsx
@@ -95,6 +95,7 @@ export default function HintCard({
             multiline
             minRows={2}
             maxRows={2}
+            disabled={isHintSubmitted}
             placeholder={t('gameinprogress.chooseanswer.hintcardplaceholder') ?? ''}
             onChange={handleEditorContentsChange}
             value={editorContents}

--- a/play/src/components/OpenAnswerCard.tsx
+++ b/play/src/components/OpenAnswerCard.tsx
@@ -169,6 +169,7 @@ export default function OpenAnswerCard({
             placeholder={t('gameinprogress.chooseanswer.openanswercardplaceholder') ?? ''}
             onChange={handleEditorContentsChange}
             value={editorContents}
+            disabled={isSubmitted}
             InputProps={{
               disableUnderline: true,
               style: {


### PR DESCRIPTION
Textfields were not being disabled when a student submitted their answer, causing confusion. This update disables the fields on submit via 

```
disabled={isSubmitted}
```

or 

```
disabled={isHintSubmitted}
```