### PR TITLE
[Backend] - Public/Private - Bug Fixes

### DIFF
--- a/central/src/components/GameDashboard.jsx
+++ b/central/src/components/GameDashboard.jsx
@@ -19,15 +19,14 @@ export default function GameDashboard({ checkGameOwner, loading, nextToken, publ
     event.stopPropagation();
   };
   const handleClose = () => {
-    setAnchorEl(null);
     setActiveIndex(null);
   };
   const editHandler = async (game) => {
     try {
       const isOwner = await checkGameOwner(game);
       if (isOwner){
-        setGameDetails(game);
-        history.push(`/gamemaker/${game.id}`); 
+       setGameDetails(game);
+       history.push(`/gamemaker/${game.id}`); 
         handleClose(); 
       } else {
         handleClose();
@@ -146,6 +145,7 @@ const useStyles = makeStyles(theme => ({
   loadingContainer: {
     margin: 'auto',
     width: '60%',
+    height: `calc(100vh - 156px)`
   },
   loadingTitle: {
     fontSize: '24px',

--- a/central/src/components/Games.jsx
+++ b/central/src/components/Games.jsx
@@ -11,6 +11,7 @@ import QuestionMaker from './QuestionMaker';
 import GameMaker from './GameMaker';
 import { getGameById, getQuestionTemplateById } from '../lib/HelperFunctions';
 import SearchBar from './SearchBar.jsx';
+import { get, set } from 'lodash';
 
 export default function Games({ 
   loading,
@@ -79,6 +80,25 @@ export default function Games({
         return {id: gameId, ...newGame};
       }
     });
+
+  const [question, setQuestion] = useState((prev) => {
+    if (prev) {
+      const copyOfOriginal = { ...prev }
+      copyOfOriginal.choices = JSON.parse(copyOfOriginal.choices)
+      copyOfOriginal.instructions = JSON.parse(copyOfOriginal.instructions);
+      copyOfOriginal.answerSettings = JSON.parse(copyOfOriginal.answerSettings);
+      return copyOfOriginal
+    }
+    return {
+      title: '',
+      imageUrl: '',
+      choices: [{ text: '', reason: '', isAnswer: true }, { text: '', reason: '', isAnswer: false }, { text: '', reason: '', isAnswer: false }, { text: '', reason: '', isAnswer: false }],
+      grade: null,
+      domain: null,
+      cluster: null,
+      standard: null,
+    }
+  });
   // these two state variables will be updated by the user on this screen, and then sent to the API when they click "Save Game"
   const [localQuestionTemplates, setLocalQuestionTemplates] = useState(game ? [...game.questionTemplates] : []);
   const handleQuestionSelected = (question, isSelected) => {
@@ -124,13 +144,15 @@ export default function Games({
               const { gameId, questionId } = match.params;
               const game = getGameById(games, gameId);
               let questions = null;
-              let question = null;
               if (game && game.questionTemplates.length > 0){
                 questions = game.questionTemplates.map(({ questionTemplate }) => questionTemplate) ?? null;
-                question = getQuestionTemplateById(questions, questionId) ?? null;
+                const checkForQuestion = getQuestionTemplateById(questions, questionId);
+                if (checkForQuestion) {
+                  setQuestion(checkForQuestion);
+                };
               }
               handleSearchClick(false);
-              return <QuestionMaker gameId={gameId} originalQuestion={question} localQuestionTemplates={localQuestionTemplates} setLocalQuestionTemplates={setLocalQuestionTemplates} handleCreateQuestionTemplate={handleCreateQuestionTemplate} handleUpdateQuestionTemplate={handleUpdateQuestionTemplate} publicPrivateQueryType={publicPrivateQueryType} handlePublicPrivateChange={handlePublicPrivateChange}/>
+              return <QuestionMaker gameId={gameId} originalQuestion={question} localQuestionTemplates={localQuestionTemplates} setLocalQuestionTemplates={setLocalQuestionTemplates} handleCreateQuestionTemplate={handleCreateQuestionTemplate} handleUpdateQuestionTemplate={handleUpdateQuestionTemplate} publicPrivateQueryType={publicPrivateQueryType} handlePublicPrivateChange={handlePublicPrivateChange} question={question} setQuestion={setQuestion}/>
             } 
           }/>
         }
@@ -193,9 +215,12 @@ export default function Games({
                 return null;
               }
               const { questionId } = match.params;
-              const question = getQuestionTemplateById(questions, questionId);
+              const checkForQuestion = getQuestionTemplateById(questions, questionId);
+              if (checkForQuestion) {
+                setQuestion(checkForQuestion);
+              };
               handleSearchClick(false);
-              return <QuestionMaker gameId={null} originalQuestion={question} localQuestionTemplates={localQuestionTemplates} setLocalQuestionTemplates={setLocalQuestionTemplates} handleCreateQuestionTemplate={handleCreateQuestionTemplate} handleUpdateQuestionTemplate={handleUpdateQuestionTemplate} listQuerySettings={listQuerySettings} handleUpdateListQuerySettings={handleUpdateListQuerySettings} publicPrivateQueryType={publicPrivateQueryType} handlePublicPrivateChange={handlePublicPrivateChange}/>
+              return <QuestionMaker gameId={null} originalQuestion={question} localQuestionTemplates={localQuestionTemplates} setLocalQuestionTemplates={setLocalQuestionTemplates} handleCreateQuestionTemplate={handleCreateQuestionTemplate} handleUpdateQuestionTemplate={handleUpdateQuestionTemplate} listQuerySettings={listQuerySettings} handleUpdateListQuerySettings={handleUpdateListQuerySettings} publicPrivateQueryType={publicPrivateQueryType} handlePublicPrivateChange={handlePublicPrivateChange} question={question} setQuestion={setQuestion}/>
             } 
         }/>
         <Route path="/">

--- a/central/src/components/Games.jsx
+++ b/central/src/components/Games.jsx
@@ -11,7 +11,6 @@ import QuestionMaker from './QuestionMaker';
 import GameMaker from './GameMaker';
 import { getGameById, getQuestionTemplateById } from '../lib/HelperFunctions';
 import SearchBar from './SearchBar.jsx';
-import { get, set } from 'lodash';
 
 export default function Games({ 
   loading,

--- a/central/src/components/QuestionDashboard.tsx
+++ b/central/src/components/QuestionDashboard.tsx
@@ -186,6 +186,7 @@ const useStyles = makeStyles((theme) => ({
   loadingContainer: {
     margin: 'auto',
     width: '60%',
+    height: `calc(100vh - 156px)`
   },
   loadingTitle: {
     fontSize: '24px',

--- a/central/src/components/QuestionMaker.jsx
+++ b/central/src/components/QuestionMaker.jsx
@@ -33,9 +33,8 @@ export default function QuestionMaker({
   const [isAnswerTypeValid, setIsAnswerTypeValid] = useState(false);
   const [isAnswerPrecisionValid, setIsAnswerPrecisionValid] = useState(false);
   const initialState = useMemo(() => originalQuestion != null, [originalQuestion]);
-
-  const [answerType, setAnswerType] = useState(question.answerSettings?.answerType ?? AnswerType.NUMBER);
-  const [answerPrecision, setAnswerPrecision] = useState(question.answerSettings?.answerPrecision ?? AnswerPrecision.WHOLE);
+  const [answerType, setAnswerType] = useState(question?.answerSettings?.answerType ?? AnswerType.NUMBER);
+  const [answerPrecision, setAnswerPrecision] = useState(question?.answerSettings?.answerPrecision ?? AnswerPrecision.WHOLE);
   // Handles which Url to redirect to when clicking the Back to Game Maker button
   const handleBack = useCallback(() => {
     if (match) {

--- a/central/src/lib/API/GameTemplates.ts
+++ b/central/src/lib/API/GameTemplates.ts
@@ -63,6 +63,7 @@ export const deleteGameTemplate = async (
   id: string
 ): Promise<boolean> => {
   const gameTemplate = await apiClients.gameTemplate.getGameTemplate(type, id);
+  console.log(gameTemplate);
   if (gameTemplate?.questionTemplates) {
     await Promise.all(gameTemplate.questionTemplates.map(async (questionTemplate) => {
       try {

--- a/central/src/lib/API/GameTemplates.ts
+++ b/central/src/lib/API/GameTemplates.ts
@@ -63,7 +63,6 @@ export const deleteGameTemplate = async (
   id: string
 ): Promise<boolean> => {
   const gameTemplate = await apiClients.gameTemplate.getGameTemplate(type, id);
-  console.log(gameTemplate);
   if (gameTemplate?.questionTemplates) {
     await Promise.all(gameTemplate.questionTemplates.map(async (questionTemplate) => {
       try {

--- a/networking/src/APIClients/templates/GameQuestionsAPIClient.ts
+++ b/networking/src/APIClients/templates/GameQuestionsAPIClient.ts
@@ -46,7 +46,7 @@ export class GameQuestionsAPIClient extends BaseAPIClient implements IGameQuesti
         id: string
     ): Promise<boolean> {
         const variables: GameQuestionType<T>['delete']['variables'] = {input: {id}};
-        const { queryFunction } = gameQuestionRuntimeMap[type]['get'];
+        const { queryFunction } = gameQuestionRuntimeMap[type]['delete'];
         const result = await this.callGraphQL<GameQuestionType<T>['delete']['query']>(
             queryFunction,
             variables

--- a/networking/src/APIClients/templates/GameTemplateAPIClient.ts
+++ b/networking/src/APIClients/templates/GameTemplateAPIClient.ts
@@ -35,17 +35,18 @@ export class GameTemplateAPIClient
   ): Promise<IGameTemplate> {
     try{
       const queryFunction = gameTemplateRuntimeMap[type].get.queryFunction;
+      const getType = `get${type}GameTemplate`;
       const result = await this.callGraphQL<GameTemplateType<T>['get']['query']>(
         queryFunction,
         { id } as unknown as GraphQLOptions
       ) as { data: any };
+      console.log(result);
       if (
-        isNullOrUndefined(result?.data) ||
-        isNullOrUndefined(result?.data.getGameTemplate)
+        isNullOrUndefined(result?.data)
       ) {
         throw new Error(`Failed to get game template`)
       }
-      return GameTemplateParser.gameTemplateFromAWSGameTemplate(result.data.getGameTemplate as AWSGameTemplate, type);
+      return GameTemplateParser.gameTemplateFromAWSGameTemplate(result.data[getType] as AWSGameTemplate, type);
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
## Background: ##
After discussing with the team (captured in the wiki [here](https://github.com/rightoneducation/righton-app/wiki/Backend-%E2%80%90-Authentication-and-Authorization#publicprivate)), we have decided to implement separate tables for Public and Private `GameTemplates` and `QuestionTemplates`. This PR and the following one implement that strategy.

They break down per:
[[Backend] - Public/Private Ownership #1082](https://github.com/rightoneducation/righton-app/pull/1082)
-> [[Backend] - Public/Private Ownership - Central UI Changes #1096](https://github.com/rightoneducation/righton-app/pull/1096)
->-> [[Backend] - Public/Private - Bug Fixes #1101](https://github.com/rightoneducation/righton-app/pull/1101)

 The first PR (#1082) is focused around `networking` changes that provide the required updates to the `schema.graphql` and the associated `APIClients`. The second PR (#1096) is focused around UI updates to ensure that `central` is functional. This PR (#1101) cleans up some bugs.
 
 ## Bugs: ##
 
 Resolved bugs are as follows:
 1. Fixes `handleOnClose` so Edit/Clone/Delete bar disappears properly
 2. Fixes height of loading page so that `SortByDropdown` isn't cut off 
 3. adds in missing `[question, setQuestion]` for use in `QuestionMaker`
 4. fixes query function type in `GameQuestionDelete` in `GameQuestionsAPIClient`
 5. update `GameTemplateAPIClient` with correct query type
 