### PR TITLE
[POC] - StartGame -> GameInProgress animation

### DIFF
--- a/host_v2/package.json
+++ b/host_v2/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^18.2.45",
     "@types/react-dom": "^18.2.18",
     "@types/uuid": "^9.0.7",
+    "framer-motion": "^11.0.3",
     "i18next": "^23.7.11",
     "i18next-browser-languagedetector": "^7.2.0",
     "i18next-http-backend": "^2.4.2",

--- a/host_v2/src/App.tsx
+++ b/host_v2/src/App.tsx
@@ -16,26 +16,14 @@ function RedirectToPlayIfMissing() {
   window.location.href = 'http://dev-central.rightoneducation.com/';
   return null;
 }
-const mockGameSession = GameSessionParser.gameSessionFromAWSGameSession({
-  ...MockGameSession,
-  currentState: MockGameSession.currentState as GameSessionState,
-});
-const handleStartGame = ()=>{
-  console.log("test")
-}
+
 const apiClient = new ApiClient(Environment.Developing);
 const router = createBrowserRouter(
   createRoutesFromElements(
     <>
       <Route
         path="/"
-        
         element={<GameSessionContainer apiClient={apiClient} />}
-      />
-      <Route
-        path="/StartGame"
-        element={<StartGame teams={mockGameSession.teams ?? []} currentQuestionIndex={mockGameSession.currentQuestionIndex ?? 0} questions={mockGameSession.questions} title={mockGameSession.title ?? ''} gameSessionId={mockGameSession.id} 
-        gameCode={mockGameSession.gameCode ?? 1100} currentState={mockGameSession.currentState} handleStartGame={handleStartGame} />}
       />
       <Route element={<RedirectToPlayIfMissing />} />
     </>,

--- a/host_v2/src/components/FooterStartGame.tsx
+++ b/host_v2/src/components/FooterStartGame.tsx
@@ -2,16 +2,14 @@ import React from 'react';
 import {Button, BottomNavigation, Box, Typography} from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-
 interface FootStartGameProps{
-    handleStateGame: () => void
-    gameSessionId: string
-    teamsLength: number;
-    currentQuestionIndex: number
+  handleStateGame: () => void
+  gameSessionId: string
+  teamsLength: number;
+  currentQuestionIndex: number
 }
 
 const ButtonStyled = styled(Button)(({ theme }) => ({
-
   border: '4px solid #159EFA',
   background: 'linear-gradient(#159EFA 100%,#19BCFB 100%)',
   borderRadius: '34px',
@@ -37,11 +35,9 @@ const ButtonStyled = styled(Button)(({ theme }) => ({
     opacity: '25%',
     cursor: 'not-allowed',
   },
-
 }))
 
 const BottomNavigationStyled = styled(Box)(({ theme }) => ({
-
   position: 'sticky',
   display: 'flex',
   flexDirection: 'column',
@@ -49,16 +45,18 @@ const BottomNavigationStyled = styled(Box)(({ theme }) => ({
   alignItems: 'center',
   bottom: '0',
   width: '100%',
-  height: '80px',
-  paddingTop: '80px',
-  paddingBottom: '50px',
+  height: '40px',
+  paddingTop: '20px',
+  paddingBottom: '20px',
   background: 'linear-gradient(196.21deg, #03295A 0%, #02215F 73.62%)',
-
 }))
 
-function FooterStartGame ({ handleStateGame, teamsLength, currentQuestionIndex, gameSessionId}: FootStartGameProps){
-    // const classes = useStyles();
-    
+function FooterStartGame ({ 
+  handleStateGame, 
+  teamsLength, 
+  currentQuestionIndex,
+  gameSessionId
+}: FootStartGameProps){
     return (
         <BottomNavigationStyled>
             <Box>
@@ -72,59 +70,4 @@ function FooterStartGame ({ handleStateGame, teamsLength, currentQuestionIndex, 
         </BottomNavigationStyled>
     );
 }
-
-// const useStyles = makeStyles((theme : Theme) => ({
-//     footer: {
-//       position: 'sticky',
-//       display: 'flex',
-//       flexDirection: 'column',
-//       justifyContent: 'center',
-//       alignItems: 'center',
-//       bottom: '0',
-//       width: '100%',
-//       height: '80px',
-//       paddingTop: '80px',
-//       paddingBottom: '50px',
-//       background: 'linear-gradient(196.21deg, #03295A 0%, #02215F 73.62%)',
-//     },
-//     clickToPair: {
-//       position: 'absolute',
-//       fontSize: '12px',
-//       marginTop: '52px',
-//       marginBottom: '75px',
-//       textAlign: 'center',
-//       fontWeight: '700',
-//       color: 'rgba(0, 117, 255, 1)',
-//       textDecoration: 'underline',
-//     },
-  
-//     startGameButton: {
-//       border: '4px solid #159EFA',
-//       background: 'linear-gradient(#159EFA 100%,#19BCFB 100%)',
-//       borderRadius: '34px',
-//       width: '300px',
-//       height: '48px',
-//       color: 'white',
-//       fontSize: '20px',
-//       bottom: '0',
-//       fontWeight: '700',
-//       lineHeight: '30px',
-//       textTransform: 'none',
-//       boxShadow: '0px 5px 22px 0px #47D9FF4D',
-//       '&:disabled': {
-//         background: 'transparent',
-//         border: '4px solid #159EFA',
-//         borderRadius: '34px',
-//         width: '300px',
-//         height: '48px',
-//         color: '#159EFA',
-//         fontSize: '20px',
-//         fontWeight: '700',
-//         lineHeight: '30px',
-//         opacity: '25%',
-//         cursor: 'not-allowed',
-//       },
-//     },
-//   }));
-  
-  export default FooterStartGame;
+export default FooterStartGame;

--- a/host_v2/src/components/FooterStartGame.tsx
+++ b/host_v2/src/components/FooterStartGame.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import {Button, BottomNavigation, Box, Typography} from '@mui/material';
 import { styled } from '@mui/material/styles';
+import { motion } from "framer-motion";
 
 interface FootStartGameProps{
   handleStateGame: () => void
   gameSessionId: string
   teamsLength: number;
-  currentQuestionIndex: number
+  currentQuestionIndex: number;
+  scope3: React.RefObject<HTMLDivElement>;
 }
 
 const ButtonStyled = styled(Button)(({ theme }) => ({
@@ -55,17 +57,20 @@ function FooterStartGame ({
   handleStateGame, 
   teamsLength, 
   currentQuestionIndex,
-  gameSessionId
+  gameSessionId,
+  scope3
 }: FootStartGameProps){
     return (
         <BottomNavigationStyled>
             <Box>
+              <motion.div ref={scope3} exit={{ y: 0, opacity: 0}}>
                 <ButtonStyled 
                     disabled={teamsLength <= 0}
                     onClick = {handleStateGame}
                 >
                     Start Game    
                 </ButtonStyled>
+              </motion.div>
             </Box>
         </BottomNavigationStyled>
     );

--- a/host_v2/src/components/HeaderContent.tsx
+++ b/host_v2/src/components/HeaderContent.tsx
@@ -3,7 +3,7 @@ import { GameSessionState } from '@righton/networking';
 import { useTheme } from '@mui/material/styles';
 import { Typography, Grid, Box, Container } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { motion, useAnimate } from "framer-motion";
+import { motion, easeOut } from "framer-motion";
 import HeaderStackContainerStyled from '../lib/styledcomponents/layout/HeaderStackContainerStyled';
 import QuestionIndicator from './QuestionIndicator';
 import playerIcon from '../img/playerIcon.svg';
@@ -89,7 +89,7 @@ export default function HeaderContent({
 
     return (
         <HeaderStackContainerStyled>
-            <motion.div ref={scope4} initial={{translateX: "50vw"}}>
+            
                 <Container maxWidth="md">
                     <Grid container justifyContent="space-between" alignItems="center">
                         <Grid item>
@@ -135,7 +135,7 @@ export default function HeaderContent({
                         </Grid>
                     </Grid>
                 </Container>
-            </motion.div>
+            
         </HeaderStackContainerStyled>
     );
 }

--- a/host_v2/src/components/HeaderContent.tsx
+++ b/host_v2/src/components/HeaderContent.tsx
@@ -3,6 +3,7 @@ import { GameSessionState } from '@righton/networking';
 import { useTheme } from '@mui/material/styles';
 import { Typography, Grid, Box, Container } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { motion, useAnimate } from "framer-motion";
 import HeaderStackContainerStyled from '../lib/styledcomponents/layout/HeaderStackContainerStyled';
 import QuestionIndicator from './QuestionIndicator';
 import playerIcon from '../img/playerIcon.svg';
@@ -22,6 +23,7 @@ interface HeaderContentProps {
     currentTimer: number;
     isPaused: boolean;
     isFinished: boolean;
+    scope4: React.RefObject<HTMLDivElement>;
     handleTimerIsFinished: () => void;
     localModel?: LocalModel;
 
@@ -39,6 +41,7 @@ export default function HeaderContent({
     isPaused,
     isFinished,
     localModel,
+    scope4,
     handleTimerIsFinished,
 }: HeaderContentProps) {
     const theme = useTheme(); // eslint-disable-line
@@ -86,51 +89,53 @@ export default function HeaderContent({
 
     return (
         <HeaderStackContainerStyled>
-            <Container maxWidth="md">
-                <Grid container justifyContent="space-between" alignItems="center">
-                    <Grid item>
-                        <QuestionIndicator
-                            totalQuestions={totalQuestions}
-                            currentQuestionIndex={currentQuestionIndex}
-                            statePosition={statePosition}
-                        />
-                    </Grid>
-                    <Grid item>
-                        <HostPlayerIconContainer>
-                            <Typography variant="subtitle2">
-                                {t('gamesession.player')}
-                            </Typography>
-                            <img src={playerIcon} alt="Player Icon" />
-                        </HostPlayerIconContainer>
-                    </Grid>
-                </Grid>
-                <Grid item style={{ marginTop: `${theme.sizing.smallPadding}px` }}>
-                    <Typography variant="h1">
-                        {stateCheck(currentState, isCorrect, isIncorrect)}
-                    </Typography>
-                </Grid>
-                <Grid item>
-                    <Grid container justifyContent="space-between" alignItems="center" >
-                        {(currentState === GameSessionState.CHOOSE_CORRECT_ANSWER ||
-                            currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER) &&
-                            localModel ? (
-                            <Timer
-                                totalTime={totalTime}
-                                currentTimer={currentTimer}
-                                isFinished={isFinished}
-                                isPaused={isPaused}
-                                handleTimerIsFinished={handleTimerIsFinished}
-                                localModel={localModel}
+            <motion.div ref={scope4} initial={{translateX: "50vw"}}>
+                <Container maxWidth="md">
+                    <Grid container justifyContent="space-between" alignItems="center">
+                        <Grid item>
+                            <QuestionIndicator
+                                totalQuestions={totalQuestions}
+                                currentQuestionIndex={currentQuestionIndex}
+                                statePosition={statePosition}
                             />
-                        ) : null}
-                        <TimerAddButton onClick={handleTimerAddButtonClick}>
-                            <Typography variant="subtitle2" style={{ fontSize: '14px' }}>
-                                {t('gamesession.addtime')}
-                            </Typography>
-                        </TimerAddButton>
+                        </Grid>
+                        <Grid item>
+                            <HostPlayerIconContainer>
+                                <Typography variant="subtitle2">
+                                    {t('gamesession.player')}
+                                </Typography>
+                                <img src={playerIcon} alt="Player Icon" />
+                            </HostPlayerIconContainer>
+                        </Grid>
                     </Grid>
-                </Grid>
-            </Container>
+                    <Grid item style={{ marginTop: `${theme.sizing.smallPadding}px` }}>
+                        <Typography variant="h1">
+                            {stateCheck(currentState, isCorrect, isIncorrect)}
+                        </Typography>
+                    </Grid>
+                    <Grid item>
+                        <Grid container justifyContent="space-between" alignItems="center" >
+                            {(currentState === GameSessionState.CHOOSE_CORRECT_ANSWER ||
+                                currentState === GameSessionState.CHOOSE_TRICKIEST_ANSWER) &&
+                                localModel ? (
+                                <Timer
+                                    totalTime={totalTime}
+                                    currentTimer={currentTimer}
+                                    isFinished={isFinished}
+                                    isPaused={isPaused}
+                                    handleTimerIsFinished={handleTimerIsFinished}
+                                    localModel={localModel}
+                                />
+                            ) : null}
+                            <TimerAddButton onClick={handleTimerAddButtonClick}>
+                                <Typography variant="subtitle2" style={{ fontSize: '14px' }}>
+                                    {t('gamesession.addtime')}
+                                </Typography>
+                            </TimerAddButton>
+                        </Grid>
+                    </Grid>
+                </Container>
+            </motion.div>
         </HeaderStackContainerStyled>
     );
 }

--- a/host_v2/src/components/PlaceholderContentArea.tsx
+++ b/host_v2/src/components/PlaceholderContentArea.tsx
@@ -10,8 +10,6 @@ import {
   BodyContentAreaSingleColumnStyled
 } from '../lib/styledcomponents/layout/BodyContentAreasStyled';
 import Card from './Card';
-import QuestionCard from './QuestionCard';
-import AnswerCard from './AnswerCard';
 import ConfidenceCard from './ConfidenceCard';
 import ScrollBoxStyled from '../lib/styledcomponents/layout/ScrollBoxStyled';
 import PaginationContainerStyled from '../lib/styledcomponents/PaginationContainerStyled';
@@ -65,27 +63,26 @@ export default function PlaceholderContentArea({
   const isLargeScreen = useMediaQuery(theme.breakpoints.up('lg'));
 
   const largeScreen =
-    <BodyContentAreaTripleColumnStyled container>
-      <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
-        <ScrollBoxStyled>
-          <ConfidenceCard confidenceData={confidenceData} graphClickIndex={confidenceGraphClickIndex} handleGraphClick={handleConfidenceGraphClick} />
-          <Card />
-        </ScrollBoxStyled>
-      </Grid>
-      <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
-        <ScrollBoxStyled>
-          <Card />
-          <Card />
-        </ScrollBoxStyled>
-      </Grid>
-      <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
-        <ScrollBoxStyled>
-          <Card />
-          <Card />
-        </ScrollBoxStyled>
-      </Grid>
-
-    </BodyContentAreaTripleColumnStyled>
+      <BodyContentAreaTripleColumnStyled container>
+        <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
+          <ScrollBoxStyled>
+            <ConfidenceCard confidenceData={confidenceData} graphClickIndex={confidenceGraphClickIndex} handleGraphClick={handleConfidenceGraphClick} />
+            <Card />
+          </ScrollBoxStyled>
+        </Grid>
+        <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
+          <ScrollBoxStyled>
+            <Card />
+            <Card />
+          </ScrollBoxStyled>
+        </Grid>
+        <Grid item xs={12} sm={4} sx={{ width: '100%', height: '100%' }}>
+          <ScrollBoxStyled>
+            <Card />
+            <Card />
+          </ScrollBoxStyled>
+        </Grid>
+      </BodyContentAreaTripleColumnStyled>
 
   const mediumScreen =
     <BodyContentAreaDoubleColumnStyled>
@@ -177,23 +174,23 @@ export default function PlaceholderContentArea({
     );
   } if (isMediumScreen) {
     return (
+        <>
+          {mediumScreen}
+          <PaginationContainerStyled
+            className="swiper-pagination-container"
+            style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
+          />
+        </>
+    );
+  }
+  return (
       <>
-        {mediumScreen}
+        {smallScreen}
         <PaginationContainerStyled
           className="swiper-pagination-container"
           style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
         />
       </>
-    );
-  }
-  return (
-    <>
-      {smallScreen}
-      <PaginationContainerStyled
-        className="swiper-pagination-container"
-        style={{ paddingTop: `${theme.sizing.largePadding}px`, zIndex: 2 }}
-      />
-    </>
   );
 
 }

--- a/host_v2/src/containers/GamePlayContainer.tsx
+++ b/host_v2/src/containers/GamePlayContainer.tsx
@@ -120,7 +120,18 @@ export default function GameSessionContainer({
     <StackContainerStyled
     >
       <HeaderBackgroundStyled />
-        <motion.div ref={scope5} initial={{translateX: "50vw"}} style={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column', zIndex: 2 }}>
+      <motion.div
+      initial={{ x: '100vw' }} // Start offscreen to the right
+      animate={{ x: '50vw', translateX: '-50%' }} // Move to the middle of the screen
+      transition={{
+        x: {
+          type: 'spring',
+          stiffness: 100,
+          damping: 10
+        },
+        ease: [0.6, -0.05, 0.01, 0.99]
+      }}
+     style={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column', zIndex: 2 }}>
           <HeaderContent
             currentState={currentState}
             totalQuestions={totalQuestions}

--- a/host_v2/src/containers/GamePlayContainer.tsx
+++ b/host_v2/src/containers/GamePlayContainer.tsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { GameSessionState, ApiClient } from '@righton/networking';
+import { Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import StackContainerStyled from '../lib/styledcomponents/layout/StackContainerStyled';
+import HeaderBackgroundStyled from '../lib/styledcomponents/layout/HeaderBackgroundStyled';
+import BodyStackContainerStyled from '../lib/styledcomponents/layout/BodyStackContainerStyled';
+import BodyBoxUpperStyled from '../lib/styledcomponents/layout/BodyBoxUpperStyled';
+import BodyBoxLowerStyled from '../lib/styledcomponents/layout/BodyBoxLowerStyled';
+import PlaceholderContentArea from '../components/PlaceholderContentArea';
+import HeaderContent from '../components/HeaderContent';
+import { LocalModel } from '../lib/HostModels';
+
+interface GameInProgressContainerProps {
+  apiClient: ApiClient;
+}
+// may have to reformat/restructure this later but here is a sample answer object
+interface AnswerOption {
+  instructions: string[] | null;
+  reason: string | null;
+  content: string;
+}
+
+interface QuestionData {
+  text: string;
+  imageUrl: string | undefined;
+}
+
+interface Player {
+  answer: string; // answer chosen by this player
+  isCorrect: boolean; // true iff the chosen answer is the correct answer 
+  name: string; // this player's name
+}
+
+interface ConfidenceOption {
+  confidence: string; // the confidence option (i.e. 'NOT_RATED', 'NOT_AT_ALL', 'KINDA', etc.)
+  correct: number; // number of teams who selected this option and answered correctly 
+  incorrect: number; // number of players who selected tgis option and answered incorrectly 
+  players: Player[]; // an array of the players that selected this option
+}
+
+export default function GameSessionContainer({
+  apiClient,
+}: GameInProgressContainerProps) {
+  console.log(apiClient); // eslint-disable-line
+  // TODO: delete hard coded values later
+  const sampleQuestion: QuestionData = {
+    text: "A pair of shoes were 10% off last week. This week, theres an additional sale, and you can get an extra 40% off the already discounted price from last week. What is the total percentage discount that youd get if you buy the shoes this week?",
+    imageUrl: "https://images.unsplash.com/photo-1609188944094-394637c26769?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80"
+  }
+
+  const sampleAnswerOptionOne: AnswerOption = {
+    instructions: ['step 1 step 1 step 1 step 1 step 1 step 1  step 1 step 1 step 1 step 1 step 1 step 1 ', 'step 2', 'step 3', 'step 4'],
+    reason: null,
+    content: "an answer choice"
+  }
+
+  const sampleAnswerOptionTwo: AnswerOption = {
+    instructions: null,
+    reason: "reasoning",
+    content: "another answer choice"
+  }
+
+  const samplePlayerOne: Player = { answer: 'C', isCorrect: false, name: 'Alex Williams' }
+  const samplePlayerTwo: Player = { answer: 'C', isCorrect: false, name: 'Alessandro DeLuca-Smith' }
+  const samplePlayerThree: Player = { answer: 'D', isCorrect: true, name: 'Jackson Cameron' }
+  const samplePlayerFour: Player = { answer: 'A', isCorrect: false, name: 'Jeremiah Tanaka' }
+  const sampleConfidenceData: ConfidenceOption[] = [{ confidence: 'NOT_RATED', correct: 0, incorrect: 0, players: [] },
+  { confidence: 'NOT_AT_ALL', correct: 0, incorrect: 0, players: [] },
+  { confidence: 'KINDA', correct: 0, incorrect: 2, players: [samplePlayerOne, samplePlayerTwo] },
+  { confidence: 'QUITE', correct: 0, incorrect: 0, players: [] },
+  { confidence: 'VERY', correct: 1, incorrect: 1, players: [samplePlayerThree, samplePlayerFour] },
+  { confidence: 'TOTALLY', correct: 0, incorrect: 0, players: [] }]
+
+  const [confidenceGraphClickIndex, setConfidenceGraphClickIndex] = useState<number | null>(
+    null);
+
+  const handleConfidenceGraphClick = (selectedIndex: number | null) => {
+    setConfidenceGraphClickIndex(selectedIndex);
+  };
+
+  const { t } = useTranslation();
+  const totalQuestions = 5;
+  const currentQuestionIndex = 3;
+  const statePosition = 3;
+  const isCorrect = false;
+  const isIncorrect = false;
+  const currentState = GameSessionState.CHOOSE_CORRECT_ANSWER;
+
+  const localModelMock:LocalModel = {currentTimer: 200, hasRejoined: false};
+  const phaseOneTime = 180;
+  const phaseTwoTime = 180;
+  const hasRejoined = false;
+  const currentTimer = 90;
+
+  const totalTime =
+    currentState === GameSessionState.CHOOSE_CORRECT_ANSWER
+      ? phaseOneTime
+      : phaseTwoTime;
+
+
+  const handleTimerIsFinished = () => {
+    console.log("timer is finished");
+  };
+
+  return (
+    <StackContainerStyled
+    >
+      <HeaderBackgroundStyled />
+      <HeaderContent
+        currentState={currentState}
+        totalQuestions={totalQuestions}
+        currentQuestionIndex={currentQuestionIndex}
+        statePosition={statePosition}
+        isCorrect={isCorrect}
+        isIncorrect={isIncorrect}
+        totalTime={totalTime}
+        currentTimer={hasRejoined ? currentTimer : totalTime}
+        isPaused={false}
+        isFinished={false}
+        handleTimerIsFinished={handleTimerIsFinished}
+        localModel={localModelMock}
+      />
+      <BodyStackContainerStyled>
+        <BodyBoxUpperStyled />
+        <BodyBoxLowerStyled />
+        <PlaceholderContentArea
+          questionData={sampleQuestion}
+          answerOptions={[sampleAnswerOptionOne, sampleAnswerOptionTwo]}
+          confidenceData={sampleConfidenceData} confidenceGraphClickIndex={confidenceGraphClickIndex} handleConfidenceGraphClick={handleConfidenceGraphClick} />
+      </BodyStackContainerStyled>
+    </StackContainerStyled>
+  );
+}

--- a/host_v2/src/containers/GamePlayContainer.tsx
+++ b/host_v2/src/containers/GamePlayContainer.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { motion, useAnimate } from "framer-motion";
 import { useTranslation } from 'react-i18next';
 import { GameSessionState, ApiClient } from '@righton/networking';
+import { Box } from '@mui/material';
+import styled from '@mui/material/styles/styled';
 import StackContainerStyled from '../lib/styledcomponents/layout/StackContainerStyled';
 import HeaderBackgroundStyled from '../lib/styledcomponents/layout/HeaderBackgroundStyled';
 import BodyStackContainerStyled from '../lib/styledcomponents/layout/BodyStackContainerStyled';
@@ -10,6 +12,16 @@ import BodyBoxLowerStyled from '../lib/styledcomponents/layout/BodyBoxLowerStyle
 import PlaceholderContentArea from '../components/PlaceholderContentArea';
 import HeaderContent from '../components/HeaderContent';
 import { LocalModel } from '../lib/HostModels';
+
+const BackgroundStyled = styled(Box)(({ theme }) => ({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '250px', 
+  background: 'linear-gradient(196.21deg, #0D68B1 0%, #02215F 73.62%)',
+  zIndex: -1,
+}))
 
 interface GameInProgressContainerProps {
   apiClient: ApiClient;
@@ -117,21 +129,25 @@ export default function GameSessionContainer({
   };
 
   return (
-    <StackContainerStyled
-    >
-      <HeaderBackgroundStyled />
-      <motion.div
-      initial={{ x: '100vw' }} // Start offscreen to the right
-      animate={{ x: '50vw', translateX: '-50%' }} // Move to the middle of the screen
-      transition={{
-        x: {
-          type: 'spring',
-          stiffness: 100,
-          damping: 10
-        },
-        ease: [0.6, -0.05, 0.01, 0.99]
-      }}
-     style={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column', zIndex: 2 }}>
+    <StackContainerStyled>
+     
+      {/* <motion.div  
+        initial={{ height: `500px`}}
+        animate={{ height: `250px`}}
+        style={{ width: '100%', position: 'absolute', top: 0 }}
+      > */}
+         <BackgroundStyled 
+         /> 
+      {/* </motion.div> */}
+        <motion.div
+          initial={{ x: '100vw' }}
+          animate={{ x: '50vw', translateX: '-50%' }}
+          transition={{
+            ease: [0.6, -0.05, 0.01, 0.99],
+            duration: 1.5
+          }}
+          style={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column', zIndex: 2 }}
+        >
           <HeaderContent
             currentState={currentState}
             totalQuestions={totalQuestions}

--- a/host_v2/src/containers/GamePlayContainer.tsx
+++ b/host_v2/src/containers/GamePlayContainer.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion, useAnimate } from "framer-motion";
 import { useTranslation } from 'react-i18next';
 import { GameSessionState, ApiClient } from '@righton/networking';
-import { Box } from '@mui/material';
+import { Paper } from '@mui/material';
 import styled from '@mui/material/styles/styled';
 import StackContainerStyled from '../lib/styledcomponents/layout/StackContainerStyled';
 import HeaderBackgroundStyled from '../lib/styledcomponents/layout/HeaderBackgroundStyled';
@@ -13,14 +13,15 @@ import PlaceholderContentArea from '../components/PlaceholderContentArea';
 import HeaderContent from '../components/HeaderContent';
 import { LocalModel } from '../lib/HostModels';
 
-const BackgroundStyled = styled(Box)(({ theme }) => ({
-  position: 'absolute',
+const BackgroundStyled = styled(Paper)(({ theme }) => ({
+  position: 'absolute', // Position it absolutely within StartGameContainer
   top: 0,
   left: 0,
-  width: '100%',
-  height: '250px', 
+  width: '100%', // Stretch across the entire container
+  height: '100vh', // Cover the full height of the container
+  display: 'flex',
   background: 'linear-gradient(196.21deg, #0D68B1 0%, #02215F 73.62%)',
-  zIndex: -1,
+  zIndex: -1, // Ensure it stays behind the content
 }))
 
 interface GameInProgressContainerProps {
@@ -131,14 +132,11 @@ export default function GameSessionContainer({
   return (
     <StackContainerStyled>
      
-      {/* <motion.div  
-        initial={{ height: `500px`}}
-        animate={{ height: `250px`}}
-        style={{ width: '100%', position: 'absolute', top: 0 }}
-      > */}
+  <motion.div initial={{y: `calc(-100vh + 250px)`}}>
          <BackgroundStyled 
          /> 
-      {/* </motion.div> */}
+           </motion.div>
+      
         <motion.div
           initial={{ x: '100vw' }}
           animate={{ x: '50vw', translateX: '-50%' }}

--- a/host_v2/src/containers/GamePlayContainer.tsx
+++ b/host_v2/src/containers/GamePlayContainer.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import { GameSessionState, ApiClient } from '@righton/networking';
-import { Typography } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { motion, useAnimate } from "framer-motion";
 import { useTranslation } from 'react-i18next';
+import { GameSessionState, ApiClient } from '@righton/networking';
 import StackContainerStyled from '../lib/styledcomponents/layout/StackContainerStyled';
 import HeaderBackgroundStyled from '../lib/styledcomponents/layout/HeaderBackgroundStyled';
 import BodyStackContainerStyled from '../lib/styledcomponents/layout/BodyStackContainerStyled';
@@ -40,9 +40,22 @@ interface ConfidenceOption {
 }
 
 export default function GameSessionContainer({
-  apiClient,
+  apiClient
 }: GameInProgressContainerProps) {
   console.log(apiClient); // eslint-disable-line
+  const [scope4, animate4] = useAnimate();
+  const [scope5, animate5] = useAnimate();
+  const AnimatedPlaceholderContentArea = motion(PlaceholderContentArea);
+  useEffect(() => {
+    // Ensure the element is present
+    if (scope4.current) {
+      animate4(scope4.current, { x: '-50vw', position: 'relative' }, { duration: 1 });
+    }
+    if (scope5.current) {
+      animate5(scope5.current, { x: '-50vw', position: 'fixed', zIndex: 2 }, { duration: 1 });
+    }
+  }, []); // eslint-disable-line
+
   // TODO: delete hard coded values later
   const sampleQuestion: QuestionData = {
     text: "A pair of shoes were 10% off last week. This week, theres an additional sale, and you can get an extra 40% off the already discounted price from last week. What is the total percentage discount that youd get if you buy the shoes this week?",
@@ -107,28 +120,34 @@ export default function GameSessionContainer({
     <StackContainerStyled
     >
       <HeaderBackgroundStyled />
-      <HeaderContent
-        currentState={currentState}
-        totalQuestions={totalQuestions}
-        currentQuestionIndex={currentQuestionIndex}
-        statePosition={statePosition}
-        isCorrect={isCorrect}
-        isIncorrect={isIncorrect}
-        totalTime={totalTime}
-        currentTimer={hasRejoined ? currentTimer : totalTime}
-        isPaused={false}
-        isFinished={false}
-        handleTimerIsFinished={handleTimerIsFinished}
-        localModel={localModelMock}
-      />
-      <BodyStackContainerStyled>
-        <BodyBoxUpperStyled />
-        <BodyBoxLowerStyled />
-        <PlaceholderContentArea
-          questionData={sampleQuestion}
-          answerOptions={[sampleAnswerOptionOne, sampleAnswerOptionTwo]}
-          confidenceData={sampleConfidenceData} confidenceGraphClickIndex={confidenceGraphClickIndex} handleConfidenceGraphClick={handleConfidenceGraphClick} />
-      </BodyStackContainerStyled>
+        <motion.div ref={scope5} initial={{translateX: "50vw"}} style={{width: '100%', height: '100%', display: 'flex', flexDirection: 'column', zIndex: 2 }}>
+          <HeaderContent
+            currentState={currentState}
+            totalQuestions={totalQuestions}
+            currentQuestionIndex={currentQuestionIndex}
+            statePosition={statePosition}
+            isCorrect={isCorrect}
+            isIncorrect={isIncorrect}
+            totalTime={totalTime}
+            currentTimer={hasRejoined ? currentTimer : totalTime}
+            isPaused={false}
+            isFinished={false}
+            scope4={scope4}
+            handleTimerIsFinished={handleTimerIsFinished}
+            localModel={localModelMock}
+          />
+          <BodyStackContainerStyled>
+            <BodyBoxUpperStyled />
+            <BodyBoxLowerStyled />
+            <PlaceholderContentArea
+              questionData={sampleQuestion}
+              answerOptions={[sampleAnswerOptionOne, sampleAnswerOptionTwo]}
+              confidenceData={sampleConfidenceData} 
+              confidenceGraphClickIndex={confidenceGraphClickIndex} 
+              handleConfidenceGraphClick={handleConfidenceGraphClick} 
+            />
+          </BodyStackContainerStyled>
+        </motion.div>
     </StackContainerStyled>
   );
 }

--- a/host_v2/src/containers/GameSessionContainer.tsx
+++ b/host_v2/src/containers/GameSessionContainer.tsx
@@ -28,8 +28,8 @@ export default function GameSessionContainer({
     const exitAnimation = () => {
       // Start all animations concurrently and return a promise that resolves when all animations are complete
       return Promise.all([
-        animate(scope.current, { y: 'calc(-100vh + 252px)', zIndex: -1, position: 'relative'}, { duration: 1 }),
-        animate2(scope2.current, { opacity: 0, position: 'relative'}, { duration: 1 }),
+        animate(scope.current, { y: 'calc(-100vh + 250px)', zIndex: -1, position: 'relative'}, { duration: 1 }),
+        animate2(scope2.current, { y: '-100vh', opacity: 0, position: 'relative'}, { duration: 1 }),
         animate3(scope3.current, { y: '-100vh', opacity: 0, zIndex: -1, position: 'relative'}, { duration: 1 }),
         animate4(scope4.current, { opacity: 0, position: 'relative'}, { duration: 0.1 }),
       ]);

--- a/host_v2/src/containers/GameSessionContainer.tsx
+++ b/host_v2/src/containers/GameSessionContainer.tsx
@@ -27,7 +27,7 @@ export default function GameSessionContainer({
     const exitAnimation = () => {
       // Start all animations concurrently and return a promise that resolves when all animations are complete
       return Promise.all([
-        animate(scope.current, { y: `calc(-100vh + 252px )`, zIndex: -1, position: 'relative'}, { duration: 1 }),
+        animate(scope.current, { scaleY: 0.345, zIndex: -1, position: 'relative'}, { duration: 1 }),
         animate2(scope2.current, { opacity: 0, position: 'relative'}, { duration: 1 }),
         animate3(scope3.current, { y: '-100vh', opacity: 0, zIndex: -1, position: 'relative'}, { duration: 1 })
       ]);

--- a/host_v2/src/containers/GameSessionContainer.tsx
+++ b/host_v2/src/containers/GameSessionContainer.tsx
@@ -21,15 +21,17 @@ export default function GameSessionContainer({
   const [scope, animate] = useAnimate();
   const [scope2, animate2] = useAnimate();
   const [scope3, animate3] = useAnimate();
+  const [scope4, animate4] = useAnimate();
 
   const theme = useTheme(); // eslint-disable-line
   const handleStartGame = () =>{
     const exitAnimation = () => {
       // Start all animations concurrently and return a promise that resolves when all animations are complete
       return Promise.all([
-        animate(scope.current, { scaleY: 0.345, zIndex: -1, position: 'relative'}, { duration: 1 }),
+        animate(scope.current, { y: 'calc(-100vh + 252px)', zIndex: -1, position: 'relative'}, { duration: 1 }),
         animate2(scope2.current, { opacity: 0, position: 'relative'}, { duration: 1 }),
-        animate3(scope3.current, { y: '-100vh', opacity: 0, zIndex: -1, position: 'relative'}, { duration: 1 })
+        animate3(scope3.current, { y: '-100vh', opacity: 0, zIndex: -1, position: 'relative'}, { duration: 1 }),
+        animate4(scope4.current, { opacity: 0, position: 'relative'}, { duration: 0.1 }),
       ]);
     };
     exitAnimation().then(() => {
@@ -46,7 +48,7 @@ export default function GameSessionContainer({
     default: 
       return (
         <StartGame teams={mockGameSession.teams ?? []} currentQuestionIndex={mockGameSession.currentQuestionIndex ?? 0} questions={mockGameSession.questions} title={mockGameSession.title ?? ''} gameSessionId={mockGameSession.id} 
-          gameCode={mockGameSession.gameCode ?? 1100} currentState={mockGameSession.currentState} scope={scope} scope2={scope2} scope3={scope3} handleStartGame={handleStartGame} />
+          gameCode={mockGameSession.gameCode ?? 1100} currentState={mockGameSession.currentState} scope={scope} scope2={scope2} scope3={scope3} scope4={scope4} handleStartGame={handleStartGame} />
       )
   }
 }

--- a/host_v2/src/containers/GameSessionContainer.tsx
+++ b/host_v2/src/containers/GameSessionContainer.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { useAnimate } from "framer-motion";
+import { useTheme } from '@mui/material/styles';
 import { GameSessionState, ApiClient, GameSessionParser } from '@righton/networking';
 import StartGame from '../pages/StartGame';
 import GamePlayContainer from './GamePlayContainer';
@@ -16,9 +18,15 @@ export default function GameSessionContainer({
     ...MockGameSession,
     currentState: MockGameSession.currentState as GameSessionState,
   });
-
-  const handleStartGame = ()=>{
-    setGameSessionState(GameSessionState.CHOOSE_CORRECT_ANSWER);
+  const [scope, animate] = useAnimate();
+  const [scope2, animate2] = useAnimate();
+  const [scope3, animate3] = useAnimate();
+  const theme = useTheme(); // eslint-disable-line
+  const handleStartGame = () =>{
+    animate(scope.current, { y: `calc(-100vh + ${theme.sizing.fullHeaderHeight}px)`, zIndex: -1, position: 'relative'}, { duration: 1 })
+    animate2(scope2.current, { opacity: 0, position: 'relative'}, { duration: 1 })
+    animate3(scope3.current, { y: '-100vh', opacity: 0, zIndex: -1, position: 'relative'}, { duration: 1 })
+    // setGameSessionState(GameSessionState.CHOOSE_CORRECT_ANSWER);
   }
 
   switch(gameSessionState) {
@@ -30,7 +38,7 @@ export default function GameSessionContainer({
     default: 
       return (
         <StartGame teams={mockGameSession.teams ?? []} currentQuestionIndex={mockGameSession.currentQuestionIndex ?? 0} questions={mockGameSession.questions} title={mockGameSession.title ?? ''} gameSessionId={mockGameSession.id} 
-          gameCode={mockGameSession.gameCode ?? 1100} currentState={mockGameSession.currentState} handleStartGame={handleStartGame} />
+          gameCode={mockGameSession.gameCode ?? 1100} currentState={mockGameSession.currentState} scope={scope} scope2={scope2} scope3={scope3} handleStartGame={handleStartGame} />
       )
   }
 }

--- a/host_v2/src/containers/GameSessionContainer.tsx
+++ b/host_v2/src/containers/GameSessionContainer.tsx
@@ -21,18 +21,26 @@ export default function GameSessionContainer({
   const [scope, animate] = useAnimate();
   const [scope2, animate2] = useAnimate();
   const [scope3, animate3] = useAnimate();
+
   const theme = useTheme(); // eslint-disable-line
   const handleStartGame = () =>{
-    animate(scope.current, { y: `calc(-100vh + ${theme.sizing.fullHeaderHeight}px)`, zIndex: -1, position: 'relative'}, { duration: 1 })
-    animate2(scope2.current, { opacity: 0, position: 'relative'}, { duration: 1 })
-    animate3(scope3.current, { y: '-100vh', opacity: 0, zIndex: -1, position: 'relative'}, { duration: 1 })
-    // setGameSessionState(GameSessionState.CHOOSE_CORRECT_ANSWER);
+    const exitAnimation = () => {
+      // Start all animations concurrently and return a promise that resolves when all animations are complete
+      return Promise.all([
+        animate(scope.current, { y: `calc(-100vh + 252px )`, zIndex: -1, position: 'relative'}, { duration: 1 }),
+        animate2(scope2.current, { opacity: 0, position: 'relative'}, { duration: 1 }),
+        animate3(scope3.current, { y: '-100vh', opacity: 0, zIndex: -1, position: 'relative'}, { duration: 1 })
+      ]);
+    };
+    exitAnimation().then(() => {
+      setGameSessionState(GameSessionState.CHOOSE_CORRECT_ANSWER);
+    });
   }
 
   switch(gameSessionState) {
     case GameSessionState.CHOOSE_CORRECT_ANSWER:
       return (
-        <GamePlayContainer apiClient={apiClient} />
+        <GamePlayContainer apiClient={apiClient}/>
       )
     case GameSessionState.TEAMS_JOINING:
     default: 

--- a/host_v2/src/containers/GameSessionContainer.tsx
+++ b/host_v2/src/containers/GameSessionContainer.tsx
@@ -1,134 +1,36 @@
 import React, { useState } from 'react';
-import { GameSessionState, ApiClient } from '@righton/networking';
-import { Typography } from '@mui/material';
-import { useTranslation } from 'react-i18next';
-import StackContainerStyled from '../lib/styledcomponents/layout/StackContainerStyled';
-import HeaderBackgroundStyled from '../lib/styledcomponents/layout/HeaderBackgroundStyled';
-import BodyStackContainerStyled from '../lib/styledcomponents/layout/BodyStackContainerStyled';
-import BodyBoxUpperStyled from '../lib/styledcomponents/layout/BodyBoxUpperStyled';
-import BodyBoxLowerStyled from '../lib/styledcomponents/layout/BodyBoxLowerStyled';
-import PlaceholderContentArea from '../components/PlaceholderContentArea';
-import HeaderContent from '../components/HeaderContent';
-import { LocalModel } from '../lib/HostModels';
+import { GameSessionState, ApiClient, GameSessionParser } from '@righton/networking';
+import StartGame from '../pages/StartGame';
+import GamePlayContainer from './GamePlayContainer';
+import MockGameSession from '../mock/MockGameSession.json';
 
 interface GameInProgressContainerProps {
   apiClient: ApiClient;
-}
-// may have to reformat/restructure this later but here is a sample answer object
-interface AnswerOption {
-  instructions: string[] | null;
-  reason: string | null;
-  content: string;
-}
-
-interface QuestionData {
-  text: string;
-  imageUrl: string | undefined;
-}
-
-interface Player {
-  answer: string; // answer chosen by this player
-  isCorrect: boolean; // true iff the chosen answer is the correct answer 
-  name: string; // this player's name
-}
-
-interface ConfidenceOption {
-  confidence: string; // the confidence option (i.e. 'NOT_RATED', 'NOT_AT_ALL', 'KINDA', etc.)
-  correct: number; // number of teams who selected this option and answered correctly 
-  incorrect: number; // number of players who selected tgis option and answered incorrectly 
-  players: Player[]; // an array of the players that selected this option
 }
 
 export default function GameSessionContainer({
   apiClient,
 }: GameInProgressContainerProps) {
-  console.log(apiClient); // eslint-disable-line
-  // TODO: delete hard coded values later
-  const sampleQuestion: QuestionData = {
-    text: "A pair of shoes were 10% off last week. This week, theres an additional sale, and you can get an extra 40% off the already discounted price from last week. What is the total percentage discount that youd get if you buy the shoes this week?",
-    imageUrl: "https://images.unsplash.com/photo-1609188944094-394637c26769?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=387&q=80"
+  const [gameSessionState, setGameSessionState] = useState<GameSessionState>(GameSessionState.TEAMS_JOINING);
+  const mockGameSession = GameSessionParser.gameSessionFromAWSGameSession({
+    ...MockGameSession,
+    currentState: MockGameSession.currentState as GameSessionState,
+  });
+
+  const handleStartGame = ()=>{
+    setGameSessionState(GameSessionState.CHOOSE_CORRECT_ANSWER);
   }
 
-  const sampleAnswerOptionOne: AnswerOption = {
-    instructions: ['step 1 step 1 step 1 step 1 step 1 step 1  step 1 step 1 step 1 step 1 step 1 step 1 ', 'step 2', 'step 3', 'step 4'],
-    reason: null,
-    content: "an answer choice"
+  switch(gameSessionState) {
+    case GameSessionState.CHOOSE_CORRECT_ANSWER:
+      return (
+        <GamePlayContainer apiClient={apiClient} />
+      )
+    case GameSessionState.TEAMS_JOINING:
+    default: 
+      return (
+        <StartGame teams={mockGameSession.teams ?? []} currentQuestionIndex={mockGameSession.currentQuestionIndex ?? 0} questions={mockGameSession.questions} title={mockGameSession.title ?? ''} gameSessionId={mockGameSession.id} 
+          gameCode={mockGameSession.gameCode ?? 1100} currentState={mockGameSession.currentState} handleStartGame={handleStartGame} />
+      )
   }
-
-  const sampleAnswerOptionTwo: AnswerOption = {
-    instructions: null,
-    reason: "reasoning",
-    content: "another answer choice"
-  }
-
-  const samplePlayerOne: Player = { answer: 'C', isCorrect: false, name: 'Alex Williams' }
-  const samplePlayerTwo: Player = { answer: 'C', isCorrect: false, name: 'Alessandro DeLuca-Smith' }
-  const samplePlayerThree: Player = { answer: 'D', isCorrect: true, name: 'Jackson Cameron' }
-  const samplePlayerFour: Player = { answer: 'A', isCorrect: false, name: 'Jeremiah Tanaka' }
-  const sampleConfidenceData: ConfidenceOption[] = [{ confidence: 'NOT_RATED', correct: 0, incorrect: 0, players: [] },
-  { confidence: 'NOT_AT_ALL', correct: 0, incorrect: 0, players: [] },
-  { confidence: 'KINDA', correct: 0, incorrect: 2, players: [samplePlayerOne, samplePlayerTwo] },
-  { confidence: 'QUITE', correct: 0, incorrect: 0, players: [] },
-  { confidence: 'VERY', correct: 1, incorrect: 1, players: [samplePlayerThree, samplePlayerFour] },
-  { confidence: 'TOTALLY', correct: 0, incorrect: 0, players: [] }]
-
-  const [confidenceGraphClickIndex, setConfidenceGraphClickIndex] = useState<number | null>(
-    null);
-
-  const handleConfidenceGraphClick = (selectedIndex: number | null) => {
-    setConfidenceGraphClickIndex(selectedIndex);
-  };
-
-  const { t } = useTranslation();
-  const totalQuestions = 5;
-  const currentQuestionIndex = 3;
-  const statePosition = 3;
-  const isCorrect = false;
-  const isIncorrect = false;
-  const currentState = GameSessionState.CHOOSE_CORRECT_ANSWER;
-
-  const localModelMock:LocalModel = {currentTimer: 200, hasRejoined: false};
-  const phaseOneTime = 180;
-  const phaseTwoTime = 180;
-  const hasRejoined = false;
-  const currentTimer = 90;
-
-  const totalTime =
-    currentState === GameSessionState.CHOOSE_CORRECT_ANSWER
-      ? phaseOneTime
-      : phaseTwoTime;
-
-
-  const handleTimerIsFinished = () => {
-    console.log("timer is finished");
-  };
-
-  return (
-    <StackContainerStyled
-    >
-      <HeaderBackgroundStyled />
-      <HeaderContent
-        currentState={currentState}
-        totalQuestions={totalQuestions}
-        currentQuestionIndex={currentQuestionIndex}
-        statePosition={statePosition}
-        isCorrect={isCorrect}
-        isIncorrect={isIncorrect}
-        totalTime={totalTime}
-        currentTimer={hasRejoined ? currentTimer : totalTime}
-        isPaused={false}
-        isFinished={false}
-        handleTimerIsFinished={handleTimerIsFinished}
-        localModel={localModelMock}
-      />
-      <BodyStackContainerStyled>
-        <BodyBoxUpperStyled />
-        <BodyBoxLowerStyled />
-        <PlaceholderContentArea
-          questionData={sampleQuestion}
-          answerOptions={[sampleAnswerOptionOne, sampleAnswerOptionTwo]}
-          confidenceData={sampleConfidenceData} confidenceGraphClickIndex={confidenceGraphClickIndex} handleConfidenceGraphClick={handleConfidenceGraphClick} />
-      </BodyStackContainerStyled>
-    </StackContainerStyled>
-  );
 }

--- a/host_v2/src/lib/styledcomponents/layout/BodyBoxUpperStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/BodyBoxUpperStyled.tsx
@@ -4,7 +4,7 @@ import { Box } from '@mui/material';
 /* lower-level container for background section in body 
 (body stack container -> body box upper, body box lower, body content area) */
 export default styled(Box)(() => ({
-  height: '70px',
+  height: '78px', // this value is set in coordination with the header height animated on Start Game page (252px)
   width: '100vw',
   boxShadow: '0px 10px 10px rgba(0, 141, 239, 0.25)',
   zIndex: 1,

--- a/host_v2/src/lib/styledcomponents/layout/BodyContentAreasStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/BodyContentAreasStyled.tsx
@@ -9,7 +9,7 @@ export const BodyContentAreaTripleColumnStyled = styled(Grid)(({ theme }) => ({
   alignItems: 'flex-start',
   maxWidth: '1236px',
   width: '100%',
-  height: '100%',
+  flex: 1,
   overflow: 'hidden',
   paddingTop: `${theme.sizing.smallPadding}px`,
   paddingLeft: `${theme.sizing.mediumPadding}px`,
@@ -27,7 +27,7 @@ export const BodyContentAreaDoubleColumnStyled = styled(Grid)(({ theme }) => ({
   alignItems: 'flex-start',
   maxWidth: `${theme.breakpoints.values.lg})px`,
   width: '100%',
-  height: '100%',
+  flex: 1,
   overflow: 'hidden',
   zIndex: 2,
 }));

--- a/host_v2/src/pages/StartGame.tsx
+++ b/host_v2/src/pages/StartGame.tsx
@@ -90,11 +90,11 @@ function StartGame({teams,
 
     return (
       <StartGameContainer>
-        <motion.div ref={scope} exit={{ y: `calc(100vh -  ${theme.sizing.fullHeaderHeight}px`}}>
+        <motion.div ref={scope} exit={{ y: `calc(100vh - 500px)`}}> 
           <BackgroundStyled /> 
         </motion.div>
         <ContentContainer>
-            <motion.div ref={scope2} exit={{y: 0, opacity: 0}} style={{height: 'calc(100vh - 80px)'}}>
+            <motion.div ref={scope2} exit={{opacity: 0}} style={{height: 'calc(100vh - 80px)'}}>
               <UpperStyled>
                 <HostHeader 
                   gameCode = {gameCode}

--- a/host_v2/src/pages/StartGame.tsx
+++ b/host_v2/src/pages/StartGame.tsx
@@ -24,6 +24,7 @@ interface StartGameProps {
   scope: React.RefObject<HTMLDivElement>
   scope2: React.RefObject<HTMLDivElement>
   scope3: React.RefObject<HTMLDivElement>
+  scope4: React.RefObject<HTMLDivElement>
   handleStartGame: () => void
 }  
 
@@ -83,6 +84,7 @@ function StartGame({teams,
   scope,
   scope2,
   scope3,
+  scope4,
   handleStartGame}: StartGameProps) {
     const theme = useTheme(); // eslint-disable-line
 
@@ -105,11 +107,12 @@ function StartGame({teams,
             </motion.div>
            
          </ContentContainer>
-         <motion.div ref={scope3} exit={{ y: 0, opacity: 0}}>
+         <motion.div ref={scope4} exit={{opacity: 0}}>
           <FooterStartGame 
               teamsLength={teams ? teams.length : 0}
               gameSessionId = {gameSessionId}
               currentQuestionIndex={currentQuestionIndex}
+              scope3={scope3}
               handleStateGame={handleStartGame}
             />
           </motion.div>

--- a/host_v2/src/pages/StartGame.tsx
+++ b/host_v2/src/pages/StartGame.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import {Box, Paper, Typography} from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { styled, useTheme } from '@mui/material/styles';
+import { motion } from "framer-motion";
 import {
   ITeam,
   IQuestion,
@@ -20,16 +21,39 @@ interface StartGameProps {
   gameSessionId: string
   gameCode: number
   currentState: GameSessionState
+  scope: React.RefObject<HTMLDivElement>
+  scope2: React.RefObject<HTMLDivElement>
+  scope3: React.RefObject<HTMLDivElement>
   handleStartGame: () => void
 }  
 
+const StartGameContainer = styled(Box)(({ theme }) => ({
+  position: 'relative', 
+  height: '100vh',
+  overflowX: 'hidden'
+}))
+
 const BackgroundStyled = styled(Paper)(({ theme }) => ({
+  position: 'absolute', // Position it absolutely within StartGameContainer
+  top: 0,
+  left: 0,
+  width: '100%', // Stretch across the entire container
+  height: '100vh', // Cover the full height of the container
   display: 'flex',
-  minHeight: '100vh',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  background: 'linear-gradient(196.21deg, #0D68B1 0%, #02215F 73.62%)'
+  background: 'linear-gradient(196.21deg, #0D68B1 0%, #02215F 73.62%)',
+  zIndex: -1, // Ensure it stays behind the content
+}))
+
+const ContentContainer = styled(Box)(({ theme }) => ({
+  overflowY: 'auto', // Enable vertical scrolling
+  msOverflowStyle: 'none', // Hide scrollbar for IE and Edge
+  scrollbarWidth: 'none', // Hide scrollbar for Firefox
+  '&::-webkit-scrollbar': {
+    display: 'none', // Hide scrollbar for Chrome, Safari, and Opera
+  },
+  height: 'calc(100vh - 80px)', // Adjust the height to prevent overflow, consider header or other elements if present
+  zIndex: 1,
+
 }))
 
 const UpperStyled = styled(Box)(({ theme }) => ({
@@ -37,8 +61,8 @@ const UpperStyled = styled(Box)(({ theme }) => ({
   flexDirection: 'column',
   justifyContent: 'flex-start',
   alignItems: 'center',
-  gap: '24px',
-    
+  gap: '24px',    
+  height: '100%'
 }))
 
 const GameStyled = styled(Typography)(({ theme }) => ({
@@ -47,7 +71,6 @@ const GameStyled = styled(Typography)(({ theme }) => ({
   fontStyle: 'Italic',
   fontSize: '18px',
   color: 'rgba(255, 255, 255, 0.46)',
-  paddingTop: '10%',
 }))
 
 function StartGame({teams,
@@ -57,25 +80,40 @@ function StartGame({teams,
   gameSessionId,
   gameCode,
   currentState,
+  scope,
+  scope2,
+  scope3,
   handleStartGame}: StartGameProps) {
+    const theme = useTheme(); // eslint-disable-line
+
     return (
-      <BackgroundStyled>
-        <UpperStyled>
-          <HostHeader 
-          gameCode = {gameCode}
-          currentQuestionIndex={currentQuestionIndex}
-          />
-          <GameCard questions = {questions} title={title} />
-          <GameStyled>Basic Mode</GameStyled>
-          <CurrentStudents teams={teams}/>
-        </UpperStyled>
-        <FooterStartGame 
-        teamsLength={teams ? teams.length : 0}
-        gameSessionId = {gameSessionId}
-        currentQuestionIndex={currentQuestionIndex}
-        handleStateGame={handleStartGame}
-        />
-      </BackgroundStyled>
+      <StartGameContainer>
+        <motion.div ref={scope} exit={{ y: `calc(100vh -  ${theme.sizing.fullHeaderHeight}px`}}>
+          <BackgroundStyled /> 
+        </motion.div>
+        <ContentContainer>
+            <motion.div ref={scope2} exit={{y: 0, opacity: 0}} style={{height: 'calc(100vh - 80px)'}}>
+              <UpperStyled>
+                <HostHeader 
+                  gameCode = {gameCode}
+                  currentQuestionIndex={currentQuestionIndex}
+                />
+                <GameCard questions = {questions} title={title} />
+                <GameStyled>Basic Mode</GameStyled>
+                <CurrentStudents teams={teams}/>
+              </UpperStyled>
+            </motion.div>
+           
+         </ContentContainer>
+         <motion.div ref={scope3} exit={{ y: 0, opacity: 0}}>
+          <FooterStartGame 
+              teamsLength={teams ? teams.length : 0}
+              gameSessionId = {gameSessionId}
+              currentQuestionIndex={currentQuestionIndex}
+              handleStateGame={handleStartGame}
+            />
+          </motion.div>
+      </StartGameContainer>
     )
 
   }

--- a/host_v2/yarn.lock
+++ b/host_v2/yarn.lock
@@ -1364,12 +1364,24 @@
   resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz"
   integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
 
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/is-prop-valid@^1.1.0", "@emotion/is-prop-valid@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz#23116cf1ed18bfeac910ec6436561ecb1a3885cc"
   integrity sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==
   dependencies:
     "@emotion/memoize" "^0.8.1"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@emotion/memoize@^0.8.1":
   version "0.8.1"
@@ -7386,6 +7398,15 @@ fraction.js@^4.3.6:
   version "4.3.7"
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
+
+framer-motion@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-11.0.3.tgz#b2a87e7ae166a9e27da33da9cfb50a0db5f94fa7"
+  integrity sha512-6x2poQpIWBdbZwLd73w6cKZ1I9IEPIU94C6/Swp1Zt3LJ+sB5bPe1E2wC6EH5hSISXNkMJ4afH7AdwS7MrtkWw==
+  dependencies:
+    tslib "^2.4.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
 
 fresh@0.5.2:
   version "0.5.2"


### PR DESCRIPTION
Yong Lin has provided the following design for a screen transition between the start game and game play phases of `host_v2`. 

https://github.com/rightoneducation/righton-app/assets/79417944/9b2c99ce-202b-4cba-b1b3-f22a428b05f2

I wanted to do a quick POC using the `framer motion` library to see how well we could match this. The chief technical difficulty here is that the animation spans two `GameSessionStates` `TEAMS_JOINING` and `CHOOSE_CORRECT_ANSWER`. Therefore, we need to provide an exit animation and an entry animation in these two states. Here is the current progress on the POC:

Small Device:

https://github.com/rightoneducation/righton-app/assets/79417944/cb3dedee-994e-46b6-aec9-d8760309e36b


Medium Device:


https://github.com/rightoneducation/righton-app/assets/79417944/ee97cd7e-cd86-41bf-a5b5-c0aa02a0c7c0




Large Device:


https://github.com/rightoneducation/righton-app/assets/79417944/33416ff1-c5b9-46d7-957a-4e0cb40a48db



