### PR TITLE
[Central] - Change 'Game Text' to 'Game Description'

### DIFF
--- a/central/src/components/GameMaker.jsx
+++ b/central/src/components/GameMaker.jsx
@@ -218,7 +218,7 @@ export default function GameMaker({
                   <Grid container item xs={12}>
                     <TextField
                       variant='outlined'
-                      label='Game Text'
+                      label='Game Description'
                       value={gameDetails.description}
                       onChange={({ currentTarget }) => { setGameDetails({ ...gameDetails, description: handleStringInput(currentTarget.value) }) }}
                       fullWidth


### PR DESCRIPTION
Resolves 'P4.1 Change “Game Text” to “Game Description” across Central pages' in https://docs.google.com/document/d/1AmQZHwj8mV1IMNGsgssL57NcIpNwxTeYsQgFFe_3aKY/edit