### PR TITLE
[Host] Fix styled-component typings so local builds compile

### DIFF
--- a/host_v2/src/components/EndGame/EndGameGameCode.tsx
+++ b/host_v2/src/components/EndGame/EndGameGameCode.tsx
@@ -39,7 +39,7 @@ const GameCodeParagraph = styled(Typography)({
 
 function GameEndedGameCode({ gameCode }: GameEndedGameCodeProps) {
   return (
-    <GameCodeCard container>
+    <GameCodeCard>
         <GameCodeParagraph>Game Code</GameCodeParagraph>
         <GameCodeText>{gameCode}</GameCodeText>
     </GameCodeCard>

--- a/host_v2/src/components/EndGame/EndGameSuggestedGames.tsx
+++ b/host_v2/src/components/EndGame/EndGameSuggestedGames.tsx
@@ -14,7 +14,9 @@ const PStyled = styled(Typography)({
   boxSizing: 'border-box'
 })
 
-const MenuItemStyled = styled(Box)(({isSelected}) => ({
+const MenuItemStyled = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isSelected',
+})<{ isSelected: boolean }>(({isSelected}) => ({
   border: `${isSelected ? '4px solid  #0094FF' : '0px solid transparent'}`,
   padding: `${isSelected ? '0px' : '4px'}`,
   borderRadius: '14px',
@@ -31,7 +33,9 @@ const MenuItemStyled = styled(Box)(({isSelected}) => ({
   minHeight: '110px',
 }))
 
-const LeftBox = styled(Box)(({isSelected}) => ({
+const LeftBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'isSelected',
+})<{ isSelected: boolean }>(() => ({
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',

--- a/host_v2/src/components/FooterStartGame.tsx
+++ b/host_v2/src/components/FooterStartGame.tsx
@@ -11,7 +11,7 @@ import { ScreenSize } from '../lib/HostModels';
 
 const ButtonStyled = styled(Button, {
   shouldForwardProp: (prop) => prop !== 'isAnimating',
-})(({ theme, isAnimating }) => ({
+})<{ isAnimating: boolean }>(({ theme, isAnimating }) => ({
   border: !isAnimating? '2px solid #159EFA' : 'none',
   borderRadius: '22px',
   width: '300px',

--- a/host_v2/src/components/HintsGraph/CustomBar.tsx
+++ b/host_v2/src/components/HintsGraph/CustomBar.tsx
@@ -47,12 +47,7 @@ export default function CustomBar( props: any ) {
           onClick={() =>
             handleGraphClick(index)
           }
-          style={{ 
-            cursor: 'pointer',
-            '&:hover': {
-              fill: 'rgba(255, 255, 255, 0.2)',
-            }, 
-          }}
+          style={{ cursor: 'pointer' }}
         />
       )}
     </g>

--- a/host_v2/src/components/HintsGraph/HintsGraph.tsx
+++ b/host_v2/src/components/HintsGraph/HintsGraph.tsx
@@ -127,7 +127,7 @@ export default function HintsGraph({
               standalone={false}
               orientation="top"
               tickValues={calculateRoundedTicks()}
-              tickFormat={(tick) => Math.round(tick)}
+              tickFormat={(tick: number) => Math.round(tick)}
             />
           )}
           <VictoryBar

--- a/host_v2/src/components/HintsGraph/HintsSubmittedBar.tsx
+++ b/host_v2/src/components/HintsGraph/HintsSubmittedBar.tsx
@@ -21,7 +21,9 @@ const TypographyTotalNum = styled(Typography)({
   margin: 'auto',
 })
 
-const InputNum = styled(Typography)(({ theme, progressPercent }) => ({
+const InputNum = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'progressPercent',
+})<{ progressPercent: number }>(({ theme, progressPercent }) => ({
   position: 'absolute',
   top: '0',
   left: `${progressPercent - 3}%`,

--- a/host_v2/src/components/ResponsesGraph/PlayersSelectedAnswer.tsx
+++ b/host_v2/src/components/ResponsesGraph/PlayersSelectedAnswer.tsx
@@ -7,7 +7,7 @@ import ArrowIcon from '../../images/Arrow.svg';
 
 const TitleText = styled(Typography, {
   shouldForwardProp: (prop) => prop !== 'statePosition',
-})(({statePosition}) => ({
+})<{ statePosition?: number }>(({statePosition}) => ({
   color: '#FFF',
   textAlign: 'left',
   fontFamily: 'Rubik',
@@ -19,7 +19,7 @@ const TitleText = styled(Typography, {
 
 const PercentageText = styled(Typography, {
   shouldForwardProp: (prop) => prop !== 'statePosition',
-})(({statePosition}) => ({
+})<{ statePosition?: number }>(({statePosition}) => ({
   color: '#FFF',
   textAlign: 'left',
   fontFamily: 'Rubik',
@@ -32,7 +32,7 @@ const PercentageText = styled(Typography, {
 
 const CountText = styled(Typography, {
   shouldForwardProp: (prop) => prop !== 'statePosition',
-})(({statePosition}) => ({
+})<{ statePosition?: number }>(({statePosition}) => ({
   color: '#FFF',
   textAlign: 'right',
   fontFamily: 'Rubik',

--- a/host_v2/src/components/ResponsesGraph/ResponsesGraph.tsx
+++ b/host_v2/src/components/ResponsesGraph/ResponsesGraph.tsx
@@ -158,7 +158,7 @@ export default function ResponsesGraph({
               standalone={false}
               orientation="top"
               tickValues={calculateRoundedTicks()}
-              tickFormat={(tick) => Math.round(tick)}
+              tickFormat={(tick: number) => Math.round(tick)}
             />
           )}
           <VictoryBar

--- a/host_v2/src/components/Timer.tsx
+++ b/host_v2/src/components/Timer.tsx
@@ -154,7 +154,6 @@ export default function Timer({
       <Box style={{display: 'flex', justifyContent: 'flex-start', alignItems: 'center', width: '100%',  gap: `calc(${theme.sizing.xSmPadding}px + ${theme.sizing.xxSmPadding}px)`, opacity: isTimerActiveRef.current ? 1 : 0.4,  }}>
         <TimerBar
           value={fillLeftToRight ? 100 - progress : progress}
-          initial={0}
           variant="determinate"
           sx={{
             ...(barBackground && { backgroundColor: barBackground }),

--- a/host_v2/src/lib/styledcomponents/footer/FooterBackgroundStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/footer/FooterBackgroundStyled.tsx
@@ -7,7 +7,7 @@ export default styled(Stack)(({ theme }) => ({
   position: 'sticky',
   bottom: 0,
   left: 0,
-  background: theme.palette.primary.mainColor,
+  background: theme.palette.primary.main,
   border: 'none',
   width: '100vw',
   zIndex: -1,

--- a/host_v2/src/lib/styledcomponents/footer/InputNum.tsx
+++ b/host_v2/src/lib/styledcomponents/footer/InputNum.tsx
@@ -1,7 +1,9 @@
 import { styled } from '@mui/material/styles';
 import { Typography } from '@mui/material';
 
-export default styled(Typography)(({ theme, progressPercent }) => ({
+export default styled(Typography, {
+  shouldForwardProp: (prop) => prop !== 'progressPercent',
+})<{ progressPercent: number }>(({ theme, progressPercent }) => ({
   position: 'absolute',
   top: '0',
   left: progressPercent > 0 ? `calc(${progressPercent}% - 30px)` : '5px',

--- a/host_v2/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
+++ b/host_v2/src/lib/styledcomponents/layout/ScrollBoxStyled.tsx
@@ -21,7 +21,9 @@ export default styled(Box)(({ theme }) => ({
   '-ms-overflow-style': 'none', // IE and Edge
 }));
 
-export const StartEndGameScrollBoxStyled = styled(Box)(({ theme, currentQuestionIndex }) => ({
+export const StartEndGameScrollBoxStyled = styled(Box, {
+  shouldForwardProp: (prop) => prop !== 'currentQuestionIndex',
+})<{ currentQuestionIndex?: number | null }>(({ theme }) => ({
   height: '100%',
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
## What
Fixes the ~22 TS errors that break a local `yarn build` of host_v2 on this branch. Amplify CI was never affected (clean isolated installs tolerate the loose source); locally, a stray root `node_modules` (TS 5.9.3 / @mui 5.18 / styled-engine-sc 9, dev-era leftovers) shadows a half-empty `host_v2/node_modules`, so the loose `styled()` calls type-check against strict typings and fail.

## How
Ports dev's canonical pattern (commit 37615b93d) — `styled(X, { shouldForwardProp })<{ prop: T }>` — to the 12 loose sites, **grafted onto this branch's CSS values** (dev's blocks carry v12 styling; deliberately not copied, per the decision to hold v1.2 from production for now). Plus:
- drop invalid `initial` (LinearProgress) and `container` (Box) props
- remove a dead `'&:hover'` inside an inline SVG `style` (never applied at runtime)
- `theme.palette.primary.mainColor` → `.main` (same const, `mainColor` was never a palette member)

Type-level only; also stops leaking custom props as DOM attributes.

## Verification
- Strict-toolchain typecheck: 22 → **0 errors**; `yarn build` compiles clean
- Production build served + driven via Playwright against the prod backend: lobby renders pixel-identical, roster rows + X-out + footer button work, and the #2577 ghost-team poll resync still recovers a DDB-written team in ~8s on the built artifact (all E2E rows cleaned up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)