### PR TITLE
functionlity for userProfile page finished.

### DIFF
--- a/central_v2/src/components/profile/OwnerCard.tsx
+++ b/central_v2/src/components/profile/OwnerCard.tsx
@@ -61,7 +61,7 @@ export default function OwnerCard({
             <AtUserNameContainerAndAccount>
                 <AtUserNameContainer >
                     <AtUserNameText>
-                        @clarkinator27
+                        @{draftUserProfile.userName}
                     </AtUserNameText>
                 </AtUserNameContainer>
                 <LeftAccountCreatedContainer>

--- a/central_v2/src/lib/styledcomponents/OwnerCardStyledComponents.tsx
+++ b/central_v2/src/lib/styledcomponents/OwnerCardStyledComponents.tsx
@@ -40,7 +40,8 @@ export const AtUserNameContainerAndAccount = styled(Box)(({ theme }) => ({
   flexDirection: 'column',
   width: '139px',
   gap: '8px',
-  alignItems: 'center'
+  alignItems: 'center',
+
 }));
 
 export const AtUserNameContainer = styled(Box)(({ theme }) => ({
@@ -50,13 +51,12 @@ export const AtUserNameContainer = styled(Box)(({ theme }) => ({
 export const AtUserNameText = styled(Typography)(({ theme }) => ({
   background: '#7E1E81',
   color: '#FFFFFF',
-  textAlign: 'center',
   padding: '4px',
   boxSizing: 'border-box',
   borderRadius: '25px',
   display: 'flex',
   flexDirection: 'row',
-  justifyContent: 'flex-start',
+  justifyContent: 'center',
   alignItems: 'center',
 }));
 

--- a/central_v2/src/pages/UserProfile.tsx
+++ b/central_v2/src/pages/UserProfile.tsx
@@ -43,8 +43,10 @@ export default function UserProfile({
     screenSize
 }: UserProfileProps) {
   const theme = useTheme();
-  const buttonEditInformation = ButtonType.EDITINFORMATION;
-  const [isEditInformation, setIsEditInformation] = useState(true);
+  const [isEditInformationHighlight, setEditInformationHighlight] = useState(true);
+  const [isSaveInformationHighlight, setSaveInformationHighlight] = useState(false);
+
+  const [isEditInformation, setIsEditInformation] = useState(false);
 
   const buttonChangePassword = ButtonType.CHANGEPASSWORD;
   const [isChangePassword , setIsChangePassword ] = useState(true);
@@ -54,11 +56,6 @@ export default function UserProfile({
   const [draftUserProfile, setDraftUserProfile] = useState<IUserProfile>(centralData.userProfile);  
   const [newProfilePic, setNewProfilePic] = useState<File | null>(null);
 
-  console.log("Printing central on intial render: ", centralData.userProfile)
-  console.log("Printing draft on intial render: ", draftUserProfile)
-
-
-
   const buttonTypeUpload = ButtonType.UPLOAD;
   const [isUploadFrontEnabled, setIsUploadFrontEnabled] = useState(true);
   const [isUploadBackEnabled, setIsUploadBackEnabled] = useState(true);
@@ -67,19 +64,10 @@ export default function UserProfile({
   const [isCloneImageChanged, setIsCloneImageChanged] = useState<boolean>(false);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const apiClients = useTSAPIClientsContext(APIClientsContext);
-  
-
-  // Information user can edit
-//   const [title, setTitle] = useState(centralData.userProfile.title) 
-//   const [firstName, setFirstName] = useState(centralData.userProfile.firstName) 
-//   const [lastName, setLastName] = useState(centralData.userProfile.lastName) 
-//   const [email, setEmail] = useState(centralData.userProfile.email) 
 
   const [frontImage, setFrontImage] = useState<File | null>(null); 
-
   const [backImage, setBackImage] = useState<File | null>(null); 
-  // TODO: remove this useEffect and set random default pic when user signs up
-  // this is just for demo purposes
+
   useEffect(() => {
     if (centralData.userProfile) {
         setDraftUserProfile(centralData.userProfile)
@@ -91,6 +79,12 @@ export default function UserProfile({
   const handleEditPicture = () => {
     setIsModalOpen(true);
   };
+
+  const handleEditInformation = () => {
+    setIsEditInformation(true);
+    setEditInformationHighlight(false)
+    setSaveInformationHighlight(true)
+  }
 
   const handleImageUploadClick = () => {
     setIsImageUploadVisible(true);
@@ -123,38 +117,14 @@ export default function UserProfile({
 
 
     const handleGetStarted = async () => {
+      setEditInformationHighlight(true)
+      setSaveInformationHighlight(false)
       try {
-        console.log("Inside HandleGetStarted. Printing Draft: ", draftUserProfile)
         const updatedUser = { ...draftUserProfile };
-
-        console.log("Title: ", draftUserProfile.title)
-        console.log("firstName: ", draftUserProfile.firstName)
-        console.log("lastName: ", draftUserProfile.lastName)
-
-
-        if (draftUserProfile.title !== centralData.userProfile.title) {
-          updatedUser.title = draftUserProfile.title;
-        }
-        
-        if (draftUserProfile.firstName !== centralData.userProfile.firstName) {
-          updatedUser.firstName = draftUserProfile.firstName;
-        }
-        
-        if (draftUserProfile.lastName !== centralData.userProfile.lastName) {
-          updatedUser.lastName = draftUserProfile.lastName;
-        }
-        
-        if (draftUserProfile.email !== centralData.userProfile.email) {
-          updatedUser.email = draftUserProfile.email;
-        }
-
-        const response = await apiClients.centralDataManager?.userProfileImageUpdate(updatedUser, newProfilePic, frontImage ?? null, backImage ?? null);
+        const response = await apiClients.centralDataManager?.userProfileImageUpdate(updatedUser, centralData.userProfile, newProfilePic, frontImage ?? null, backImage ?? null);
         if (response?.updatedUser){
-            console.log("Inside HandleGetStarted. Going to central dispatch updatedUSER!!!: ", response.updatedUser)
             centralDataDispatch({type: 'SET_USER_PROFILE', payload: response.updatedUser});
-            } 
-        
-
+        } 
       } catch (error) {
         console.error(error);
       }
@@ -300,14 +270,21 @@ export default function UserProfile({
                     )}
                     <UsernameTextContainer>
                         <SubHeadingText>Username</SubHeadingText>
-                        <BodyText>( Note: username cannot be edited )</BodyText>
+                        <BodyText>( Note: email cannot be edited )</BodyText>
                     </UsernameTextContainer>
                     <UsernameInputContainer>
                         <img src={Adpic} alt="Adpic" style={{ width: '26px' }} />
                         <TextContainerStyled
                             variant="outlined"
                             placeholder="Username..."
-                            value={centralData.userProfile.userName}
+                            value={draftUserProfile.userName}
+                            onChange={(event) => 
+                                setDraftUserProfile({
+                                    ...draftUserProfile, 
+                                    userName: event.target.value  
+                                  })
+                              }
+                            disabled={!isEditInformation}
                         />
                     </UsernameInputContainer>
                     <SubHeadingText>Information</SubHeadingText>
@@ -321,7 +298,8 @@ export default function UserProfile({
                                       ...draftUserProfile, 
                                       title: event.target.value  
                                     })
-                                  }  
+                                  }
+                                disabled={!isEditInformation}  
                             >
                                 <MenuItem value="Title...">Title...</MenuItem>
                                 <MenuItem value="Mr.">Mr.</MenuItem>
@@ -338,7 +316,8 @@ export default function UserProfile({
                                         ...draftUserProfile, 
                                         firstName: event.target.value  
                                       })
-                                  }                        
+                                  }
+                                disabled={!isEditInformation}                        
                             />
                             <TextContainerStyled
                                 variant="outlined"
@@ -350,18 +329,14 @@ export default function UserProfile({
                                         lastName: event.target.value  
                                       })
                                   }
+                                disabled={!isEditInformation}
                             />
                         </UserInfoItemContainer>
                         <TextContainerStyled
                             variant="outlined"
                             placeholder="School Email..."
                             value={draftUserProfile.email}
-                            onChange={(event) => 
-                                setDraftUserProfile({
-                                    ...draftUserProfile, 
-                                    email: event.target.value  
-                                  })
-                              }
+                            disabled
                         />
                         <SubHeadingTextLight>Teacher ID Image</SubHeadingTextLight>
                         <UploadImagesContainer>
@@ -385,6 +360,7 @@ export default function UserProfile({
                                         setFrontImage(e.target.files[0]); // Store the selected image
                                     }
                                     }}
+                                    disabled={!isEditInformation}
                                 />
                                 {renderFrontImageSection()}    
                             </ImageContainer>    
@@ -408,12 +384,13 @@ export default function UserProfile({
                                             setBackImage(e.target.files[0]); // Store the selected image
                                         }
                                     }}
+                                    disabled={!isEditInformation}
                                 />
                                 {renderBackImageSection()}
                             </ImageContainer>
                         </UploadImagesContainer>
                     </UserInfoContainer>
-                   <CentralButton buttonType={ButtonType.EDITINFORMATION} isEnabled smallScreenOverride/>
+                   <CentralButton buttonType={ButtonType.EDITINFORMATION} isEnabled={isEditInformationHighlight} smallScreenOverride onClick={handleEditInformation}/>
                     <SubHeadingText>
                         Password
                     </SubHeadingText>
@@ -422,7 +399,7 @@ export default function UserProfile({
                         placeholder="Password..."
                         value="********"
                     />
-                    <CentralButton buttonType={ButtonType.SAVE} isEnabled smallScreenOverride onClick={handleGetStarted}/>
+                    <CentralButton buttonType={ButtonType.SAVE} isEnabled={isSaveInformationHighlight} smallScreenOverride onClick={handleGetStarted}/>
                 </UserProfileGridItem>
                 <Grid  
                     sm

--- a/networking/src/APIClients/auth/AuthAPIClient.ts
+++ b/networking/src/APIClients/auth/AuthAPIClient.ts
@@ -17,7 +17,8 @@ import {
   ResendSignUpCodeOutput,
   ConfirmSignUpOutput,
   AuthSession,
-  decodeJWT
+  decodeJWT,
+  updateUserAttributes
 } from 'aws-amplify/auth';
 import { uploadData, downloadData } from 'aws-amplify/storage';
 import amplifyconfig from "../../amplifyconfiguration.json";
@@ -135,7 +136,20 @@ export class AuthAPIClient
       }
   }
   
-  
+  async updateCognitoUsername(newUsername: string): Promise<void> {
+    try {
+      await updateUserAttributes({
+        userAttributes: {
+          nickname: newUsername,
+        }
+      });
+      console.log('Username updated in Cognito successfully');
+    } catch (error) {
+      console.error('Failed to update username in Cognito:', error);
+      throw new Error('Could not update username in Cognito');
+    }
+  }
+
   async getUserNickname(): Promise<string | null> {
     try {
       const attributes = await fetchUserAttributes();

--- a/networking/src/APIClients/auth/interfaces/IAuthAPIClient.ts
+++ b/networking/src/APIClients/auth/interfaces/IAuthAPIClient.ts
@@ -16,6 +16,7 @@ export interface IAuthAPIClient {
   getCurrentUserName(): Promise<string>;
   getFirstAndLastName(): Promise<{firstName: string, lastName: string}>;
   getCurrentSession(): Promise<AuthSession>;
+  updateCognitoUsername(newUsername: string): Promise<void>;
   getUserNickname(): Promise<string | null>;
   awsUserCleaner(userProfile: IUserProfile): Promise<void>;
   awsSignUp(username: string, email: string, password: string): void;

--- a/networking/src/APIClients/datamanagers/interfaces/ICentralDataManagerAPIClient.ts
+++ b/networking/src/APIClients/datamanagers/interfaces/ICentralDataManagerAPIClient.ts
@@ -36,6 +36,6 @@ export interface ICentralDataManagerAPIClient {
   signUpConfirmAndBuildBackendUser(user: IUserProfile, confirmationCode: string, frontImage: File, backImage: File): Promise<{ updatedUser: any; images: any[] }>;
   signOut: () => void;
   signUpGoogleBuildBackendUser(user: IUserProfile, frontImage: File, backImage: File): Promise<{ updatedUser: any; images: any[] }>;
-  userProfileImageUpdate(user: IUserProfile, newProfilePic: File | null, frontImage?: File | null,
+  userProfileImageUpdate(user: IUserProfile, oldUser: IUserProfile, newProfilePic: File | null, frontImage?: File | null,
     backImage?: File | null): Promise<{updatedUser: any}>;
 }

--- a/networking/src/Models/AWS/AWSUser.ts
+++ b/networking/src/Models/AWS/AWSUser.ts
@@ -13,6 +13,7 @@ export type AWSUser = {
   owner?: string | null
   frontIdPath?: string | null
   backIdPath?: string | null
+  profilePicPath?: string |null
   dynamoId?: string | null
   cognitoId?: string | null
   favoriteGameTemplateIds?: string | null

--- a/networking/src/Parsers/UserParser.ts
+++ b/networking/src/Parsers/UserParser.ts
@@ -32,6 +32,7 @@ export class UserParser {
       dynamoId: user.dynamoId,
       frontIdPath: user.frontIdPath,
       backIdPath: user.backIdPath,
+      profilePicPath: user.profilePicPath,
       title: user.title ?? '',
       firstName: user.firstName ?? '',
       lastName: user.lastName ?? '',


### PR DESCRIPTION

**Issue:**

Task:
- User should be able to edit their information:
-  ChangeAvatar
-  Username
-  FirstName,
-  LastName,
-  FrontImage
-  BackImage
-  Password

**Resolution:**

Users have given the ability to change their avatar, firstname, lastname, frontimage, and backimage. Giving users the ability to change password has not been implemented yet. Need more information from the design team on figma. 

Relevant code:
- UserProfile.tsx: This component captures the whole page. This is where the UserInterface is laid out for that page.
- UserProfileImageUploadModal.tsx: The component is responsible for letting user upload their image or choose an avatar.
- AuthAPIClient.tsx: A file that lives in networking responsible for connecting with the backend. This is also where we added the function updateCognitoUsername. Function is responsible for updating username in cognito.
- CentralDatamangerAPIClients.tsx: This builds longer functionalities using the functions provided in AuthAPIClient.tsx. This is also where the whole functionality of userProfile is created. 

On the left side of the profile card the game info like gamesmade, questionmade, gamesused don't display data dynamically yet. And the ability to change password is still not implemented as well.

**Preview:**
![image](https://github.com/user-attachments/assets/32d1048d-655c-4a57-9f3f-de2824b02dc1)
![image](https://github.com/user-attachments/assets/13166766-343a-43ba-8942-ac741b42f8fc)

