### PR TITLE
[Central/Host/Play] - Bug Fixes

### DIFF
--- a/central/src/components/GameDashboard.jsx
+++ b/central/src/components/GameDashboard.jsx
@@ -62,7 +62,6 @@ export default function GameDashboard({ loading, nextToken, games, handleScrollD
           </div>
         </div>
     );
-    if (games.length >= 1) {
       return <InfiniteScroll
           dataLength={games.length}
           next={() => handleScrollDown(nextToken)}
@@ -72,7 +71,8 @@ export default function GameDashboard({ loading, nextToken, games, handleScrollD
           scrollableTarget="GameDashboard"
           className={classes.infiniteScroll}
         > 
-          {games.map((game, index) => 
+        { (games.length >=1 ) ?
+          games.map((game, index) => 
             <Grid key={index} container item xs={12} md={addquestion ? 12 : 6} lg={addquestion ? 12 : 4} style={{width: '100%'}}>
               <GameCard 
                 key={game.id}
@@ -90,15 +90,12 @@ export default function GameDashboard({ loading, nextToken, games, handleScrollD
                 onClick={() => history.push(`/games/${game.id}`)}
               />
             </Grid>
-          )}
+          ) : 
+          <Typography> 
+            No results found.
+          </Typography>
+        }
       </InfiniteScroll>
-    }
-    return (
-      <Typography gutterBottom>
-        No results found.
-      </Typography>
-    );
-    
   }
 
   return (

--- a/host/src/components/FeaturedMistakes.jsx
+++ b/host/src/components/FeaturedMistakes.jsx
@@ -35,6 +35,9 @@ export default function FeaturedMistakes({
         return mistakes;
       }, []);
     let sortedMistakes = extractedMistakes.sort((a, b) => {
+      if (a.percent === b.percent) {
+        return a.answer.localeCompare(b.answer);
+      }
       return b.percent - a.percent;
     });
     if (isPopularMode) {

--- a/host/src/components/GameInProgressContentSwitch.jsx
+++ b/host/src/components/GameInProgressContentSwitch.jsx
@@ -234,7 +234,7 @@ export default function GameInProgressContentSwitch({
       ) : (
         graphClickRenderSwitch(graphClickInfo)
       )
-      };
+      }
     </Box>,
   ];
 

--- a/host/src/components/LinearProgressBar.jsx
+++ b/host/src/components/LinearProgressBar.jsx
@@ -23,7 +23,7 @@ export default function LinearProgressBar({ inputNum, totalNum }) {
           style={{
             position: 'absolute',
             top: '0',
-            left: '0',
+            left: '5px',
             width: `${progressPercent - 2}%`,
             textAlign: 'right',
             fontFamily: 'Helvetica',

--- a/networking/amplify/team-provider-info.json
+++ b/networking/amplify/team-provider-info.json
@@ -34,9 +34,6 @@
           "deploymentBucketName": "amplify-mobile-dev-130906-deployment",
           "s3Key": "amplify-builds/createGame-3573313230526d5a416a-build.zip"
         }
-      },
-      "api": {
-        "mobile": {}
       }
     }
   }

--- a/play/src/components/GameSessionSwitch.tsx
+++ b/play/src/components/GameSessionSwitch.tsx
@@ -37,6 +37,7 @@ export default function GameSessionSwitch({
   const { currentState } = gameSession;
   const currentQuestion =
     gameSession.questions[gameSession.currentQuestionIndex] as IQuestion;
+  
   const currentTeam = gameSession.teams.find( 
     (team) => team.id === localModel.teamId
   );
@@ -51,13 +52,7 @@ export default function GameSessionSwitch({
   (isShortAnswerEnabled
     ? currentQuestion?.responses?.reduce(
         (acc: IChoice[], response: IResponse) => {
-          const shouldAddResponse = 
-            (currentState !== GameSessionState.CHOOSE_CORRECT_ANSWER && 
-            currentState !== GameSessionState.PHASE_1_DISCUSS && 
-            currentState !== GameSessionState.PHASE_1_RESULTS) 
-              ? (response.isSelectedMistake || response.isCorrect) 
-              : true;
-        
+          const shouldAddResponse = (response.isSelectedMistake || response.isCorrect);
           if (shouldAddResponse) {
             acc.push({
               id: uuidv4(),

--- a/play/src/containers/PregameContainer.tsx
+++ b/play/src/containers/PregameContainer.tsx
@@ -80,8 +80,7 @@ export function PregameContainer({ apiClients }: PregameFinished) {
         return false;
       }
       if (
-        gameSessionResponse.currentState === GameSessionState.FINISHED ||
-        gameSessionResponse.currentState === GameSessionState.NOT_STARTED
+        gameSessionResponse.currentState !== GameSessionState.TEAMS_JOINING
       ) {
         return false;
       }


### PR DESCRIPTION
https://docs.google.com/document/d/1qrd4EKozYLYnbKpVRjA-ysuClvETTKHWXHWgOJXKubQ/edit

Resolved Bugs:

- P1 - Host: Short Answer Mode: Manual selection for Phase 2 does not work

    Issue: `answerChoices` does not update correctly with `isSelectedMistake`
    Resolution: Adjusted logic for when to parse `isSelectedMistake` from `Question` object

- P2 - Host: Short Answer Mode: “Use the top 3 answers by popularity” sometimes results in more than 3 distractors being displayed in Play in Phase 2

    Issue: Answers with differing decimal places are being seen as equal, thus pushing more distractors over to phase 2
    Resolution: Adjusted normalization and comparison logic for numeric answers to check for differing decimal places and reject answers that don't have the same number

- P2 - Short Answer Mode -  Numerical responses that should not be grouped (ex: 4.0 and 4) are sometimes grouped, based on order of submission

    Issue: Same as previous issue
    Resolution: Resolved through previous issue

- P3 - Students with code can unexpectedly join after the game has begun and can submit answers, but they do not get recorded on Host

    Issue: When a player joins the game, it only ensures that the gamesession hasn't finished before the player to join.
    Resolution: Now, when a player enters a game code, the `GameSessionState` must be `TEAMS_JOINING` otherwise they are blocked from joining.

- P3 - Host: Short Answer Response Mode: Default “top 3 answers by popularity” for Phase 2 are not ordered as expected

    Issue: Sorting was only performed by percentage of students answered.
    Resolution: Now, if a tie is detected, a subsort occurs that sorts answers by numerically/alphabetically

- P4 - Host: Semicolon appears on the phase 1 teacher screen

    Issue: Semicolon on screen
    Resolution: Semicolon removed

- P4 - Host: Cosmetic spacing issue with “Players who have answered” bar

    Issue: Text css set to `left: '0'`
    Resolution: Text css set to `left: '5px'`

- P4 - Central: The “sort” dropdown menu gets cut off when a search returns no results

    Issue: CSS formatting
    Resolution: CSS fixed via changes to the render method
