### PR TITLE
[Host] - Display player hints on when clicking on hints graph

### DIFF
--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -104,11 +104,7 @@ export default function GameInProgressContentSwitch({
         );
       case ('hint'):
         return (
-          <div
-            id="hint-scrollbox"
-            ref={hintCardRef}
-            className={classes.contentContainer}
-          >
+          <div className={classes.contentContainer}>
             <PlayerThinking
               hints={hints}
               gptHints={gptHints}
@@ -126,11 +122,16 @@ export default function GameInProgressContentSwitch({
               isHintLoading={isHintLoading}
               handleProcessHints={handleProcessHints}
             />
-            <PlayerThinkingSelectedAnswer
-              gptHints={gptHints}
-              graphClickInfo={graphClickInfo}
-              numPlayers={numPlayers}
-            />
+            <div
+              id="hint-scrollbox"
+              ref={hintCardRef}
+            >
+              <PlayerThinkingSelectedAnswer
+                gptHints={gptHints}
+                graphClickInfo={graphClickInfo}
+                numPlayers={numPlayers}
+              />
+            </div>
           </div>
         );
     }

--- a/host/src/components/PlayerThinking/PlayerThinkingSelectedAnswer.jsx
+++ b/host/src/components/PlayerThinking/PlayerThinkingSelectedAnswer.jsx
@@ -16,14 +16,6 @@ export default function PlayerThinkingSelectedAnswer(props) {
   return (
     <div>
       <div style={{ width: '100%' }}>
-        <Typography className={classes.titleText}>
-          Showing players who submitted this hint:
-        </Typography>
-        <div className={classes.rectStyle}>
-          <div className={classes.textContainer}>
-            {gptHints[graphClickInfo.selectedIndex].themeText}
-          </div>
-        </div>
         <PlayersSelectedAnswer
           gptHints={gptHints}
           graphClickInfo={graphClickInfo}

--- a/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
+++ b/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
@@ -15,25 +15,15 @@ export default function PlayersSelectedAnswer(props) {
     <div>
       <div className={classes.textContainer}>
         <Typography className={classes.titleText}>
-          Players who submitted this hint:
+          {`Players who submitted hints that were categorized under "${gptHints[graphClickInfo.selectedIndex].themeText}":`}
         </Typography>
-        <div className={classes.numberContainer}>
-          <Typography className={classes.countText}>
-            {/* count from stateposition === 6 saved and displayed here for stateposition === 6 */}
-            {hintCount}
-          </Typography>
-          <Typography className={classes.percentageText}>
-            {/* percentage from  stateposition === 6saved and displayed here for stateposition === 6 */}
-            ({Math.round(percentage)}%)
-          </Typography>
-        </div>
       </div>
       {teamsWithSelectedAnswer.map((team, index) => (
         <div key={index} className={classes.rectStyle}>
-          <Typography className={classes.nameText} style={{fontWeight: 700}}>
+          <Typography className={classes.nameText} >
             {team.name}
           </Typography>
-          <Typography className={classes.nameText}>
+          <Typography className={classes.nameText} style={{color: 'rgba(255,255,255,0.6)'}}>
             {team.rawHint}
           </Typography>
         </div>

--- a/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
+++ b/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
@@ -11,7 +11,7 @@ export default function PlayersSelectedAnswer(props) {
   const hintCount = gptHints[graphClickInfo.selectedIndex].teamCount;
   const percentage = (hintCount / numPlayers) * 100;
   const teamsWithSelectedAnswer = gptHints[graphClickInfo.selectedIndex].teams.map((team) => team);
-
+  console.log(gptHints);
   return (
     <div>
       <div className={classes.textContainer}>

--- a/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
+++ b/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
@@ -11,7 +11,6 @@ export default function PlayersSelectedAnswer(props) {
   const hintCount = gptHints[graphClickInfo.selectedIndex].teamCount;
   const percentage = (hintCount / numPlayers) * 100;
   const teamsWithSelectedAnswer = gptHints[graphClickInfo.selectedIndex].teams.map((team) => team);
-  console.log(gptHints);
   return (
     <div>
       <div className={classes.textContainer}>
@@ -29,10 +28,13 @@ export default function PlayersSelectedAnswer(props) {
           </Typography>
         </div>
       </div>
-      {teamsWithSelectedAnswer.map((teamChoice, index) => (
+      {teamsWithSelectedAnswer.map((team, index) => (
         <div key={index} className={classes.rectStyle}>
+          <Typography className={classes.nameText} style={{fontWeight: 700}}>
+            {team.team}
+          </Typography>
           <Typography className={classes.nameText}>
-            {teamChoice}
+          {team.rawHint}
           </Typography>
         </div>
       ))}
@@ -114,7 +116,6 @@ const useStyles = makeStyles({
   },
   rectStyle: {
     width: '100%',
-    height: '40px',
     color: 'white',
     backgroundColor: '#063772',
     fontSize: '16px',

--- a/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
+++ b/host/src/components/PlayerThinking/PlayersSelectedAnswer.jsx
@@ -31,10 +31,10 @@ export default function PlayersSelectedAnswer(props) {
       {teamsWithSelectedAnswer.map((team, index) => (
         <div key={index} className={classes.rectStyle}>
           <Typography className={classes.nameText} style={{fontWeight: 700}}>
-            {team.team}
+            {team.name}
           </Typography>
           <Typography className={classes.nameText}>
-          {team.rawHint}
+            {team.rawHint}
           </Typography>
         </div>
       ))}

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -498,7 +498,7 @@ const GameSessionContainer = () => {
         const combinedHints = parsedHints.map(parsedHint => {
           const updatedTeams = parsedHint.teams.map(team => {
             if (hintsLookup.has(team)) {
-              return { team: team, rawHint: hintsLookup.get(team) };
+              return { name: team, rawHint: hintsLookup.get(team) };
             } else {
               return team;
             }

--- a/host/src/containers/GameSessionContainer.tsx
+++ b/host/src/containers/GameSessionContainer.tsx
@@ -489,26 +489,23 @@ const GameSessionContainer = () => {
       const correctChoiceIndex =
         currentQuestion.choices.findIndex(({ isAnswer }) => isAnswer);
       const correctAnswer = currentQuestion.choices[correctChoiceIndex].text;
-      console.log('what up');
-      console.log(hints);
       apiClient.groupHints(hints, questionText, correctAnswer).then((response) => {
         const parsedHints = JSON.parse(response.gptHints.content);
-        console.log(parsedHints);
         // adds rawHint text to parsedHints received from GPT
         // (we want to minimize the amount of data we send and receive to/from OpenAI
         // so we do this ourselves instead of asking GPT to return data we already have)
-        const combinedHints = 
-          hints.forEach((hint) => {
-            parsedHints.forEach((parsedHint) => {
-              parsedHint.teams.forEach((team, index) => {
-                  if (hint.teamName === team)
-                  {
-                    parsedHint.teams[index] = {team: team, rawHint: hint.rawHint}
-                  }
-              });
-            });
+        const hintsLookup = new Map(hints.map(hint => [hint.teamName, hint.rawHint]));
+        const combinedHints = parsedHints.map(parsedHint => {
+          const updatedTeams = parsedHint.teams.map(team => {
+            if (hintsLookup.has(team)) {
+              return { team: team, rawHint: hintsLookup.get(team) };
+            } else {
+              return team;
+            }
           });
-          console.log(combinedHints);
+
+          return { ...parsedHint, teams: updatedTeams };
+        });
         setGptHints(combinedHints);
         setisHintLoading(false);
         if (combinedHints) {

--- a/networking/src/Models/IQuestion.ts
+++ b/networking/src/Models/IQuestion.ts
@@ -49,6 +49,9 @@ export interface IResponseTeam {
 
 export interface IHints {
     themeText: string;
-    teams: string[];
+    teams: {
+        name: string;
+        rawHint: string;
+    }[];
     teamCount: number;
 }


### PR DESCRIPTION
Fixes these two issues:

- [[Q1 Dev PM] - [LHF] - Hint all team names start with "Team" #940](https://github.com/rightoneducation/righton-app/issues/940)
- [[Q1 Dev PM] - [LHF] - Show Student Hints on Host #936](https://github.com/rightoneducation/righton-app/issues/936)

Updated behaviour can be seen in the video below:

https://github.com/rightoneducation/righton-app/assets/79417944/0c698e6a-6608-454e-8fd7-e9ec2302812f

