### PR TITLE
[play] fixing ghost swipe bug when confidence meter is not enabled

### DIFF
--- a/central/package.json
+++ b/central/package.json
@@ -40,6 +40,7 @@
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "@types/uuid": "^9.0.8",
     "eslint": "^8.24.0",
     "eslint-config-prettier": "^8.5.0",
     "file-system-cache": "1.0.5",

--- a/central/yarn.lock
+++ b/central/yarn.lock
@@ -4833,6 +4833,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
+"@types/uuid@^9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
+
 "@types/ws@^8.5.1":
   version "8.5.4"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"

--- a/networking/package.json
+++ b/networking/package.json
@@ -5,6 +5,7 @@
     "@types/jest": "^29.5.1",
     "@types/node": "^18.16.3",
     "@types/stopword": "^2.0.3",
+    "@types/uuid": "^9.0.8",
     "create-ts-index": "^1.14.0",
     "jest": "^29.5.0",
     "ts-jest": "^29.1.0",
@@ -15,7 +16,8 @@
     "aws-amplify": "^5.3.1",
     "mathjs": "^11.11.2",
     "reflect-metadata": "^0.1.13",
-    "stopword": "^2.0.8"
+    "stopword": "^2.0.8",
+    "uuid": "^9.0.1"
   },
   "scripts": {
     "build": "cti s -p ./tsconfig.build.json ./src -s true -b -f index.ts && tsc --build tsconfig.json",

--- a/networking/src/@types/aws/aws-exports.d.ts
+++ b/networking/src/@types/aws/aws-exports.d.ts
@@ -1,2 +1,0 @@
-export = awsmobile
-declare const awsmobile: any

--- a/networking/src/APIClients/index.ts
+++ b/networking/src/APIClients/index.ts
@@ -7,7 +7,7 @@ export * from './GameSessionAPIClient';
 export * from './GameTemplateAPIClient';
 export * from './QuestionAPIClient';
 export * from './QuestionTemplateAPIClient';
-export * from './TeamAPIClient';
 export * from './TeamAnswerAPIClient';
+export * from './TeamAPIClient';
 export * from './TeamMemberAPIClient';
 export * from './interfaces';

--- a/networking/src/APIClients/interfaces/index.ts
+++ b/networking/src/APIClients/interfaces/index.ts
@@ -7,6 +7,6 @@ export * from './IGameSessionAPIClient';
 export * from './IGameTemplateAPIClient';
 export * from './IQuestionAPIClient';
 export * from './IQuestionTemplateAPIClient';
-export * from './ITeamAPIClient';
 export * from './ITeamAnswerAPIClient';
+export * from './ITeamAPIClient';
 export * from './ITeamMemberAPIClient';

--- a/networking/yarn.lock
+++ b/networking/yarn.lock
@@ -2829,6 +2829,11 @@
   resolved "https://registry.yarnpkg.com/@types/stopword/-/stopword-2.0.3.tgz#4e7c629000a74eb56f772fa0f4eb77775de425de"
   integrity sha512-hioMj0lOvISM+EDevf7ijG8EMbU+J3pj4SstCyfQC1t39uPYpAe7beSfBdU6c1d9jeECTQQtR3UJWtVoUO8Weg==
 
+"@types/uuid@^9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
+
 "@types/yargs-parser@*":
   version "21.0.0"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz"
@@ -4825,6 +4830,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/play/src/pages/gameinprogress/ChooseAnswer.tsx
+++ b/play/src/pages/gameinprogress/ChooseAnswer.tsx
@@ -246,7 +246,7 @@ export default function ChooseAnswer({
             >
               {answerContents}
             </SwiperSlide>
-            { isSubmitted && isSmallDevice &&
+            { isSubmitted && isSmallDevice && isConfidenceEnabled &&
          
                 <SwiperSlide
                   style={{


### PR DESCRIPTION

**Issue:**

The issue was that when the confidence meter was not enabled, users were still able to swipe to where the confidence meter would have been. This solution makes it so that they are not able to swipe in that scenario.