### PR TITLE
[Host] Fix mobile timer bars crawling then jumping

### DIFF
--- a/host_v2/src/components/FooterGameInProgress.tsx
+++ b/host_v2/src/components/FooterGameInProgress.tsx
@@ -200,6 +200,7 @@ function FooterGameInProgress({
               onTimerComplete={() => setIsTimerComplete(true)}
               width="300px"
               hideTimerText
+              disableBarTransition
             />
           </Box>
         )}

--- a/host_v2/src/components/HeaderContent.tsx
+++ b/host_v2/src/components/HeaderContent.tsx
@@ -83,6 +83,7 @@ export default function HeaderContent({
                 totalTime={totalTime}
                 isAddTime={isAddTime}
                 localGameSession={localGameSession}
+                disableBarTransition
               />
         
         </Grid>

--- a/host_v2/src/components/Timer.tsx
+++ b/host_v2/src/components/Timer.tsx
@@ -40,6 +40,10 @@ interface TimerProps {
   onTimerComplete?: () => void;
   width?: string;
   hideTimerText?: boolean;
+  // remove MUI's built-in transform transition on the bar. the bar value is already driven
+  // every frame by requestAnimationFrame, so the .4s transition is redundant — and on iOS it
+  // fights the per-frame fill updates, causing the bar to crawl (~10%) then jump on complete.
+  disableBarTransition?: boolean;
 }
 
 export default function Timer({
@@ -53,6 +57,7 @@ export default function Timer({
   onTimerComplete,
   width,
   hideTimerText,
+  disableBarTransition,
 }: TimerProps) {
   const theme = useTheme();
   const { t } = useTranslation();
@@ -157,7 +162,10 @@ export default function Timer({
           variant="determinate"
           sx={{
             ...(barBackground && { backgroundColor: barBackground }),
-            ...(barGradient && { '& .MuiLinearProgress-bar': { background: barGradient } }),
+            '& .MuiLinearProgress-bar': {
+              ...(barGradient && { background: barGradient }),
+              ...(disableBarTransition && { transition: 'none' }),
+            },
           }}
         />
         {!hideTimerText && (


### PR DESCRIPTION
## What
Both timer bars on mobile (header question timer, footer discuss-delay timer) crawl near their starting fill and then snap on completion — e.g. showing ~95% full at 1:20 remaining of 2:00.

## Why
MUI LinearProgress applies a 0.4s transform transition on every value change. The Timer drives its value every frame via requestAnimationFrame, so on mobile the constantly-restarting transition never lets the bar move. Already fixed on dev (1.2); this ports that fix — `disableBarTransition` prop setting `transition: 'none'` on the bar — to the production branch, applied at both call sites (dev only wires the footer; the header exhibits the same defect here).

## Verification
- Strict typecheck 0 errors; `yarn build` clean.
- Behavioral confirmation needs a real mobile device (the defect is a mobile compositor behavior): watch the header bar track ~1/3 drained at 40s of a 2:00 question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)